### PR TITLE
fix: remove unused GenreChips component to fix CI lint failure

### DIFF
--- a/apps/desktop/src/ui/ChatAppView.js
+++ b/apps/desktop/src/ui/ChatAppView.js
@@ -45,32 +45,6 @@ function ModePill({ modeValue, modeOptions, onModeChange }) {
   );
 }
 
-function GenreChips({ genres, textTertiary, border }) {
-  if (!genres?.length) return null;
-  return React.createElement(
-    "div",
-    { style: { display: "flex", gap: "6px", flexWrap: "wrap", marginBottom: "10px" } },
-    genres.map((g) =>
-      React.createElement(
-        "span",
-        {
-          key: g,
-          style: {
-            fontSize: "11px",
-            letterSpacing: "0.04em",
-            textTransform: "uppercase",
-            color: textTertiary,
-            border: `1px solid ${border}`,
-            borderRadius: "4px",
-            padding: "2px 7px",
-          },
-        },
-        g,
-      ),
-    ),
-  );
-}
-
 function renderCardActions(card, theme, handlers) {
   const btnStyle = {
     backgroundColor: theme.buttonBg,

--- a/package-lock.json
+++ b/package-lock.json
@@ -891,9 +891,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -911,9 +908,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -931,9 +925,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -951,9 +942,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -971,9 +959,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [


### PR DESCRIPTION
ESLint no-unused-vars flagged GenreChips as defined but never called.
Genres are already rendered inline in RecommendationCard.

https://claude.ai/code/session_01X2r8mtNfouEV3e358WAGWE