### PR TITLE
docs: update architecture doc and README after reflection fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 AI-powered music recommendations for niche and lesser-known artists.
 Combines conversational AI with MusicBrainz metadata and preference memory.
 
-**Recommendation pipeline:** Gemini plans Brave web searches (FFO/Bandcamp-style discovery), extracts candidate band names from snippets, verifies them via MusicBrainz (`lookupArtist` with tags/genres/URL relations), optionally runs one reflection round within a fixed Brave call budget, then ranks picks with evidence-grounded `why` text. `BRAVE_API_KEY` is required at startup — there is no fallback.
+**Recommendation pipeline:** Gemini plans Brave web searches (FFO/Bandcamp-style discovery), extracts candidate band names from snippets, verifies them via MusicBrainz (`lookupArtist` with tags/genres/URL relations), optionally runs up to two reflection rounds (each processes only the new hits from that round and accumulates candidates across rounds), then ranks picks with evidence-grounded `why` text. `BRAVE_API_KEY` is required at startup — there is no fallback.
 
 ```mermaid
 flowchart TD
@@ -310,7 +310,7 @@ Tests run automatically before every commit via a pre-commit hook (installed by 
 apps/desktop/     — Tauri + React desktop client
 services/api/     — Express API
 shared/schemas/   — shared validation contracts (TypeScript contracts.ts + tests)
-docs/             — roadmap and design specs
+docs/             — architecture docs, ADRs, design specs, roadmap
 ```
 
 In development (browser or embedded webview), the chat UI chooses **mobile vs desktop layout** from window width (`matchMedia`, max-width **767px**), so you do not need to pass a `viewport` option manually when resizing the window.
@@ -326,6 +326,15 @@ In development (browser or embedded webview), the chat UI chooses **mobile vs de
 ---
 
 ## Maintenance notes
+
+**2026-05-30 — Reflection subgraph fixes + architecture docs**
+
+### Changes
+
+- **Research pipeline**: Fixed three bugs in the reflection subgraph — `extract_r` now processes only the new hits from each round (not all accumulated hits), `verify_r` skips already-verified candidates and merges results across rounds instead of overwriting, and `formatEvidenceForPrompt` defensively deduplicates candidates before building the LLM evidence block.
+- **Docs**: Added `docs/architecture/ARCHITECTURE.md` with a full description of the pipeline, state fields, integrations, storage, auth, and key design decisions. Added a Mermaid LangGraph diagram to `README.md`.
+
+---
 
 **2026-05-28 — Phase 7 Windows support**
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -89,9 +89,9 @@ START → assess →(sufficient or budget gone)───────────
 | Node | Model / Service | Description |
 |------|----------------|-------------|
 | `assess` | Gemini | Evaluates current results; generates `extraQueries` when gaps are found |
-| `search` | Brave Search API | Executes extra queries against remaining budget |
-| `extract_r` | Gemini | Re-extracts candidates from the expanded hit pool |
-| `verify_r` | MusicBrainz | Re-verifies new candidates; merges results |
+| `search` | Brave Search API | Executes extra queries against remaining budget; stores new hits in `newHits` separately from the accumulated `braveHits` |
+| `extract_r` | Gemini | Extracts candidates from `newHits` **only** (not all accumulated hits); merges result into existing `extractedCandidates` via `mergeExtractedCandidates` |
+| `verify_r` | MusicBrainz | Verifies only candidates not yet present in `verifiedCandidates` (by name/canonicalName); merges into existing set via `mergeVerifiedCandidates` — preserves all prior-round results |
 
 ### Budget Management (`researchBudget.ts`)
 
@@ -190,3 +190,5 @@ Three-tier progressive auth — determined by the number of registered users at 
 | **Progressive auth** | Single-user deployments require no configuration; auth activates as users are added |
 | **Dedup cache for Brave** | `BraveDedupCache` (Map) prevents redundant API calls within a single recommendation request |
 | **Reflection as nested subgraph** | LangGraph subgraph encapsulates the reflection loop's own state and conditional edges cleanly, keeping the main graph linear |
+| **Symmetric merge helpers** | `mergeExtractedCandidates` and `mergeVerifiedCandidates` follow the same contract (flat array → deduped array); reused across reflection rounds and as a defensive layer inside `formatEvidenceForPrompt` |
+| **Defensive ranker dedup** | `formatEvidenceForPrompt` deduplicates `verifiedCandidates` by `mbid › canonicalName › name` before building the LLM evidence block, regardless of upstream state |


### PR DESCRIPTION
Follow-up to #20. Updates documentation to reflect the reflection subgraph fixes merged in that PR.

## Changes

**`docs/architecture/ARCHITECTURE.md`**
- `extract_r` node description corrected: processes only `newHits` from the current round, merges into existing `extractedCandidates` via `mergeExtractedCandidates`
- `verify_r` node description corrected: skips already-verified candidates, accumulates via `mergeVerifiedCandidates`
- Two new entries in Key Design Decisions: symmetric merge helpers and defensive ranker dedup

**`README.md`**
- Pipeline description: "one reflection round" → "up to two reflection rounds (new hits only per round, accumulated candidates)"
- Monorepo structure: `docs/` entry updated to mention architecture docs
- Maintenance note added for 2026-05-30 changes

## No code changes
This PR contains documentation only — all source and test changes were in #20.

https://claude.ai/code/session_01JMBQmdpqJiqJRX6hyMabbw

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMBQmdpqJiqJRX6hyMabbw)_