### PR TITLE
chore: extend pre-commit hook — lint, typecheck, test, ruff

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,9 @@
+npm run lint
+npm run typecheck
 npm test
+
+if ! command -v ruff &> /dev/null; then
+  echo "ruff not found — install with: pip install ruff"
+  exit 1
+fi
+ruff check .


### PR DESCRIPTION
## Summary

- Updates `.husky/pre-commit` to run all CI checks locally before every commit
- Previous hook only ran `npm test`
- New order: `npm run lint` → `npm run typecheck` → `npm test` → `ruff check .`
- Fast checks (lint, typecheck) run first to fail early
- If `ruff` is not found, the hook exits with a helpful install message

## Test plan

- [ ] Make a commit with an ESLint violation — hook should block it
- [ ] Make a commit with a TypeScript type error — hook should block it
- [ ] Make a commit with a ruff violation in a `.py` file — hook should block it
- [ ] Clean commit goes through without issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)