### PR TITLE
fix: use npm ci in CI, bump GitHub Actions to current stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,16 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -28,7 +28,7 @@ jobs:
         run: python -m pip install --upgrade pip ruff black
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Lint
         run: npm run lint

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Bandsearch uses optional local multi-user auth (bcrypt + 30-day JWT).
 **Single-user bypass (default):** When no users are registered the API runs open with no auth checks — ideal for local single-user setups. Auth is enforced only once you register the first account.
 
 | Users registered | Behaviour |
-|-----------------|-----------|
+|-----------------|----------|
 | 0 | Pass-through — all requests accepted, no token needed |
 | 1 | Auto-attach — requests are automatically associated with the single user |
 | ≥ 2 | Enforced — `Authorization: Bearer <token>` required for preference endpoints |
@@ -274,6 +274,25 @@ In development (browser or embedded webview), the chat UI chooses **mobile vs de
 - [LangChain](https://www.langchain.com) — framework used to structure and invoke the Gemini model calls.
 - [Tauri](https://tauri.app) — framework for building the native desktop wrapper around the web UI.
 - [Brave Search](https://brave.com/search/api/) — web search API used for niche artist discovery.
+
+---
+
+## Maintenance notes
+
+**2026-05-27 — Weekly maintenance**
+
+### Fixes applied
+
+- **CI**: `npm install` changed to `npm ci` for reproducible, locked installs in CI environments.
+- **CI**: Action versions bumped to current stable — `checkout@v6`, `setup-node@v6`, `setup-python@v6`.
+
+### Major upgrades available (not auto-applied — require testing)
+
+| Package | In use | Latest | Notes |
+|---|---|---|---|
+| `eslint` / `@eslint/js` | `^9.x` | `10.x` | Flat-config updates; review eslint v10 migration guide |
+| `globals` | `^16.5.0` | `17.x` | Breaking changes in the globals API |
+| `typescript` | `^5.9.x` | `6.x` | New type-system features; some breaking changes |
 
 ---
 


### PR DESCRIPTION
## Weekly maintenance — 2026-05-27

### What was wrong and what was fixed

#### 🐛 CI: `npm install` instead of `npm ci`

The CI workflow used `npm install` to install dependencies. In a CI environment this is incorrect: `npm install` may update `package-lock.json` if it finds version drift, leading to builds that install different package versions than what was locked. **`npm ci`** always installs the exact versions recorded in `package-lock.json`, giving deterministic, reproducible builds.

**Fix:** Changed `npm install` → `npm ci` in `.github/workflows/ci.yml`.

#### ✅ GitHub Actions bumped to current stable

All action pinned versions in the CI workflow were behind current stable releases:

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | `@v4` | `@v6` |
| `actions/setup-node` | `@v4` | `@v6` |
| `actions/setup-python` | `@v5` | `@v6` |

---

### Major upgrades available (NOT applied — require testing)

These were identified during the weekly audit but have not been auto-applied because they involve **breaking API or config changes**:

| Package | Currently pinned | Latest stable | Why it needs attention |
|---|---|---|---|
| `eslint` / `@eslint/js` | `^9.x` | `10.x` | Flat-config system updates; rule changes may break existing config |
| `globals` | `^16.5.0` | `17.x` | Breaking changes in the globals API |
| `typescript` | `^5.9.x` | `6.x` | New type-system features; some previously valid code may produce errors |

---

### Files changed

| File | Change |
|---|---|
| `.github/workflows/ci.yml` | `npm install` → `npm ci`; action versions bumped to current stable |
| `README.md` | Added "Maintenance notes" section documenting the fix and available major-version upgrades |

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gvx4kgyWexywGeSJrhrcB6)_