### PR TITLE
feat: Phase 3 — Compact Cards, View Router, Saved Artists, Artist Search, Directional Selection

### DIFF
--- a/apps/desktop/src/chatClient.js
+++ b/apps/desktop/src/chatClient.js
@@ -2,11 +2,13 @@ function createChatClient({ apiBaseUrl, fetchImpl = fetch }) {
   const baseUrl = apiBaseUrl.endsWith("/") ? apiBaseUrl.slice(0, -1) : apiBaseUrl;
 
   return {
-    async fetchRecommendations(query, mode = "fresh") {
+    async fetchRecommendations(query, mode = "fresh", { selectedArtistIds = [] } = {}) {
+      const body = { query, mode };
+      if (selectedArtistIds.length > 0) body.selectedArtistIds = selectedArtistIds;
       const response = await fetchImpl(`${baseUrl}/recommendations`, {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ query, mode }),
+        body: JSON.stringify(body),
       });
 
       if (!response.ok) {

--- a/apps/desktop/src/chatClient.js
+++ b/apps/desktop/src/chatClient.js
@@ -37,6 +37,23 @@ function createChatClient({ apiBaseUrl, fetchImpl = fetch }) {
       }
       return response.json();
     },
+    async listPreferences() {
+      const response = await fetchImpl(`${baseUrl}/preferences`);
+      if (!response.ok) {
+        throw new Error(`preferences fetch failed with status ${response.status}`);
+      }
+      const data = await response.json();
+      return data.savedBands || [];
+    },
+    async deletePreference(id) {
+      const response = await fetchImpl(`${baseUrl}/preferences/${encodeURIComponent(id)}`, {
+        method: "DELETE",
+      });
+      if (!response.ok) {
+        throw new Error(`preference delete request failed with status ${response.status}`);
+      }
+      return response.json();
+    },
   };
 }
 

--- a/apps/desktop/src/chatClient.js
+++ b/apps/desktop/src/chatClient.js
@@ -54,6 +54,14 @@ function createChatClient({ apiBaseUrl, fetchImpl = fetch }) {
       }
       return response.json();
     },
+    async searchArtists(query) {
+      const response = await fetchImpl(`${baseUrl}/search/artists?q=${encodeURIComponent(query)}`);
+      if (!response.ok) {
+        throw new Error(`artist search failed with status ${response.status}`);
+      }
+      const data = await response.json();
+      return data.artists || [];
+    },
   };
 }
 

--- a/apps/desktop/src/index.js
+++ b/apps/desktop/src/index.js
@@ -11,12 +11,15 @@ const { createChatRenderAdapter } = require("./chatRenderAdapter");
 const { createDesktopReactShell } = require("./ui/createDesktopReactShell");
 const { createDesktopReactMount } = require("./ui/mountDesktopReactApp");
 
+const VALID_VIEWS = ["chat", "saved-artists"];
+
 /**
  * @param {{ apiBaseUrl?: string, fetchImpl?: any }} [options]
  */
 function bootstrapDesktopApp({ apiBaseUrl = "http://localhost:3001", fetchImpl } = {}) {
   const chatClient = createChatClient({ apiBaseUrl, fetchImpl });
   let state = { ...createInitialChatState(), savedBands: [] };
+  let currentView = "chat";
 
   function findLatestRecommendationByName(artistName) {
     const messages = state.messages || [];
@@ -39,6 +42,13 @@ function bootstrapDesktopApp({ apiBaseUrl = "http://localhost:3001", fetchImpl }
   return {
     getState() {
       return state;
+    },
+    getView() {
+      return currentView;
+    },
+    navigate(view) {
+      if (!VALID_VIEWS.includes(view)) return;
+      currentView = view;
     },
     async requestRecommendations(query, mode = "fresh") {
       const result = await chatClient.fetchRecommendations(query, mode);

--- a/apps/desktop/src/index.js
+++ b/apps/desktop/src/index.js
@@ -89,6 +89,10 @@ function bootstrapDesktopApp({ apiBaseUrl = "http://localhost:3001", fetchImpl }
       state = { ...state, savedBands: bands };
       return bands;
     },
+    async deleteSavedBand(id) {
+      await chatClient.deletePreference(id);
+      state = { ...state, savedBands: state.savedBands.filter((b) => b.id !== id) };
+    },
     async searchArtists(query) {
       return chatClient.searchArtists ? chatClient.searchArtists(query) : [];
     },
@@ -141,10 +145,12 @@ function bootstrapDesktopReactShell({ app, viewport = "desktop", actionHandlers 
     },
     searchArtistsImpl: (query) => savedArtistsModel.searchArtists(query),
     toggleSelectionImpl: (id) => savedArtistsModel.toggleSelection(id),
+    deleteSavedArtistImpl: (id) => savedArtistsModel.deleteSavedArtist(id),
     activateStyleRefImpl: async () => {
       const ids = savedArtistsModel.getSelectedIds();
-      app.navigate?.("chat");
+      savedArtistsModel.clearSelection();
       app.setPendingStyleRef?.(ids);
+      app.navigate?.("chat");
     },
     getSavedArtistsViewPropsImpl: () => savedArtistsModel.getScreenState(),
   });

--- a/apps/desktop/src/index.js
+++ b/apps/desktop/src/index.js
@@ -113,7 +113,12 @@ function bootstrapDesktopReactShell({ app, viewport = "desktop", actionHandlers 
     onRate: resolvedActionHandlers.onRate || ((artistName) => app.rateBand?.(artistName, 5)),
     onMore: resolvedActionHandlers.onMore || (() => {}),
   };
-  return createDesktopReactShell({ renderAdapter, actionHandlers: mergedActionHandlers });
+  return createDesktopReactShell({
+    renderAdapter,
+    actionHandlers: mergedActionHandlers,
+    getViewImpl: () => app.getView(),
+    navigateImpl: (view) => app.navigate(view),
+  });
 }
 
 function bootstrapDesktopReactApp({ app, viewport = "desktop", actionHandlers = {} }) {

--- a/apps/desktop/src/index.js
+++ b/apps/desktop/src/index.js
@@ -133,6 +133,7 @@ function bootstrapDesktopReactShell({ app, viewport = "desktop", actionHandlers 
         await savedArtistsModel.loadSavedArtists();
       }
     },
+    searchArtistsImpl: (query) => savedArtistsModel.searchArtists(query),
     getSavedArtistsViewPropsImpl: () => savedArtistsModel.getScreenState(),
   });
 }

--- a/apps/desktop/src/index.js
+++ b/apps/desktop/src/index.js
@@ -116,6 +116,7 @@ function bootstrapDesktopRenderAdapter({ app, viewport = "desktop" }) {
 
 function bootstrapDesktopReactShell({ app, viewport = "desktop", actionHandlers = {} }) {
   const renderAdapter = bootstrapDesktopRenderAdapter({ app, viewport });
+  const savedArtistsModel = createSavedArtistsModel({ app });
   const resolvedActionHandlers = /** @type {any} */ (actionHandlers);
   const mergedActionHandlers = {
     onSave: resolvedActionHandlers.onSave || ((artistName) => app.saveBand?.(artistName)),
@@ -125,8 +126,14 @@ function bootstrapDesktopReactShell({ app, viewport = "desktop", actionHandlers 
   return createDesktopReactShell({
     renderAdapter,
     actionHandlers: mergedActionHandlers,
-    getViewImpl: () => app.getView(),
-    navigateImpl: (view) => app.navigate(view),
+    getViewImpl: () => app.getView?.() ?? "chat",
+    navigateImpl: async (view) => {
+      app.navigate?.(view);
+      if (view === "saved-artists") {
+        await savedArtistsModel.loadSavedArtists();
+      }
+    },
+    getSavedArtistsViewPropsImpl: () => savedArtistsModel.getScreenState(),
   });
 }
 

--- a/apps/desktop/src/index.js
+++ b/apps/desktop/src/index.js
@@ -21,6 +21,7 @@ function bootstrapDesktopApp({ apiBaseUrl = "http://localhost:3001", fetchImpl }
   const chatClient = createChatClient({ apiBaseUrl, fetchImpl });
   let state = { ...createInitialChatState(), savedBands: [] };
   let currentView = "chat";
+  let pendingSelectedArtistIds = [];
 
   function findLatestRecommendationByName(artistName) {
     const messages = state.messages || [];
@@ -51,8 +52,13 @@ function bootstrapDesktopApp({ apiBaseUrl = "http://localhost:3001", fetchImpl }
       if (!VALID_VIEWS.includes(view)) return;
       currentView = view;
     },
+    setPendingStyleRef(ids) {
+      pendingSelectedArtistIds = Array.isArray(ids) ? [...ids] : [];
+    },
     async requestRecommendations(query, mode = "fresh") {
-      const result = await chatClient.fetchRecommendations(query, mode);
+      const selectedArtistIds = [...pendingSelectedArtistIds];
+      pendingSelectedArtistIds = [];
+      const result = await chatClient.fetchRecommendations(query, mode, { selectedArtistIds });
       state = applyAssistantMessage(state, result);
       return result;
     },
@@ -134,6 +140,12 @@ function bootstrapDesktopReactShell({ app, viewport = "desktop", actionHandlers 
       }
     },
     searchArtistsImpl: (query) => savedArtistsModel.searchArtists(query),
+    toggleSelectionImpl: (id) => savedArtistsModel.toggleSelection(id),
+    activateStyleRefImpl: async () => {
+      const ids = savedArtistsModel.getSelectedIds();
+      app.navigate?.("chat");
+      app.setPendingStyleRef?.(ids);
+    },
     getSavedArtistsViewPropsImpl: () => savedArtistsModel.getScreenState(),
   });
 }

--- a/apps/desktop/src/index.js
+++ b/apps/desktop/src/index.js
@@ -8,6 +8,7 @@ const { createChatViewModel } = require("./chatViewModel");
 const { createChatScreenModel } = require("./chatScreenModel");
 const { createChatScreen } = require("./chatScreen");
 const { createChatRenderAdapter } = require("./chatRenderAdapter");
+const { createSavedArtistsModel } = require("./savedArtistsModel");
 const { createDesktopReactShell } = require("./ui/createDesktopReactShell");
 const { createDesktopReactMount } = require("./ui/mountDesktopReactApp");
 
@@ -76,6 +77,14 @@ function bootstrapDesktopApp({ apiBaseUrl = "http://localhost:3001", fetchImpl }
       const result = /** @type {any} */ (await chatClient.updatePreference(savedBand.id, { rating }));
       upsertSavedBand(result.savedBand);
       return result.savedBand;
+    },
+    async listSavedBands() {
+      const bands = await chatClient.listPreferences();
+      state = { ...state, savedBands: bands };
+      return bands;
+    },
+    async searchArtists(query) {
+      return chatClient.searchArtists ? chatClient.searchArtists(query) : [];
     },
   };
 }

--- a/apps/desktop/src/savedArtistsModel.js
+++ b/apps/desktop/src/savedArtistsModel.js
@@ -35,12 +35,22 @@ function createSavedArtistsModel({ app }) {
       };
     },
 
+    async deleteSavedArtist(id) {
+      await app.deleteSavedBand(id);
+      state.savedArtists = state.savedArtists.filter((b) => b.id !== id);
+      state.selectedIds.delete(id);
+    },
+
     toggleSelection(id) {
       if (state.selectedIds.has(id)) {
         state.selectedIds.delete(id);
       } else {
         state.selectedIds.add(id);
       }
+    },
+
+    clearSelection() {
+      state.selectedIds.clear();
     },
 
     getSelectedIds() {

--- a/apps/desktop/src/savedArtistsModel.js
+++ b/apps/desktop/src/savedArtistsModel.js
@@ -1,0 +1,65 @@
+function createSavedArtistsModel({ app }) {
+  const state = {
+    savedArtists: [],
+    selectedIds: new Set(),
+    searchResults: [],
+    isSearching: false,
+    isLoading: false,
+  };
+
+  return {
+    async loadSavedArtists() {
+      state.isLoading = true;
+      try {
+        state.savedArtists = await app.listSavedBands();
+      } finally {
+        state.isLoading = false;
+      }
+    },
+
+    getScreenState() {
+      return {
+        header: { title: "Saved Artists", subtitle: "Your style references" },
+        isLoading: state.isLoading,
+        artists: state.savedArtists.map((band) => ({
+          id: band.id,
+          name: band.name,
+          rating: band.rating,
+          categoryTags: band.categories || [],
+          note: band.note || "",
+          isSelected: state.selectedIds.has(band.id),
+        })),
+        selectedCount: state.selectedIds.size,
+        searchResults: state.searchResults,
+        isSearching: state.isSearching,
+      };
+    },
+
+    toggleSelection(id) {
+      if (state.selectedIds.has(id)) {
+        state.selectedIds.delete(id);
+      } else {
+        state.selectedIds.add(id);
+      }
+    },
+
+    getSelectedIds() {
+      return [...state.selectedIds];
+    },
+
+    async searchArtists(query) {
+      if (!query || !query.trim()) {
+        state.searchResults = [];
+        return;
+      }
+      state.isSearching = true;
+      try {
+        state.searchResults = await app.searchArtists(query);
+      } finally {
+        state.isSearching = false;
+      }
+    },
+  };
+}
+
+module.exports = { createSavedArtistsModel };

--- a/apps/desktop/src/ui/SavedArtistsView.js
+++ b/apps/desktop/src/ui/SavedArtistsView.js
@@ -1,0 +1,178 @@
+const React = require("react");
+
+const theme = {
+  pageBg: "#0d0f14",
+  cardBg: "#111827",
+  border: "#1e2a3a",
+  textPrimary: "#f0f4f8",
+  textSecondary: "#8896a8",
+  textTertiary: "#5a6880",
+  accent: "#7aa7d9",
+  accentDim: "#1c2d42",
+  buttonBg: "#161e2e",
+  buttonBorder: "#243044",
+  buttonText: "#c8d4e8",
+};
+
+function SavedArtistItem({ artist, handlers }) {
+  const itemStyles = {
+    li: {
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "space-between",
+      padding: "10px 12px",
+      backgroundColor: theme.cardBg,
+      border: `1px solid ${theme.border}`,
+      borderLeft: `3px solid ${artist.isSelected ? theme.accent : theme.border}`,
+      borderRadius: "8px",
+    },
+    name: { fontSize: "14px", fontWeight: "600", color: theme.textPrimary },
+    meta: { fontSize: "12px", color: theme.textSecondary, marginTop: "2px" },
+    actions: { display: "flex", gap: "6px", alignItems: "center" },
+    tickBtn: {
+      width: "28px",
+      height: "28px",
+      borderRadius: "50%",
+      border: `1px solid ${artist.isSelected ? theme.accent : theme.border}`,
+      backgroundColor: artist.isSelected ? theme.accentDim : "transparent",
+      color: artist.isSelected ? theme.accent : theme.textTertiary,
+      fontSize: "14px",
+      display: "inline-flex",
+      alignItems: "center",
+      justifyContent: "center",
+      cursor: "pointer",
+    },
+    deleteBtn: {
+      background: "transparent",
+      border: "none",
+      color: theme.textTertiary,
+      fontSize: "13px",
+      cursor: "pointer",
+      padding: "4px 8px",
+    },
+  };
+
+  const ratingText = artist.rating ? `${artist.rating}/5` : null;
+  const tagsText = artist.categoryTags?.length ? artist.categoryTags.join(", ") : null;
+  const metaParts = [ratingText, tagsText].filter(Boolean).join(" · ");
+
+  return React.createElement(
+    "li",
+    { style: itemStyles.li },
+    React.createElement(
+      "div",
+      null,
+      React.createElement("p", { style: itemStyles.name }, artist.name),
+      metaParts
+        ? React.createElement("p", { style: itemStyles.meta }, metaParts)
+        : null,
+    ),
+    React.createElement(
+      "div",
+      { style: itemStyles.actions },
+      React.createElement(
+        "button",
+        {
+          type: "button",
+          className: "tick-btn",
+          style: itemStyles.tickBtn,
+          onClick: () => handlers.onToggleSelection?.(artist.id),
+          title: "Use as style reference",
+        },
+        artist.isSelected ? "✓" : "○",
+      ),
+      React.createElement(
+        "button",
+        {
+          type: "button",
+          style: itemStyles.deleteBtn,
+          onClick: () => handlers.onDelete(artist.id),
+        },
+        "×",
+      ),
+    ),
+  );
+}
+
+function SavedArtistsView({ viewProps, handlers }) {
+  const styles = {
+    page: {
+      backgroundColor: theme.pageBg,
+      color: theme.textPrimary,
+      minHeight: "100vh",
+      padding: "32px 24px",
+      maxWidth: "760px",
+      margin: "0 auto",
+    },
+    header: { marginBottom: "24px" },
+    headerRow: {
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "space-between",
+      marginBottom: "16px",
+    },
+    title: { fontSize: "20px", fontWeight: "700", letterSpacing: "-0.02em", marginBottom: "3px" },
+    subtitle: { fontSize: "13px", color: theme.textSecondary },
+    backBtn: {
+      backgroundColor: theme.buttonBg,
+      color: theme.buttonText,
+      border: `1px solid ${theme.buttonBorder}`,
+      borderRadius: "7px",
+      padding: "6px 14px",
+      fontSize: "13px",
+      cursor: "pointer",
+    },
+    divider: { border: "none", borderTop: `1px solid ${theme.border}`, margin: "0" },
+    list: { display: "grid", gap: "8px", marginTop: "20px" },
+    empty: {
+      padding: "48px 0 24px",
+      textAlign: "center",
+      fontSize: "14px",
+      color: theme.textSecondary,
+    },
+  };
+
+  const { artists = [], header, isLoading } = viewProps;
+
+  return React.createElement(
+    "main",
+    { style: styles.page },
+    React.createElement(
+      "header",
+      { style: styles.header },
+      React.createElement(
+        "div",
+        { style: styles.headerRow },
+        React.createElement(
+          "div",
+          null,
+          React.createElement("h1", { style: styles.title }, header.title),
+          React.createElement("p", { style: styles.subtitle }, header.subtitle),
+        ),
+        React.createElement(
+          "button",
+          {
+            type: "button",
+            style: styles.backBtn,
+            onClick: () => handlers.onNavigate("chat"),
+          },
+          "← Recommendations",
+        ),
+      ),
+      React.createElement("hr", { style: styles.divider }),
+    ),
+    isLoading
+      ? React.createElement("p", { style: styles.empty }, "Loading…")
+      : artists.length === 0
+        ? React.createElement("p", { style: styles.empty }, "No saved artists yet. Save artists from recommendation cards.")
+        : React.createElement(
+            "ul",
+            { style: { ...styles.list, listStyle: "none", padding: "0", margin: "0" } },
+            artists.map((artist) =>
+              React.createElement(SavedArtistItem, { key: artist.id, artist, handlers }),
+            ),
+          ),
+  );
+}
+
+module.exports = { SavedArtistsView };

--- a/apps/desktop/src/ui/SavedArtistsView.js
+++ b/apps/desktop/src/ui/SavedArtistsView.js
@@ -215,6 +215,47 @@ function SearchSection({ searchResults, isSearching, handlers }) {
   );
 }
 
+function SelectionBar({ selectedCount, handlers }) {
+  const styles = {
+    bar: {
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "space-between",
+      padding: "10px 14px",
+      backgroundColor: theme.accentDim,
+      border: `1px solid ${theme.accent}`,
+      borderRadius: "8px",
+      marginTop: "16px",
+    },
+    label: { fontSize: "13px", color: theme.accent },
+    btn: {
+      backgroundColor: theme.accent,
+      color: "#0d0f14",
+      border: "none",
+      borderRadius: "6px",
+      padding: "5px 12px",
+      fontSize: "12px",
+      fontWeight: "600",
+      cursor: "pointer",
+    },
+  };
+
+  return React.createElement(
+    "div",
+    { style: styles.bar },
+    React.createElement("span", { style: styles.label }, `${selectedCount} selected`),
+    React.createElement(
+      "button",
+      {
+        type: "button",
+        style: styles.btn,
+        onClick: () => handlers.onActivateStyleRef?.(),
+      },
+      "Use as style reference",
+    ),
+  );
+}
+
 function SavedArtistsView({ viewProps, handlers }) {
   const styles = {
     page: {
@@ -253,7 +294,7 @@ function SavedArtistsView({ viewProps, handlers }) {
     },
   };
 
-  const { artists = [], header, isLoading, searchResults = [], isSearching = false } = viewProps;
+  const { artists = [], header, isLoading, searchResults = [], isSearching = false, selectedCount = 0 } = viewProps;
 
   return React.createElement(
     "main",
@@ -283,6 +324,9 @@ function SavedArtistsView({ viewProps, handlers }) {
       React.createElement("hr", { style: styles.divider }),
     ),
     React.createElement(SearchSection, { searchResults, isSearching, handlers }),
+    selectedCount > 0
+      ? React.createElement(SelectionBar, { selectedCount, handlers })
+      : null,
     isLoading
       ? React.createElement("p", { style: styles.empty }, "Loading…")
       : artists.length === 0

--- a/apps/desktop/src/ui/SavedArtistsView.js
+++ b/apps/desktop/src/ui/SavedArtistsView.js
@@ -86,11 +86,128 @@ function SavedArtistItem({ artist, handlers }) {
         {
           type: "button",
           style: itemStyles.deleteBtn,
-          onClick: () => handlers.onDelete(artist.id),
+          onClick: () => handlers.onDelete?.(artist.id),
         },
         "×",
       ),
     ),
+  );
+}
+
+function SearchResultItem({ result, handlers }) {
+  const styles = {
+    li: {
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "space-between",
+      padding: "8px 12px",
+      backgroundColor: theme.cardBg,
+      border: `1px solid ${theme.border}`,
+      borderRadius: "8px",
+    },
+    name: { fontSize: "13px", fontWeight: "600", color: theme.textPrimary },
+    disambiguation: { fontSize: "12px", color: theme.textSecondary, marginTop: "2px" },
+    addBtn: {
+      backgroundColor: theme.accentDim,
+      color: theme.accent,
+      border: `1px solid ${theme.accent}`,
+      borderRadius: "6px",
+      padding: "4px 10px",
+      fontSize: "12px",
+      cursor: "pointer",
+      flexShrink: 0,
+    },
+  };
+
+  return React.createElement(
+    "li",
+    { style: styles.li },
+    React.createElement(
+      "div",
+      null,
+      React.createElement("p", { style: styles.name }, result.name),
+      result.disambiguation
+        ? React.createElement("p", { style: styles.disambiguation }, result.disambiguation)
+        : null,
+    ),
+    React.createElement(
+      "button",
+      {
+        type: "button",
+        style: styles.addBtn,
+        onClick: () => handlers.onAddArtist?.({ id: result.id, name: result.name }),
+      },
+      "Add",
+    ),
+  );
+}
+
+function SearchSection({ searchResults, isSearching, handlers }) {
+  const styles = {
+    section: { marginTop: "20px" },
+    sectionTitle: { fontSize: "13px", fontWeight: "600", color: theme.textSecondary, marginBottom: "8px" },
+    row: { display: "flex", gap: "8px", marginBottom: "12px" },
+    input: {
+      flex: 1,
+      backgroundColor: theme.cardBg,
+      border: `1px solid ${theme.border}`,
+      borderRadius: "7px",
+      padding: "7px 12px",
+      fontSize: "13px",
+      color: theme.textPrimary,
+      outline: "none",
+    },
+    searchBtn: {
+      backgroundColor: theme.buttonBg,
+      color: theme.buttonText,
+      border: `1px solid ${theme.buttonBorder}`,
+      borderRadius: "7px",
+      padding: "7px 14px",
+      fontSize: "13px",
+      cursor: "pointer",
+    },
+    hint: { fontSize: "12px", color: theme.textTertiary },
+    list: { display: "grid", gap: "6px", listStyle: "none", padding: "0", margin: "0" },
+  };
+
+  return React.createElement(
+    "section",
+    { style: styles.section },
+    React.createElement("p", { style: styles.sectionTitle }, "Add artist"),
+    React.createElement(
+      "form",
+      {
+        style: styles.row,
+        onSubmit: (e) => {
+          e.preventDefault();
+          const q = e.target.elements["artist-search"].value.trim();
+          if (q) handlers.onSearch?.(q);
+        },
+      },
+      React.createElement("input", {
+        type: "text",
+        name: "artist-search",
+        placeholder: "Search MusicBrainz…",
+        style: styles.input,
+        autoComplete: "off",
+      }),
+      React.createElement(
+        "button",
+        { type: "submit", style: styles.searchBtn },
+        "Search",
+      ),
+    ),
+    isSearching
+      ? React.createElement("p", { style: styles.hint }, "Searching…")
+      : searchResults.length > 0
+        ? React.createElement(
+            "ul",
+            { style: styles.list },
+            searchResults.map((result) =>
+              React.createElement(SearchResultItem, { key: result.id, result, handlers }),
+            ),
+          )
+        : null,
   );
 }
 
@@ -132,7 +249,7 @@ function SavedArtistsView({ viewProps, handlers }) {
     },
   };
 
-  const { artists = [], header, isLoading } = viewProps;
+  const { artists = [], header, isLoading, searchResults = [], isSearching = false } = viewProps;
 
   return React.createElement(
     "main",
@@ -154,13 +271,14 @@ function SavedArtistsView({ viewProps, handlers }) {
           {
             type: "button",
             style: styles.backBtn,
-            onClick: () => handlers.onNavigate("chat"),
+            onClick: () => handlers.onNavigate?.("chat"),
           },
           "← Recommendations",
         ),
       ),
       React.createElement("hr", { style: styles.divider }),
     ),
+    React.createElement(SearchSection, { searchResults, isSearching, handlers }),
     isLoading
       ? React.createElement("p", { style: styles.empty }, "Loading…")
       : artists.length === 0

--- a/apps/desktop/src/ui/SavedArtistsView.js
+++ b/apps/desktop/src/ui/SavedArtistsView.js
@@ -142,6 +142,17 @@ function SearchResultItem({ result, handlers }) {
   );
 }
 
+function SearchResultsList({ results, handlers }) {
+  const listStyle = { display: "grid", gap: "6px", listStyle: "none", padding: "0", margin: "0" };
+  return React.createElement(
+    "ul",
+    { style: listStyle },
+    results.map((result) =>
+      React.createElement(SearchResultItem, { key: result.id, result, handlers }),
+    ),
+  );
+}
+
 function SearchSection({ searchResults, isSearching, handlers }) {
   const styles = {
     section: { marginTop: "20px" },
@@ -167,7 +178,6 @@ function SearchSection({ searchResults, isSearching, handlers }) {
       cursor: "pointer",
     },
     hint: { fontSize: "12px", color: theme.textTertiary },
-    list: { display: "grid", gap: "6px", listStyle: "none", padding: "0", margin: "0" },
   };
 
   return React.createElement(
@@ -200,13 +210,7 @@ function SearchSection({ searchResults, isSearching, handlers }) {
     isSearching
       ? React.createElement("p", { style: styles.hint }, "Searching…")
       : searchResults.length > 0
-        ? React.createElement(
-            "ul",
-            { style: styles.list },
-            searchResults.map((result) =>
-              React.createElement(SearchResultItem, { key: result.id, result, handlers }),
-            ),
-          )
+        ? React.createElement(SearchResultsList, { results: searchResults, handlers })
         : null,
   );
 }

--- a/apps/desktop/src/ui/createDesktopReactShell.js
+++ b/apps/desktop/src/ui/createDesktopReactShell.js
@@ -11,6 +11,7 @@ function createDesktopReactShell({
   navigateImpl = () => {},
   searchArtistsImpl = async () => {},
   toggleSelectionImpl = () => {},
+  deleteSavedArtistImpl = async () => {},
   activateStyleRefImpl = async () => {},
   getSavedArtistsViewPropsImpl = () => ({
     header: { title: "Saved Artists", subtitle: "Your style references" },
@@ -97,6 +98,15 @@ function createDesktopReactShell({
     },
     toggleSelection(id) {
       toggleSelectionImpl(id);
+    },
+    async deleteSavedArtist(id) {
+      try {
+        await deleteSavedArtistImpl(id);
+      } catch (error) {
+        actionStatus = { type: "error", message: "Could not delete artist." };
+        scheduleStatusClear();
+        throw error;
+      }
     },
     async activateStyleRef() {
       await activateStyleRefImpl();

--- a/apps/desktop/src/ui/createDesktopReactShell.js
+++ b/apps/desktop/src/ui/createDesktopReactShell.js
@@ -10,6 +10,8 @@ function createDesktopReactShell({
   getViewImpl = () => "chat",
   navigateImpl = () => {},
   searchArtistsImpl = async () => {},
+  toggleSelectionImpl = () => {},
+  activateStyleRefImpl = async () => {},
   getSavedArtistsViewPropsImpl = () => ({
     header: { title: "Saved Artists", subtitle: "Your style references" },
     artists: [],
@@ -92,6 +94,12 @@ function createDesktopReactShell({
     },
     async searchArtists(query) {
       await searchArtistsImpl(query);
+    },
+    toggleSelection(id) {
+      toggleSelectionImpl(id);
+    },
+    async activateStyleRef() {
+      await activateStyleRefImpl();
     },
     renderHtml() {
       const viewProps = renderAdapter.getViewProps();

--- a/apps/desktop/src/ui/createDesktopReactShell.js
+++ b/apps/desktop/src/ui/createDesktopReactShell.js
@@ -9,6 +9,14 @@ function createDesktopReactShell({
   setTimeoutImpl = setTimeout,
   getViewImpl = () => "chat",
   navigateImpl = () => {},
+  getSavedArtistsViewPropsImpl = () => ({
+    header: { title: "Saved Artists", subtitle: "Your style references" },
+    artists: [],
+    isLoading: false,
+    selectedCount: 0,
+    searchResults: [],
+    isSearching: false,
+  }),
 }) {
   const resolvedActionHandlers = /** @type {any} */ (actionHandlers);
   let actionStatus = null;
@@ -33,11 +41,11 @@ function createDesktopReactShell({
 
   return {
     getViewProps() {
+      if (getViewImpl() === "saved-artists") {
+        return getSavedArtistsViewPropsImpl();
+      }
       const base = renderAdapter.getViewProps();
-      return {
-        ...base,
-        actionStatus,
-      };
+      return { ...base, actionStatus };
     },
     async updateMode(mode) {
       return handlers.onModeChange(mode);
@@ -78,8 +86,8 @@ function createDesktopReactShell({
     getView() {
       return getViewImpl();
     },
-    navigate(view) {
-      navigateImpl(view);
+    async navigate(view) {
+      await navigateImpl(view);
     },
     renderHtml() {
       const viewProps = renderAdapter.getViewProps();

--- a/apps/desktop/src/ui/createDesktopReactShell.js
+++ b/apps/desktop/src/ui/createDesktopReactShell.js
@@ -9,6 +9,7 @@ function createDesktopReactShell({
   setTimeoutImpl = setTimeout,
   getViewImpl = () => "chat",
   navigateImpl = () => {},
+  searchArtistsImpl = async () => {},
   getSavedArtistsViewPropsImpl = () => ({
     header: { title: "Saved Artists", subtitle: "Your style references" },
     artists: [],
@@ -88,6 +89,9 @@ function createDesktopReactShell({
     },
     async navigate(view) {
       await navigateImpl(view);
+    },
+    async searchArtists(query) {
+      await searchArtistsImpl(query);
     },
     renderHtml() {
       const viewProps = renderAdapter.getViewProps();

--- a/apps/desktop/src/ui/createDesktopReactShell.js
+++ b/apps/desktop/src/ui/createDesktopReactShell.js
@@ -2,7 +2,14 @@ const React = require("react");
 const { renderToStaticMarkup } = require("react-dom/server");
 const { ChatAppView } = require("./ChatAppView");
 
-function createDesktopReactShell({ renderAdapter, actionHandlers = {}, statusTimeoutMs = 3000, setTimeoutImpl = setTimeout }) {
+function createDesktopReactShell({
+  renderAdapter,
+  actionHandlers = {},
+  statusTimeoutMs = 3000,
+  setTimeoutImpl = setTimeout,
+  getViewImpl = () => "chat",
+  navigateImpl = () => {},
+}) {
   const resolvedActionHandlers = /** @type {any} */ (actionHandlers);
   let actionStatus = null;
   let clearStatusTimer = null;
@@ -67,6 +74,12 @@ function createDesktopReactShell({ renderAdapter, actionHandlers = {}, statusTim
         scheduleStatusClear();
         throw error;
       }
+    },
+    getView() {
+      return getViewImpl();
+    },
+    navigate(view) {
+      navigateImpl(view);
     },
     renderHtml() {
       const viewProps = renderAdapter.getViewProps();

--- a/apps/desktop/src/ui/mountDesktopReactApp.js
+++ b/apps/desktop/src/ui/mountDesktopReactApp.js
@@ -1,6 +1,7 @@
 const React = require("react");
 const { createRoot } = require("react-dom/client");
 const { ChatAppView } = require("./ChatAppView");
+const { SavedArtistsView } = require("./SavedArtistsView");
 
 function defaultContainerResolver() {
   /** @type {any} */ const browserDocument = globalThis.document;
@@ -12,8 +13,7 @@ function defaultContainerResolver() {
 }
 
 function resolveViewComponent(viewName) {
-  // SavedArtistsView will be plugged in here in Phase 3
-  void viewName;
+  if (viewName === "saved-artists") return SavedArtistsView;
   return ChatAppView;
 }
 

--- a/apps/desktop/src/ui/mountDesktopReactApp.js
+++ b/apps/desktop/src/ui/mountDesktopReactApp.js
@@ -55,8 +55,8 @@ function createDesktopReactMount({
     onMore: (artistName) => {
       void artistName;
     },
-    onNavigate: (view) => {
-      shell.navigate?.(view);
+    onNavigate: async (view) => {
+      await shell.navigate?.(view);
       return renderCurrent();
     },
   };

--- a/apps/desktop/src/ui/mountDesktopReactApp.js
+++ b/apps/desktop/src/ui/mountDesktopReactApp.js
@@ -55,6 +55,14 @@ function createDesktopReactMount({
     onMore: (artistName) => {
       void artistName;
     },
+    onDelete: async (id) => {
+      try {
+        await shell.deleteSavedArtist?.(id);
+      } catch {
+        // Error surfaced via actionStatus
+      }
+      return renderCurrent();
+    },
     onToggleSelection: (id) => {
       shell.toggleSelection?.(id);
       return renderCurrent();

--- a/apps/desktop/src/ui/mountDesktopReactApp.js
+++ b/apps/desktop/src/ui/mountDesktopReactApp.js
@@ -11,6 +11,12 @@ function defaultContainerResolver() {
   return root;
 }
 
+function resolveViewComponent(viewName) {
+  // SavedArtistsView will be plugged in here in Phase 3
+  void viewName;
+  return ChatAppView;
+}
+
 function createDesktopReactMount({
   shell,
   createRootImpl = createRoot,
@@ -21,12 +27,9 @@ function createDesktopReactMount({
 
   async function renderCurrent() {
     const viewProps = shell.getViewProps();
-    root.render(
-      React.createElement(ChatAppView, {
-        viewProps,
-        handlers,
-      }),
-    );
+    const currentView = shell.getView?.() ?? "chat";
+    const ViewComponent = resolveViewComponent(currentView);
+    root.render(React.createElement(ViewComponent, { viewProps, handlers }));
     return viewProps;
   }
 
@@ -51,6 +54,10 @@ function createDesktopReactMount({
     },
     onMore: (artistName) => {
       void artistName;
+    },
+    onNavigate: (view) => {
+      shell.navigate?.(view);
+      return renderCurrent();
     },
   };
 

--- a/apps/desktop/src/ui/mountDesktopReactApp.js
+++ b/apps/desktop/src/ui/mountDesktopReactApp.js
@@ -55,6 +55,18 @@ function createDesktopReactMount({
     onMore: (artistName) => {
       void artistName;
     },
+    onSearch: async (query) => {
+      await shell.searchArtists?.(query);
+      return renderCurrent();
+    },
+    onAddArtist: async ({ name }) => {
+      try {
+        await shell.saveBand?.(name);
+      } catch {
+        // Error surfaced via actionStatus
+      }
+      return renderCurrent();
+    },
     onNavigate: async (view) => {
       await shell.navigate?.(view);
       return renderCurrent();

--- a/apps/desktop/src/ui/mountDesktopReactApp.js
+++ b/apps/desktop/src/ui/mountDesktopReactApp.js
@@ -55,6 +55,14 @@ function createDesktopReactMount({
     onMore: (artistName) => {
       void artistName;
     },
+    onToggleSelection: (id) => {
+      shell.toggleSelection?.(id);
+      return renderCurrent();
+    },
+    onActivateStyleRef: async () => {
+      await shell.activateStyleRef?.();
+      return renderCurrent();
+    },
     onSearch: async (query) => {
       await shell.searchArtists?.(query);
       return renderCurrent();

--- a/apps/desktop/test/app-navigation.test.js
+++ b/apps/desktop/test/app-navigation.test.js
@@ -1,0 +1,32 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { bootstrapDesktopApp } = require("../src");
+
+function makeApp() {
+  return bootstrapDesktopApp({ apiBaseUrl: "http://localhost:3001", fetchImpl: async () => ({}) });
+}
+
+test("bootstrapDesktopApp starts on chat view", () => {
+  const app = makeApp();
+  assert.equal(app.getView(), "chat");
+});
+
+test("navigate to saved-artists changes view", () => {
+  const app = makeApp();
+  app.navigate("saved-artists");
+  assert.equal(app.getView(), "saved-artists");
+});
+
+test("navigate back to chat works", () => {
+  const app = makeApp();
+  app.navigate("saved-artists");
+  app.navigate("chat");
+  assert.equal(app.getView(), "chat");
+});
+
+test("navigate to unknown view is ignored", () => {
+  const app = makeApp();
+  app.navigate("unknown-view");
+  assert.equal(app.getView(), "chat");
+});

--- a/apps/desktop/test/chat-client.test.js
+++ b/apps/desktop/test/chat-client.test.js
@@ -78,3 +78,40 @@ test("normalizeArtistId creates stable local fallback id", () => {
   assert.equal(normalizeArtistId("Alcest"), "local-alcest");
   assert.equal(normalizeArtistId("Les Discrets"), "local-les-discrets");
 });
+
+test("chat client fetches saved bands from GET /preferences", async () => {
+  const calls = [];
+  const client = createChatClient({
+    apiBaseUrl: "http://localhost:3001",
+    fetchImpl: async (url, init) => {
+      calls.push({ url, method: init?.method });
+      return {
+        ok: true,
+        json: async () => ({ savedBands: [{ id: "b1", name: "Fen", rating: 3 }] }),
+      };
+    },
+  });
+
+  const bands = await client.listPreferences();
+
+  assert.equal(calls[0].url, "http://localhost:3001/preferences");
+  assert.equal(calls[0].method, undefined);
+  assert.equal(bands.length, 1);
+  assert.equal(bands[0].name, "Fen");
+});
+
+test("chat client deletes a preference via DELETE /preferences/:id", async () => {
+  const calls = [];
+  const client = createChatClient({
+    apiBaseUrl: "http://localhost:3001",
+    fetchImpl: async (url, init) => {
+      calls.push({ url, method: init?.method });
+      return { ok: true, json: async () => ({ ok: true }) };
+    },
+  });
+
+  await client.deletePreference("pref-123");
+
+  assert.equal(calls[0].url, "http://localhost:3001/preferences/pref-123");
+  assert.equal(calls[0].method, "DELETE");
+});

--- a/apps/desktop/test/chat-client.test.js
+++ b/apps/desktop/test/chat-client.test.js
@@ -115,3 +115,24 @@ test("chat client deletes a preference via DELETE /preferences/:id", async () =>
   assert.equal(calls[0].url, "http://localhost:3001/preferences/pref-123");
   assert.equal(calls[0].method, "DELETE");
 });
+
+test("chat client searches artists via GET /search/artists", async () => {
+  const calls = [];
+  const client = createChatClient({
+    apiBaseUrl: "http://localhost:3001",
+    fetchImpl: async (url, init) => {
+      calls.push({ url, method: init?.method });
+      return {
+        ok: true,
+        json: async () => ({ artists: [{ id: "abc", name: "Alcest", score: 100, disambiguation: "" }] }),
+      };
+    },
+  });
+
+  const results = await client.searchArtists("Alcest");
+
+  assert.equal(calls[0].url, "http://localhost:3001/search/artists?q=Alcest");
+  assert.equal(calls[0].method, undefined);
+  assert.equal(results.length, 1);
+  assert.equal(results[0].name, "Alcest");
+});

--- a/apps/desktop/test/saved-artists-model.test.js
+++ b/apps/desktop/test/saved-artists-model.test.js
@@ -88,6 +88,48 @@ test("saved artists model isSearching is true during search", async () => {
   assert.equal(model.getScreenState().isSearching, false);
 });
 
+test("saved artists model toggleSelection adds artist to selection", async () => {
+  const bands = [{ id: "b1", name: "Fen", rating: 4, categories: [], note: "" }];
+  const model = createSavedArtistsModel({ app: makeApp(bands) });
+  await model.loadSavedArtists();
+
+  model.toggleSelection("b1");
+
+  const state = model.getScreenState();
+  assert.equal(state.artists[0].isSelected, true);
+  assert.equal(state.selectedCount, 1);
+});
+
+test("saved artists model toggleSelection removes already-selected artist", async () => {
+  const bands = [{ id: "b1", name: "Fen", rating: 4, categories: [], note: "" }];
+  const model = createSavedArtistsModel({ app: makeApp(bands) });
+  await model.loadSavedArtists();
+
+  model.toggleSelection("b1");
+  model.toggleSelection("b1");
+
+  const state = model.getScreenState();
+  assert.equal(state.artists[0].isSelected, false);
+  assert.equal(state.selectedCount, 0);
+});
+
+test("saved artists model getSelectedIds returns current selection as array", async () => {
+  const bands = [
+    { id: "b1", name: "Fen", rating: 4, categories: [], note: "" },
+    { id: "b2", name: "Alcest", rating: 5, categories: [], note: "" },
+  ];
+  const model = createSavedArtistsModel({ app: makeApp(bands) });
+  await model.loadSavedArtists();
+
+  model.toggleSelection("b1");
+  model.toggleSelection("b2");
+  const ids = model.getSelectedIds();
+
+  assert.equal(ids.length, 2);
+  assert.equal(ids.includes("b1"), true);
+  assert.equal(ids.includes("b2"), true);
+});
+
 test("saved artists model clears search results for empty query", async () => {
   const model = createSavedArtistsModel({
     app: {

--- a/apps/desktop/test/saved-artists-model.test.js
+++ b/apps/desktop/test/saved-artists-model.test.js
@@ -1,0 +1,57 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { createSavedArtistsModel } = require("../src/savedArtistsModel");
+
+function makeApp(savedBands = []) {
+  return {
+    listSavedBands: async () => savedBands,
+  };
+}
+
+test("saved artists model returns empty artist list initially", () => {
+  const model = createSavedArtistsModel({ app: makeApp() });
+  const state = model.getScreenState();
+  assert.deepEqual(state.artists, []);
+  assert.equal(state.isLoading, false);
+});
+
+test("saved artists model maps saved bands to UI items after load", async () => {
+  const bands = [
+    { id: "b1", name: "Fen", rating: 4, categories: ["post-black"], note: "Atmospheric" },
+    { id: "b2", name: "Alcest", rating: 5, categories: [], note: "" },
+  ];
+  const model = createSavedArtistsModel({ app: makeApp(bands) });
+  await model.loadSavedArtists();
+  const state = model.getScreenState();
+
+  assert.equal(state.artists.length, 2);
+  assert.equal(state.artists[0].id, "b1");
+  assert.equal(state.artists[0].name, "Fen");
+  assert.equal(state.artists[0].rating, 4);
+  assert.deepEqual(state.artists[0].categoryTags, ["post-black"]);
+  assert.equal(state.artists[0].note, "Atmospheric");
+  assert.equal(state.artists[0].isSelected, false);
+});
+
+test("saved artists model sets isLoading true during load", async () => {
+  let observedDuringLoad = null;
+  const app = {
+    listSavedBands: async () => {
+      observedDuringLoad = model.getScreenState().isLoading;
+      return [];
+    },
+  };
+  const model = createSavedArtistsModel({ app });
+  await model.loadSavedArtists();
+
+  assert.equal(observedDuringLoad, true);
+  assert.equal(model.getScreenState().isLoading, false);
+});
+
+test("saved artists model includes header in screen state", () => {
+  const model = createSavedArtistsModel({ app: makeApp() });
+  const state = model.getScreenState();
+  assert.equal(state.header.title, "Saved Artists");
+  assert.ok(state.header.subtitle);
+});

--- a/apps/desktop/test/saved-artists-model.test.js
+++ b/apps/desktop/test/saved-artists-model.test.js
@@ -55,3 +55,49 @@ test("saved artists model includes header in screen state", () => {
   assert.equal(state.header.title, "Saved Artists");
   assert.ok(state.header.subtitle);
 });
+
+test("saved artists model tracks search results after searchArtists call", async () => {
+  const model = createSavedArtistsModel({
+    app: {
+      ...makeApp(),
+      searchArtists: async () => [{ id: "abc", name: "Alcest", score: 100, disambiguation: "French blackgaze" }],
+    },
+  });
+
+  await model.searchArtists("Alcest");
+  const state = model.getScreenState();
+
+  assert.equal(state.searchResults.length, 1);
+  assert.equal(state.searchResults[0].name, "Alcest");
+  assert.equal(state.searchResults[0].id, "abc");
+});
+
+test("saved artists model isSearching is true during search", async () => {
+  let resolveSearch;
+  const model = createSavedArtistsModel({
+    app: {
+      ...makeApp(),
+      searchArtists: () => new Promise((resolve) => { resolveSearch = resolve; }),
+    },
+  });
+
+  const searchPromise = model.searchArtists("Fen");
+  assert.equal(model.getScreenState().isSearching, true);
+  resolveSearch([]);
+  await searchPromise;
+  assert.equal(model.getScreenState().isSearching, false);
+});
+
+test("saved artists model clears search results for empty query", async () => {
+  const model = createSavedArtistsModel({
+    app: {
+      ...makeApp(),
+      searchArtists: async () => [{ id: "x", name: "Test", score: 80, disambiguation: "" }],
+    },
+  });
+
+  await model.searchArtists("Test");
+  assert.equal(model.getScreenState().searchResults.length, 1);
+  await model.searchArtists("");
+  assert.equal(model.getScreenState().searchResults.length, 0);
+});

--- a/apps/desktop/test/saved-artists-model.test.js
+++ b/apps/desktop/test/saved-artists-model.test.js
@@ -4,8 +4,10 @@ const assert = require("node:assert/strict");
 const { createSavedArtistsModel } = require("../src/savedArtistsModel");
 
 function makeApp(savedBands = []) {
+  const bands = [...savedBands];
   return {
-    listSavedBands: async () => savedBands,
+    listSavedBands: async () => bands,
+    deleteSavedBand: async (id) => { const i = bands.findIndex((b) => b.id === id); if (i >= 0) bands.splice(i, 1); },
   };
 }
 
@@ -128,6 +130,50 @@ test("saved artists model getSelectedIds returns current selection as array", as
   assert.equal(ids.length, 2);
   assert.equal(ids.includes("b1"), true);
   assert.equal(ids.includes("b2"), true);
+});
+
+test("saved artists model deleteSavedArtist removes band from list", async () => {
+  const bands = [
+    { id: "b1", name: "Fen", rating: 4, categories: [], note: "" },
+    { id: "b2", name: "Alcest", rating: 5, categories: [], note: "" },
+  ];
+  const model = createSavedArtistsModel({ app: makeApp(bands) });
+  await model.loadSavedArtists();
+
+  await model.deleteSavedArtist("b1");
+
+  const state = model.getScreenState();
+  assert.equal(state.artists.length, 1);
+  assert.equal(state.artists[0].id, "b2");
+});
+
+test("saved artists model deleteSavedArtist also removes from selection", async () => {
+  const bands = [{ id: "b1", name: "Fen", rating: 4, categories: [], note: "" }];
+  const model = createSavedArtistsModel({ app: makeApp(bands) });
+  await model.loadSavedArtists();
+  model.toggleSelection("b1");
+  assert.equal(model.getScreenState().selectedCount, 1);
+
+  await model.deleteSavedArtist("b1");
+
+  assert.equal(model.getScreenState().selectedCount, 0);
+});
+
+test("saved artists model clearSelection empties the selection", async () => {
+  const bands = [
+    { id: "b1", name: "Fen", rating: 4, categories: [], note: "" },
+    { id: "b2", name: "Alcest", rating: 5, categories: [], note: "" },
+  ];
+  const model = createSavedArtistsModel({ app: makeApp(bands) });
+  await model.loadSavedArtists();
+  model.toggleSelection("b1");
+  model.toggleSelection("b2");
+  assert.equal(model.getScreenState().selectedCount, 2);
+
+  model.clearSelection();
+
+  assert.equal(model.getScreenState().selectedCount, 0);
+  assert.equal(model.getSelectedIds().length, 0);
 });
 
 test("saved artists model clears search results for empty query", async () => {

--- a/apps/desktop/test/saved-artists-view.test.js
+++ b/apps/desktop/test/saved-artists-view.test.js
@@ -1,0 +1,76 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const React = require("react");
+const { renderToStaticMarkup } = require("react-dom/server");
+
+const { SavedArtistsView } = require("../src/ui/SavedArtistsView");
+
+const baseHandlers = {
+  onNavigate: () => {},
+  onDelete: () => {},
+};
+
+test("SavedArtistsView renders each saved artist name", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(SavedArtistsView, {
+      viewProps: {
+        header: { title: "Saved Artists", subtitle: "Your style references" },
+        artists: [
+          { id: "b1", name: "Fen", rating: 4, categoryTags: ["post-black"], note: "", isSelected: false },
+          { id: "b2", name: "Alcest", rating: 5, categoryTags: [], note: "", isSelected: false },
+        ],
+        isLoading: false,
+      },
+      handlers: baseHandlers,
+    }),
+  );
+
+  assert.equal(html.includes("Fen"), true);
+  assert.equal(html.includes("Alcest"), true);
+});
+
+test("SavedArtistsView renders empty state when no artists", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(SavedArtistsView, {
+      viewProps: {
+        header: { title: "Saved Artists", subtitle: "Your style references" },
+        artists: [],
+        isLoading: false,
+      },
+      handlers: baseHandlers,
+    }),
+  );
+
+  assert.equal(html.includes("Saved Artists"), true);
+  assert.equal(html.includes("No saved artists"), true);
+});
+
+test("SavedArtistsView renders navigation back to chat", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(SavedArtistsView, {
+      viewProps: {
+        header: { title: "Saved Artists", subtitle: "Your style references" },
+        artists: [],
+        isLoading: false,
+      },
+      handlers: baseHandlers,
+    }),
+  );
+
+  assert.equal(html.includes("Recommendations") || html.includes("Back"), true);
+});
+
+test("SavedArtistsView renders Saved Artists heading", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(SavedArtistsView, {
+      viewProps: {
+        header: { title: "Saved Artists", subtitle: "Your style references" },
+        artists: [],
+        isLoading: false,
+      },
+      handlers: baseHandlers,
+    }),
+  );
+
+  assert.equal(html.includes("Saved Artists"), true);
+});

--- a/apps/desktop/test/saved-artists-view.test.js
+++ b/apps/desktop/test/saved-artists-view.test.js
@@ -112,6 +112,42 @@ test("SavedArtistsView renders search results with Add buttons", () => {
   assert.equal(html.includes("Add"), true, "should render Add button per result");
 });
 
+test("SavedArtistsView renders tick button per artist", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(SavedArtistsView, {
+      viewProps: {
+        header: { title: "Saved Artists", subtitle: "Your style references" },
+        artists: [{ id: "b1", name: "Fen", rating: 4, categoryTags: [], note: "", isSelected: false }],
+        isLoading: false,
+        searchResults: [],
+        isSearching: false,
+        selectedCount: 0,
+      },
+      handlers: { ...baseHandlers, onToggleSelection: () => {} },
+    }),
+  );
+
+  assert.equal(html.includes("tick-btn") || html.includes("○"), true, "should render tick button");
+});
+
+test("SavedArtistsView shows selection bar when selectedCount > 0", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(SavedArtistsView, {
+      viewProps: {
+        header: { title: "Saved Artists", subtitle: "Your style references" },
+        artists: [{ id: "b1", name: "Fen", rating: 4, categoryTags: [], note: "", isSelected: true }],
+        isLoading: false,
+        searchResults: [],
+        isSearching: false,
+        selectedCount: 1,
+      },
+      handlers: { ...baseHandlers, onToggleSelection: () => {}, onActivateStyleRef: () => {} },
+    }),
+  );
+
+  assert.equal(html.includes("1 selected"), true, "should show selected count in selection bar");
+});
+
 test("SavedArtistsView shows searching indicator when isSearching", () => {
   const html = renderToStaticMarkup(
     React.createElement(SavedArtistsView, {

--- a/apps/desktop/test/saved-artists-view.test.js
+++ b/apps/desktop/test/saved-artists-view.test.js
@@ -74,3 +74,57 @@ test("SavedArtistsView renders Saved Artists heading", () => {
 
   assert.equal(html.includes("Saved Artists"), true);
 });
+
+test("SavedArtistsView renders search input and button", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(SavedArtistsView, {
+      viewProps: {
+        header: { title: "Saved Artists", subtitle: "Your style references" },
+        artists: [],
+        isLoading: false,
+        searchResults: [],
+        isSearching: false,
+      },
+      handlers: baseHandlers,
+    }),
+  );
+
+  assert.equal(html.includes('name="artist-search"'), true, "should render search input");
+  assert.equal(html.includes("Search"), true, "should render Search button");
+});
+
+test("SavedArtistsView renders search results with Add buttons", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(SavedArtistsView, {
+      viewProps: {
+        header: { title: "Saved Artists", subtitle: "Your style references" },
+        artists: [],
+        isLoading: false,
+        searchResults: [{ id: "abc", name: "Alcest", disambiguation: "French blackgaze" }],
+        isSearching: false,
+      },
+      handlers: { ...baseHandlers, onAddArtist: () => {} },
+    }),
+  );
+
+  assert.equal(html.includes("Alcest"), true, "should show search result name");
+  assert.equal(html.includes("French blackgaze"), true, "should show disambiguation");
+  assert.equal(html.includes("Add"), true, "should render Add button per result");
+});
+
+test("SavedArtistsView shows searching indicator when isSearching", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(SavedArtistsView, {
+      viewProps: {
+        header: { title: "Saved Artists", subtitle: "Your style references" },
+        artists: [],
+        isLoading: false,
+        searchResults: [],
+        isSearching: true,
+      },
+      handlers: baseHandlers,
+    }),
+  );
+
+  assert.equal(html.includes("Searching"), true, "should show searching indicator");
+});

--- a/apps/desktop/test/saved-artists-view.test.js
+++ b/apps/desktop/test/saved-artists-view.test.js
@@ -127,7 +127,46 @@ test("SavedArtistsView renders tick button per artist", () => {
     }),
   );
 
-  assert.equal(html.includes("tick-btn") || html.includes("○"), true, "should render tick button");
+  assert.equal(html.includes("tick-btn"), true, "should render element with tick-btn class");
+  assert.equal(html.includes("○"), true, "unselected tick should show empty circle");
+});
+
+test("SavedArtistsView renders checkmark for selected artist", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(SavedArtistsView, {
+      viewProps: {
+        header: { title: "Saved Artists", subtitle: "Your style references" },
+        artists: [{ id: "b1", name: "Fen", rating: 4, categoryTags: [], note: "", isSelected: true }],
+        isLoading: false,
+        searchResults: [],
+        isSearching: false,
+        selectedCount: 1,
+      },
+      handlers: { ...baseHandlers, onToggleSelection: () => {}, onActivateStyleRef: () => {} },
+    }),
+  );
+
+  assert.equal(html.includes("✓"), true, "selected tick should show checkmark");
+  assert.equal(html.includes("○"), false, "selected artist should not show empty circle");
+});
+
+test("SavedArtistsView shows loading state when isLoading", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(SavedArtistsView, {
+      viewProps: {
+        header: { title: "Saved Artists", subtitle: "Your style references" },
+        artists: [],
+        isLoading: true,
+        searchResults: [],
+        isSearching: false,
+        selectedCount: 0,
+      },
+      handlers: baseHandlers,
+    }),
+  );
+
+  assert.equal(html.includes("Loading"), true, "should show loading indicator");
+  assert.equal(html.includes("No saved artists"), false, "should not show empty state while loading");
 });
 
 test("SavedArtistsView shows selection bar when selectedCount > 0", () => {

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -21,6 +21,7 @@
 - Client-side view router: `getView()`/`navigate()` on bootstrapDesktopApp, threaded through shell and mount layer; `resolveViewComponent` dispatch point ready for Phase 3 plug-in. ✓ Done.
 - Saved Artists page — Basic List: `SavedArtistsView` component with band list, header, back navigation; `savedArtistsModel` (combined ViewModel + ScreenModel); `listPreferences`/`deletePreference` on chatClient; shell wired to serve view-specific props and trigger data load on navigate. ✓ Done.
   - MusicBrainz search to find and add artists by name directly, without going through the recommendation flow. API: `GET /search/artists?q=` endpoint; client: `searchArtists()`; musicBrainzClient shared in app factory scope. ✓ Done.
+    UI: search form in SavedArtistsView with isSearching indicator, SearchResultsList sub-component, Add button wired through shell to saveBand. ✓ Done.
   - Directional selection (tick/checkbox) to mark which saved artists should act as style references for the next search — these get injected as a priority preference context alongside the normal query.
 
 ## Phase 4 — Richer Artist Data

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -22,7 +22,7 @@
 - Saved Artists page — Basic List: `SavedArtistsView` component with band list, header, back navigation; `savedArtistsModel` (combined ViewModel + ScreenModel); `listPreferences`/`deletePreference` on chatClient; shell wired to serve view-specific props and trigger data load on navigate. ✓ Done.
   - MusicBrainz search to find and add artists by name directly, without going through the recommendation flow. API: `GET /search/artists?q=` endpoint; client: `searchArtists()`; musicBrainzClient shared in app factory scope. ✓ Done.
     UI: search form in SavedArtistsView with isSearching indicator, SearchResultsList sub-component, Add button wired through shell to saveBand. ✓ Done.
-  - Directional selection (tick/checkbox) to mark which saved artists should act as style references for the next search — these get injected as a priority preference context alongside the normal query.
+  - Directional selection (tick/checkbox) to mark which saved artists should act as style references for the next search — SelectionBar with count + CTA, selectedArtistIds forwarded to API, buildContextForIds in SQLite repo, pendingSelectedArtistIds lifecycle in bootstrapDesktopApp. ✓ Done.
 
 ## Phase 4 — Richer Artist Data
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -20,7 +20,7 @@
 - Compact card layout: reduce card height and visual weight so more results fit on screen without scrolling. Pure CSS/layout change, no data model impact. ✓ Done.
 - Client-side view router: `getView()`/`navigate()` on bootstrapDesktopApp, threaded through shell and mount layer; `resolveViewComponent` dispatch point ready for Phase 3 plug-in. ✓ Done.
 - Saved Artists page — Basic List: `SavedArtistsView` component with band list, header, back navigation; `savedArtistsModel` (combined ViewModel + ScreenModel); `listPreferences`/`deletePreference` on chatClient; shell wired to serve view-specific props and trigger data load on navigate. ✓ Done.
-  - MusicBrainz search to find and add artists by name directly, without going through the recommendation flow.
+  - MusicBrainz search to find and add artists by name directly, without going through the recommendation flow. API: `GET /search/artists?q=` endpoint; client: `searchArtists()`; musicBrainzClient shared in app factory scope. ✓ Done.
   - Directional selection (tick/checkbox) to mark which saved artists should act as style references for the next search — these get injected as a priority preference context alongside the normal query.
 
 ## Phase 4 — Richer Artist Data

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -19,7 +19,7 @@
 - Playwright browser smoke tests: verify the built app actually renders in a real browser. ✓ Done.
 - Compact card layout: reduce card height and visual weight so more results fit on screen without scrolling. Pure CSS/layout change, no data model impact. ✓ Done.
 - Client-side view router: `getView()`/`navigate()` on bootstrapDesktopApp, threaded through shell and mount layer; `resolveViewComponent` dispatch point ready for Phase 3 plug-in. ✓ Done.
-- Saved Artists page: dedicated view for managing saved artists, requiring in-app client-side routing (currently the app is single-view). Two sub-features:
+- Saved Artists page — Basic List: `SavedArtistsView` component with band list, header, back navigation; `savedArtistsModel` (combined ViewModel + ScreenModel); `listPreferences`/`deletePreference` on chatClient; shell wired to serve view-specific props and trigger data load on navigate. ✓ Done.
   - MusicBrainz search to find and add artists by name directly, without going through the recommendation flow.
   - Directional selection (tick/checkbox) to mark which saved artists should act as style references for the next search — these get injected as a priority preference context alongside the normal query.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -18,6 +18,7 @@
 
 - Playwright browser smoke tests: verify the built app actually renders in a real browser. ✓ Done.
 - Compact card layout: reduce card height and visual weight so more results fit on screen without scrolling. Pure CSS/layout change, no data model impact. ✓ Done.
+- Client-side view router: `getView()`/`navigate()` on bootstrapDesktopApp, threaded through shell and mount layer; `resolveViewComponent` dispatch point ready for Phase 3 plug-in. ✓ Done.
 - Saved Artists page: dedicated view for managing saved artists, requiring in-app client-side routing (currently the app is single-view). Two sub-features:
   - MusicBrainz search to find and add artists by name directly, without going through the recommendation flow.
   - Directional selection (tick/checkbox) to mark which saved artists should act as style references for the next search — these get injected as a priority preference context alongside the normal query.

--- a/services/api/src/app.js
+++ b/services/api/src/app.js
@@ -63,6 +63,11 @@ function createApp({ recommendationService, preferenceRepository, musicBrainzCli
     preferenceRepository || createPreferenceRepository(runtimeConfig),
   );
 
+  const resolvedMusicBrainzClient = musicBrainzClient || createMusicBrainzClient({
+    timeoutMs: runtimeConfig.musicBrainzTimeoutMs,
+    retries: runtimeConfig.musicBrainzRetries,
+  });
+
   const resolvedRecommendationService = recommendationService;
 
   app.get("/health", (_req, res) => {
@@ -87,6 +92,7 @@ function createApp({ recommendationService, preferenceRepository, musicBrainzCli
       const recommendations = await getRecommendationService(
         resolvedRecommendationService,
         runtimeConfig,
+        resolvedMusicBrainzClient,
       ).getRecommendations(validation.query, {
         mode: requestedMode,
         preferenceContext,
@@ -147,11 +153,7 @@ function createApp({ recommendationService, preferenceRepository, musicBrainzCli
       return sendError(res, 400, "validation_error", "query parameter q is required");
     }
     try {
-      const client = musicBrainzClient || createMusicBrainzClient({
-        timeoutMs: runtimeConfig.musicBrainzTimeoutMs,
-        retries: runtimeConfig.musicBrainzRetries,
-      });
-      const artists = await client.searchArtists(q);
+      const artists = await resolvedMusicBrainzClient.searchArtists(q);
       return res.status(200).json({ artists });
     } catch {
       return sendError(res, 502, "search_unavailable", "artist search unavailable");
@@ -176,26 +178,22 @@ function createApp({ recommendationService, preferenceRepository, musicBrainzCli
 
 let cachedDefaultService;
 
-function getRecommendationService(overriddenService, runtimeConfig) {
+function getRecommendationService(overriddenService, runtimeConfig, musicBrainzClient) {
   if (overriddenService) {
     return overriddenService;
   }
   if (!cachedDefaultService) {
-    cachedDefaultService = createRecommendationService({
-      musicBrainzClient: createMusicBrainzClient({
-        timeoutMs: runtimeConfig.musicBrainzTimeoutMs,
-        retries: runtimeConfig.musicBrainzRetries,
-      }),
+    const client = musicBrainzClient || createMusicBrainzClient({
+      timeoutMs: runtimeConfig.musicBrainzTimeoutMs,
+      retries: runtimeConfig.musicBrainzRetries,
     });
+    cachedDefaultService = createRecommendationService({ musicBrainzClient: client });
 
     if (process.env.GEMINI_API_KEY) {
       createLangChainRunner({ timeoutMs: runtimeConfig.recommendationTimeoutMs })
         .then((runModel) => {
           cachedDefaultService = createRecommendationService({
-            musicBrainzClient: createMusicBrainzClient({
-              timeoutMs: runtimeConfig.musicBrainzTimeoutMs,
-              retries: runtimeConfig.musicBrainzRetries,
-            }),
+            musicBrainzClient: client,
             recommendationAgent: createRecommendationAgent({ runModel }),
           });
         })

--- a/services/api/src/app.js
+++ b/services/api/src/app.js
@@ -68,7 +68,27 @@ function createApp({ recommendationService, preferenceRepository, musicBrainzCli
     retries: runtimeConfig.musicBrainzRetries,
   });
 
-  const resolvedRecommendationService = recommendationService;
+  let defaultRecommendationService = null;
+
+  function resolveRecommendationService() {
+    if (recommendationService) return recommendationService;
+    if (!defaultRecommendationService) {
+      defaultRecommendationService = createRecommendationService({ musicBrainzClient: resolvedMusicBrainzClient });
+      if (process.env.GEMINI_API_KEY) {
+        createLangChainRunner({ timeoutMs: runtimeConfig.recommendationTimeoutMs })
+          .then((runModel) => {
+            defaultRecommendationService = createRecommendationService({
+              musicBrainzClient: resolvedMusicBrainzClient,
+              recommendationAgent: createRecommendationAgent({ runModel }),
+            });
+          })
+          .catch(() => {
+            // Keep deterministic fallback service if LangChain initialization fails.
+          });
+      }
+    }
+    return defaultRecommendationService;
+  }
 
   app.get("/health", (_req, res) => {
     return res.status(200).json({ status: "ok" });
@@ -90,7 +110,7 @@ function createApp({ recommendationService, preferenceRepository, musicBrainzCli
       : [];
     let preferenceContext = "";
     if (requestedMode === "preference-aware") {
-      if (selectedArtistIds.length > 0 && typeof resolvedPreferenceRepository.buildContextForIds === "function") {
+      if (selectedArtistIds.length > 0 && resolvedPreferenceRepository.buildContextForIds) {
         preferenceContext = await resolvedPreferenceRepository.buildContextForIds(selectedArtistIds);
       } else {
         preferenceContext = await resolvedPreferenceRepository.buildContext();
@@ -98,11 +118,7 @@ function createApp({ recommendationService, preferenceRepository, musicBrainzCli
     }
 
     try {
-      const recommendations = await getRecommendationService(
-        resolvedRecommendationService,
-        runtimeConfig,
-        resolvedMusicBrainzClient,
-      ).getRecommendations(validation.query, {
+      const recommendations = await resolveRecommendationService().getRecommendations(validation.query, {
         mode: requestedMode,
         preferenceContext,
       });
@@ -183,35 +199,6 @@ function createApp({ recommendationService, preferenceRepository, musicBrainzCli
   });
 
   return app;
-}
-
-let cachedDefaultService;
-
-function getRecommendationService(overriddenService, runtimeConfig, musicBrainzClient) {
-  if (overriddenService) {
-    return overriddenService;
-  }
-  if (!cachedDefaultService) {
-    const client = musicBrainzClient || createMusicBrainzClient({
-      timeoutMs: runtimeConfig.musicBrainzTimeoutMs,
-      retries: runtimeConfig.musicBrainzRetries,
-    });
-    cachedDefaultService = createRecommendationService({ musicBrainzClient: client });
-
-    if (process.env.GEMINI_API_KEY) {
-      createLangChainRunner({ timeoutMs: runtimeConfig.recommendationTimeoutMs })
-        .then((runModel) => {
-          cachedDefaultService = createRecommendationService({
-            musicBrainzClient: client,
-            recommendationAgent: createRecommendationAgent({ runModel }),
-          });
-        })
-        .catch(() => {
-          // Keep deterministic fallback service if LangChain initialization fails.
-        });
-    }
-  }
-  return cachedDefaultService;
 }
 
 module.exports = { createApp };

--- a/services/api/src/app.js
+++ b/services/api/src/app.js
@@ -16,9 +16,9 @@ const { assertPreferenceRepository, createPreferenceRepository } = require("./pr
 const { sendError } = require("./http/errors");
 
 /**
- * @param {{ recommendationService?: any, preferenceRepository?: any, runtimeConfig?: any }} [options]
+ * @param {{ recommendationService?: any, preferenceRepository?: any, musicBrainzClient?: any, runtimeConfig?: any }} [options]
  */
-function createApp({ recommendationService, preferenceRepository, runtimeConfig = {} } = {}) {
+function createApp({ recommendationService, preferenceRepository, musicBrainzClient, runtimeConfig = {} } = {}) {
   const app = express();
   app.use(helmet());
   app.use(
@@ -139,6 +139,23 @@ function createApp({ recommendationService, preferenceRepository, runtimeConfig 
     return res.status(200).json({
       context,
     });
+  });
+
+  app.get("/search/artists", async (req, res) => {
+    const q = String(req.query.q || "").trim();
+    if (!q) {
+      return sendError(res, 400, "validation_error", "query parameter q is required");
+    }
+    try {
+      const client = musicBrainzClient || createMusicBrainzClient({
+        timeoutMs: runtimeConfig.musicBrainzTimeoutMs,
+        retries: runtimeConfig.musicBrainzRetries,
+      });
+      const artists = await client.searchArtists(q);
+      return res.status(200).json({ artists });
+    } catch {
+      return sendError(res, 502, "search_unavailable", "artist search unavailable");
+    }
   });
 
   app.use((req, res) => sendError(res, 404, "not_found", `route not found: ${req.path}`));

--- a/services/api/src/app.js
+++ b/services/api/src/app.js
@@ -85,8 +85,17 @@ function createApp({ recommendationService, preferenceRepository, musicBrainzCli
     }
 
     const requestedMode = validateRecommendationMode(req.body?.mode);
-    const preferenceContext =
-      requestedMode === "preference-aware" ? await resolvedPreferenceRepository.buildContext() : "";
+    const selectedArtistIds = Array.isArray(req.body?.selectedArtistIds)
+      ? req.body.selectedArtistIds.filter((id) => typeof id === "string")
+      : [];
+    let preferenceContext = "";
+    if (requestedMode === "preference-aware") {
+      if (selectedArtistIds.length > 0 && typeof resolvedPreferenceRepository.buildContextForIds === "function") {
+        preferenceContext = await resolvedPreferenceRepository.buildContextForIds(selectedArtistIds);
+      } else {
+        preferenceContext = await resolvedPreferenceRepository.buildContext();
+      }
+    }
 
     try {
       const recommendations = await getRecommendationService(

--- a/services/api/src/preferences/sqlitePreferenceRepository.js
+++ b/services/api/src/preferences/sqlitePreferenceRepository.js
@@ -14,6 +14,10 @@ function mapRowToSavedBand(row) {
   };
 }
 
+function formatBandContext(b) {
+  return `${b.name} (rating ${b.rating}/5) tags: ${b.categories.join(", ")} note: ${b.note}`;
+}
+
 function createSqlitePreferenceRepository({ db }) {
   return {
     async addSavedBand(input) {
@@ -78,9 +82,7 @@ function createSqlitePreferenceRepository({ db }) {
     async buildContext() {
       const savedBands = await this.listSavedBands();
       if (savedBands.length === 0) return "";
-      return savedBands
-        .map((b) => `${b.name} (rating ${b.rating}/5) tags: ${b.categories.join(", ")} note: ${b.note}`)
-        .join("\n");
+      return savedBands.map(formatBandContext).join("\n");
     },
 
     async buildContextForIds(ids) {
@@ -88,10 +90,7 @@ function createSqlitePreferenceRepository({ db }) {
       const placeholders = ids.map(() => "?").join(", ");
       const rows = db.prepare(`SELECT * FROM saved_bands WHERE id IN (${placeholders})`).all(...ids);
       if (rows.length === 0) return "";
-      return rows
-        .map(mapRowToSavedBand)
-        .map((b) => `${b.name} (rating ${b.rating}/5) tags: ${b.categories.join(", ")} note: ${b.note}`)
-        .join("\n");
+      return rows.map(mapRowToSavedBand).map(formatBandContext).join("\n");
     },
   };
 }

--- a/services/api/src/preferences/sqlitePreferenceRepository.js
+++ b/services/api/src/preferences/sqlitePreferenceRepository.js
@@ -82,6 +82,17 @@ function createSqlitePreferenceRepository({ db }) {
         .map((b) => `${b.name} (rating ${b.rating}/5) tags: ${b.categories.join(", ")} note: ${b.note}`)
         .join("\n");
     },
+
+    async buildContextForIds(ids) {
+      if (!ids || ids.length === 0) return "";
+      const placeholders = ids.map(() => "?").join(", ");
+      const rows = db.prepare(`SELECT * FROM saved_bands WHERE id IN (${placeholders})`).all(...ids);
+      if (rows.length === 0) return "";
+      return rows
+        .map(mapRowToSavedBand)
+        .map((b) => `${b.name} (rating ${b.rating}/5) tags: ${b.categories.join(", ")} note: ${b.note}`)
+        .join("\n");
+    },
   };
 }
 

--- a/services/api/test/recommendations-route.test.js
+++ b/services/api/test/recommendations-route.test.js
@@ -110,6 +110,42 @@ test("POST /recommendations returns 502 on recommendation service error", async 
   assert.equal(result.data.error.message, "recommendation service unavailable");
 });
 
+test("POST /recommendations with selectedArtistIds uses buildContextForIds", async () => {
+  const calls = [];
+  const app = createApp({
+    recommendationService: {
+      getRecommendations: async (query, options) => {
+        calls.push({ type: "getRecommendations", query, options });
+        return [{ artist: "Les Discrets", why: "Similar tone", sourceSignals: ["musicbrainz_search"] }];
+      },
+    },
+    preferenceRepository: {
+      addSavedBand: async () => ({ ok: true, savedBand: null }),
+      listSavedBands: async () => [],
+      updateSavedBand: async () => ({ ok: false, status: 404, error: "" }),
+      deleteSavedBand: async () => ({ ok: false, status: 404, error: "" }),
+      buildContext: async () => "fallback context",
+      buildContextForIds: async (ids) => {
+        calls.push({ type: "buildContextForIds", ids });
+        return `context for ${ids.join(",")}`;
+      },
+    },
+  });
+
+  const result = await makeRequest(app, "/recommendations", {
+    query: "I like blackgaze",
+    mode: "preference-aware",
+    selectedArtistIds: ["id-1", "id-2"],
+  });
+
+  assert.equal(result.status, 200);
+  const buildCall = calls.find((c) => c.type === "buildContextForIds");
+  assert.ok(buildCall, "should call buildContextForIds");
+  assert.deepEqual(buildCall.ids, ["id-1", "id-2"]);
+  const recCall = calls.find((c) => c.type === "getRecommendations");
+  assert.equal(recCall.options.preferenceContext.includes("context for"), true);
+});
+
 test("POST /recommendations defaults to fresh mode", async () => {
   const calls = [];
   const app = createApp({

--- a/services/api/test/search-route.test.js
+++ b/services/api/test/search-route.test.js
@@ -1,0 +1,64 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { createApp } = require("../src/app");
+const { createPreferenceRepository } = require("../src/preferences/preferenceRepository");
+
+function freshApp(musicBrainzClient) {
+  return createApp({
+    preferenceRepository: createPreferenceRepository({ preferenceStore: "memory" }),
+    musicBrainzClient,
+  });
+}
+
+async function makeGetRequest(app, path) {
+  const server = app.listen(0);
+  await new Promise((resolve) => server.once("listening", resolve));
+  const port = server.address().port;
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}${path}`);
+    const data = await response.json();
+    return { status: response.status, data };
+  } finally {
+    server.close();
+  }
+}
+
+test("GET /search/artists returns artists from MusicBrainz for a query", async () => {
+  const fakeMusicBrainz = {
+    searchArtists: async (query) => {
+      assert.equal(query, "Alcest");
+      return [{ id: "abc-123", name: "Alcest", score: 100, disambiguation: "French shoegaze" }];
+    },
+  };
+
+  const app = freshApp(fakeMusicBrainz);
+  const result = await makeGetRequest(app, "/search/artists?q=Alcest");
+
+  assert.equal(result.status, 200);
+  assert.equal(Array.isArray(result.data.artists), true);
+  assert.equal(result.data.artists[0].id, "abc-123");
+  assert.equal(result.data.artists[0].name, "Alcest");
+});
+
+test("GET /search/artists returns 400 when query is empty", async () => {
+  const fakeMusicBrainz = { searchArtists: async () => [] };
+  const app = freshApp(fakeMusicBrainz);
+  const result = await makeGetRequest(app, "/search/artists?q=");
+
+  assert.equal(result.status, 400);
+  assert.equal(result.data.error.code, "validation_error");
+});
+
+test("GET /search/artists returns 502 when MusicBrainz fails", async () => {
+  const fakeMusicBrainz = {
+    searchArtists: async () => {
+      throw new Error("timeout");
+    },
+  };
+  const app = freshApp(fakeMusicBrainz);
+  const result = await makeGetRequest(app, "/search/artists?q=Alcest");
+
+  assert.equal(result.status, 502);
+  assert.equal(result.data.error.code, "search_unavailable");
+});

--- a/services/api/test/sqlite-preference-repository.test.js
+++ b/services/api/test/sqlite-preference-repository.test.js
@@ -130,3 +130,21 @@ test("sqlite repository returns empty string context when no bands saved", async
   const context = await repo.buildContext();
   assert.equal(context, "");
 });
+
+test("sqlite repository buildContextForIds returns context for given ids", async () => {
+  const repo = createSqlitePreferenceRepository({ db: createTestDb() });
+
+  const r1 = await repo.addSavedBand({ musicbrainzArtistId: "mb-1", name: "Alcest", rating: 5, categories: ["blackgaze"], note: "dreamy" });
+  await repo.addSavedBand({ musicbrainzArtistId: "mb-2", name: "Fen", rating: 4, categories: ["post-black"], note: "atmospheric" });
+
+  const context = await repo.buildContextForIds([r1.savedBand.id]);
+
+  assert.equal(context.includes("Alcest"), true);
+  assert.equal(context.includes("Fen"), false, "should only include given ids");
+});
+
+test("sqlite repository buildContextForIds returns empty string for unknown ids", async () => {
+  const repo = createSqlitePreferenceRepository({ db: createTestDb() });
+  const context = await repo.buildContextForIds(["not-a-real-id"]);
+  assert.equal(context, "");
+});


### PR DESCRIPTION
## Summary

Implements all six sub-phases of Phase 3 from the roadmap via TDD (red → green → refactor per phase), plus a post-review fix pass.

- **Compact card layout** — reduced padding (16px → 10px), grid gap (12px → 8px), CSS custom properties for card spacing tokens
- **View router** — `getView()`/`navigate()` on `bootstrapDesktopApp` as a closure variable; `resolveViewComponent` dispatch in the mount layer; shell threaded through with `getViewImpl`/`navigateImpl`
- **Saved Artists page** — `SavedArtistsView` React component (createElement, no JSX); `savedArtistsModel` combining ViewModel + ScreenModel; `listPreferences`/`deletePreference` on `chatClient`; data loaded on navigate
- **Artist search API** — `GET /search/artists?q=` proxying MusicBrainz (avoids browser User-Agent block); `musicBrainzClient` created once in `createApp` scope and shared with the recommendations route
- **Artist search UI** — search form in `SavedArtistsView` with `isSearching` indicator; `SearchResultsList` sub-component; Add button wired through shell to `saveBand`
- **Directional selection** — tick/checkbox per saved artist; `SelectionBar` CTA; `selectedArtistIds[]` forwarded in POST `/recommendations`; `buildContextForIds` in SQLite repo; `pendingSelectedArtistIds` lifecycle in `bootstrapDesktopApp`

### Post-review fixes
- Wired `onDelete` end-to-end (`savedArtistsModel.deleteSavedArtist` → `app.deleteSavedBand` → `chatClient.deletePreference` → shell → mount) — the × button was previously a silent no-op
- `clearSelection()` called after "Use as style reference" so selection doesn't persist on return to Saved Artists
- Fixed `activateStyleRefImpl` order: `setPendingStyleRef` before `navigate`
- Moved recommendation service cache from module scope into `createApp` closure (was a test-isolation hazard)
- Replaced `typeof repo.buildContextForIds === "function"` with simple truthiness check

## Test plan

- [ ] 105 tests pass (`npm test --workspaces`) — 55 desktop, 46 API, 4 schemas
- [ ] Compact card layout renders smaller cards (10px padding, 8px gap)
- [ ] Navigating to Saved Artists loads and displays saved bands
- [ ] Search form queries MusicBrainz and shows results with Add buttons
- [ ] Adding a search result saves it and shows it in the list
- [ ] × button removes an artist from the list
- [ ] Ticking artists and clicking "Use as style reference" navigates to chat and uses selected artists as context for the next recommendation query
- [ ] Selection is cleared after activating style reference

https://claude.ai/code/session_01Skk2VsysPFcE68Ter33Nzw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Skk2VsysPFcE68Ter33Nzw)_