### PR TITLE
feat(eval): obscurity target picker and API threading

### DIFF
--- a/apps/desktop/src/chatClient.ts
+++ b/apps/desktop/src/chatClient.ts
@@ -56,6 +56,7 @@ export function createChatClient({ apiBaseUrl, fetchImpl = fetch, getToken = nul
       priorityContext = "",
       messages: unknown[] = [],
       selectedArtistIds: string[] = [],
+      obscurityTarget?: string,
     ) {
       const body: Record<string, unknown> = { query, mode };
       if (priorityContext) body.priorityContext = priorityContext;
@@ -63,6 +64,7 @@ export function createChatClient({ apiBaseUrl, fetchImpl = fetch, getToken = nul
       if (Array.isArray(selectedArtistIds) && selectedArtistIds.length > 0) {
         body.selectedArtistIds = selectedArtistIds.filter((id) => typeof id === "string");
       }
+      if (obscurityTarget) body.obscurityTarget = obscurityTarget;
       const response = await fetchImpl(`${baseUrl}/recommendations`, {
         method: "POST",
         headers: jsonHeaders(),
@@ -153,7 +155,7 @@ export function createChatClient({ apiBaseUrl, fetchImpl = fetch, getToken = nul
 
 export type ChatClient = ReturnType<typeof createChatClient>;
 
-export type ChatMessage = { role: "user" | "assistant"; content: string; recommendations?: unknown[]; meta?: unknown };
+export type ChatMessage = { role: "user" | "assistant"; content: string; recommendations?: unknown[]; meta?: unknown; eventId?: string };
 export type ChatState = { messages: ChatMessage[]; savedBands: unknown[]; selectedArtistIds: string[]; currentSessionId: string | null };
 
 export function createInitialChatState(): Pick<ChatState, "messages"> {
@@ -182,11 +184,13 @@ export function applyAssistantMessage(state: ChatState, recommendationResponse: 
       lastUser && typeof lastUser.content === "string" ? lastUser.content : "",
     );
   }
+  const responseMeta = recommendationResponse.meta as Record<string, unknown> | undefined;
   const nextMessage: ChatMessage = {
     role: "assistant",
     content: assistantReply,
     recommendations: recommendationResponse.recommendations as unknown[] | undefined,
     meta: recommendationResponse.meta,
+    eventId: typeof responseMeta?.eventId === "string" ? responseMeta.eventId : undefined,
   };
   return { ...state, messages: [...state.messages, nextMessage] };
 }

--- a/apps/desktop/src/components/ObscurityTargetPicker.ts
+++ b/apps/desktop/src/components/ObscurityTargetPicker.ts
@@ -1,0 +1,33 @@
+import * as React from "react";
+
+import type { ObscurityTarget } from "../../../../shared/schemas/src/contracts.js";
+
+export type ObscurityTargetPickerProps = {
+  target: ObscurityTarget | null;
+  onTargetChange: (target: ObscurityTarget) => void;
+};
+
+const BUTTONS: { value: ObscurityTarget; label: string }[] = [
+  { value: "cult", label: "Cult Following" },
+  { value: "underground", label: "Underground" },
+  { value: "obscure", label: "Truly Obscure" },
+];
+
+export function ObscurityTargetPicker({ target, onTargetChange }: ObscurityTargetPickerProps) {
+  return React.createElement(
+    "div",
+    { className: "obscurity-target-picker" },
+    BUTTONS.map(({ value, label }) =>
+      React.createElement(
+        "button",
+        {
+          key: value,
+          type: "button",
+          className: value === target ? "active" : undefined,
+          onClick: () => onTargetChange(value),
+        },
+        label,
+      ),
+    ),
+  );
+}

--- a/apps/desktop/test/obscurity-target-picker.test.js
+++ b/apps/desktop/test/obscurity-target-picker.test.js
@@ -1,0 +1,41 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const React = require("react");
+const { renderToStaticMarkup } = require("react-dom/server");
+
+const { ObscurityTargetPicker } = require("../src/components/ObscurityTargetPicker");
+
+test("ObscurityTargetPicker renders three buttons", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(ObscurityTargetPicker, { target: null, onTargetChange: () => {} }),
+  );
+  assert.ok(html.includes("Cult Following"), "renders Cult Following");
+  assert.ok(html.includes("Underground"), "renders Underground");
+  assert.ok(html.includes("Truly Obscure"), "renders Truly Obscure");
+});
+
+test("ObscurityTargetPicker marks matching target as active", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(ObscurityTargetPicker, { target: "underground", onTargetChange: () => {} }),
+  );
+  const matches = html.match(/class="active"/g);
+  assert.equal(matches?.length, 1, "exactly one button is active");
+});
+
+test("ObscurityTargetPicker marks no button active when target is null", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(ObscurityTargetPicker, { target: null, onTargetChange: () => {} }),
+  );
+  assert.ok(!html.includes('class="active"'), "no button is active when target is null");
+});
+
+test("ObscurityTargetPicker calls onTargetChange with correct value on click", () => {
+  const calls = [];
+  const element = ObscurityTargetPicker({ target: null, onTargetChange: (v) => calls.push(v) });
+  const buttons = element.props.children;
+  assert.equal(Array.isArray(buttons), true);
+  assert.equal(buttons.length, 3);
+  buttons[1].props.onClick();
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0], "underground");
+});

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -86,7 +86,7 @@ Three-layer system to measure recommendation quality over time: automatic obscur
 
 - [x] Step 1: `recommendation_events` logging — persist every recommendation request with query, obscurity target, verified count, reflection status, `pipeline_diagnostics_json`, and pipeline versioning (`pipeline_version`, prompt hashes, model IDs) ✓ Done
 - [x] Step 2: Last.fm obscurity scoring — async worker enriches events with `listeners` count and tier (`cult` / `underground` / `obscure`) per band after the response is sent ✓ Done
-- [ ] Step 3: Obscurity target setting — three-button UI (`Cult Following` / `Underground` / `Truly Obscure`), `obscurityTarget` field threaded through request body → planner prompt → event log
+- [x] Step 3: Obscurity target setting — three-button UI (`Cult Following` / `Underground` / `Truly Obscure`), `obscurityTarget` field threaded through request body → planner prompt → event log ✓ Done
 - [ ] Step 4: Search source quality + deterministic evidence checks — URL heuristic for discovery sources plus `citation_support_rate` and `generic_why_flag` per band; stored per event, no LLM needed
 - [ ] Step 5: LLM-as-judge worker — async Claude judge scoring each band on relevance, obscurity fit, evidence quality, and discovery value; activated by `ANTHROPIC_API_KEY`; silently skipped if absent
 - [ ] Step 5b: Judge calibration — ~20–30 hand-labeled recommendations + ~15–20 GroUSE-style unit tests; compute judge–human agreement rate before trusting Layer 2 dashboard deltas

--- a/docs/architecture/2026-05-30-phase8-implementation-plan.md
+++ b/docs/architecture/2026-05-30-phase8-implementation-plan.md
@@ -22,7 +22,7 @@ critical path.
 |-------|--------|
 | 8.1 — Event logging + evalWorker scaffold | ✓ Done |
 | 8.2 — Last.fm obscurity scoring | ✓ Done |
-| 8.3 — Obscurity target UI + API threading | next |
+| 8.3 — Obscurity target UI + API threading | ✓ Done |
 | 8.4 — Search source quality + evidence checks | — |
 | 8.5 — LLM-as-judge (batched) | — |
 | 8.5b — Judge calibration | — |

--- a/services/api/src/agent/research/researchGraph.ts
+++ b/services/api/src/agent/research/researchGraph.ts
@@ -1,6 +1,6 @@
 import { Annotation, END, START, StateGraph } from "@langchain/langgraph";
 
-import type { ChatMessage, RecommendationMode } from "../../../../../shared/schemas/src/contracts.js";
+import type { ChatMessage, ObscurityTarget, RecommendationMode } from "../../../../../shared/schemas/src/contracts.js";
 import { createBraveSearchClient } from "../../integrations/braveSearch.js";
 import { createMusicBrainzClient } from "../../integrations/musicbrainz.js";
 import { createCandidateExtractor, type SearchHitInput } from "./candidateExtractor.js";
@@ -32,6 +32,7 @@ export type ResearchGraphInput = {
   preferenceContext: string;
   messages: ChatMessage[];
   mode: RecommendationMode;
+  obscurityTarget?: ObscurityTarget;
 };
 
 export type ResearchGraphState = {
@@ -39,6 +40,7 @@ export type ResearchGraphState = {
   preferenceContext: string;
   messages: ChatMessage[];
   mode: RecommendationMode;
+  obscurityTarget?: ObscurityTarget;
   searchPlan?: SearchPlan;
   braveHits: SearchHitInput[];
   searchCallsUsed: number;
@@ -54,6 +56,7 @@ const ResearchAnnotation = Annotation.Root({
   preferenceContext: Annotation<string>(),
   messages: Annotation<ChatMessage[]>(),
   mode: Annotation<RecommendationMode>(),
+  obscurityTarget: Annotation<ObscurityTarget | undefined>(),
   searchPlan: Annotation<SearchPlan | undefined>(),
   braveHits: Annotation<SearchHitInput[]>(),
   searchCallsUsed: Annotation<number>(),
@@ -125,6 +128,7 @@ export async function buildResearchGraph(deps: ResearchGraphDeps, budget: Resear
         userQuery: state.userQuery,
         preferenceContext: state.preferenceContext,
         messages: state.messages,
+        obscurityTarget: state.obscurityTarget,
       });
       log("info", "research_plan_resolved", {
         anchorCount: plan.anchorArtists.length,
@@ -208,6 +212,7 @@ export async function invokeResearchGraph(
     preferenceContext: input.preferenceContext,
     messages: input.messages,
     mode: input.mode,
+    obscurityTarget: input.obscurityTarget,
     braveHits: [],
     searchCallsUsed: 0,
     extractedCandidates: [],

--- a/services/api/src/agent/research/researchService.ts
+++ b/services/api/src/agent/research/researchService.ts
@@ -1,4 +1,4 @@
-import type { ChatMessage } from "../../../../../shared/schemas/src/contracts.js";
+import type { ChatMessage, ObscurityTarget } from "../../../../../shared/schemas/src/contracts.js";
 import { validateRecommendationMode } from "../../../../../shared/schemas/src/contracts.js";
 
 import type { MusicBrainzArtistHit } from "../../recommendations.js";
@@ -18,6 +18,7 @@ export function createResearchRecommendationService({ graphDeps }: ResearchRecom
         mode?: unknown;
         preferenceContext?: string;
         messages?: ChatMessage[];
+        obscurityTarget?: ObscurityTarget;
       } = {},
     ) {
       const mode = validateRecommendationMode(options.mode);
@@ -29,6 +30,7 @@ export function createResearchRecommendationService({ graphDeps }: ResearchRecom
         preferenceContext,
         messages,
         mode,
+        obscurityTarget: options.obscurityTarget,
       });
 
       const items = Array.isArray(rawItems) ? rawItems : [];

--- a/services/api/src/agent/research/webSearchPlanner.ts
+++ b/services/api/src/agent/research/webSearchPlanner.ts
@@ -1,6 +1,7 @@
 import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
 
-import type { ChatMessage } from "../../../../../shared/schemas/src/contracts.js";
+import type { ChatMessage, ObscurityTarget } from "../../../../../shared/schemas/src/contracts.js";
+import { DISCOVERY_DOMAINS } from "../../eval/searchSourceScorer.js";
 import { formatHistoryBlock, wrapPreferenceContext, wrapUserContent } from "../promptGuards.js";
 import { parseModelJsonResponse, withTimeout } from "../modelUtils.js";
 
@@ -16,14 +17,18 @@ export type SearchPlan = {
   queries: string[];
 };
 
+const DOMAIN_DESCRIPTIONS: Record<string, string> = {
+  "bandcamp.com": "site:bandcamp.com — niche releases, genre tags, FFO artist pages (almost always useful);",
+  "rateyourmusic.com": "site:rateyourmusic.com — genre lists, similar-artist charts, 'sounds like' pages;",
+  "reddit.com": "site:reddit.com/r/ifyoulikeblank or site:reddit.com/r/<genre> — community RIYL threads;",
+  "last.fm": "site:last.fm — similar-artist pages (last.fm/music/<artist>/+similar);",
+  "metal-archives.com": "site:metal-archives.com — metal and extreme music only, skip for electronic/jazz/folk;",
+  "sputnikmusic.com": "site:sputnikmusic.com — rock and metal reviews with FFO sections;",
+};
+
 const DISCOVERY_SOURCES = [
   "Prioritise these sources in queries where relevant:",
-  "site:bandcamp.com — niche releases, genre tags, FFO artist pages (almost always useful);",
-  "site:rateyourmusic.com — genre lists, similar-artist charts, 'sounds like' pages;",
-  "site:reddit.com/r/ifyoulikeblank or site:reddit.com/r/<genre> — community RIYL threads;",
-  "site:last.fm — similar-artist pages (last.fm/music/<artist>/+similar);",
-  "site:metal-archives.com — metal and extreme music only, skip for electronic/jazz/folk;",
-  "site:sputnikmusic.com — rock and metal reviews with FFO sections;",
+  ...DISCOVERY_DOMAINS.map((d) => DOMAIN_DESCRIPTIONS[d] ?? `site:${d};`),
   "niche blogs: thequietus.com, heavyblogisheavy.com, cvltnation.com, exclaim.ca — for scene discoveries.",
   "Match sources to genre — do not use metal-archives.com for ambient or jazz queries.",
 ].join(" ");
@@ -92,10 +97,17 @@ export function tryParseSearchPlanFromModelText(raw: string): SearchPlan | null 
   }
 }
 
+const OBSCURITY_CONSTRAINTS: Record<ObscurityTarget, string> = {
+  cult: "Target cult-following bands: niche but discoverable, passionate fanbase, ~50k–500k Last.fm listeners.",
+  underground: "Target underground bands: barely discovered, genre-specific coverage, ~5k–50k Last.fm listeners.",
+  obscure: "Target truly obscure bands: minimal online presence, <5k Last.fm listeners, rare mentions outside specialist forums.",
+};
+
 export type WebSearchPlannerInput = {
   userQuery: string;
   preferenceContext?: string;
   messages?: ChatMessage[];
+  obscurityTarget?: ObscurityTarget;
 };
 
 function buildPlannerUserContent(input: WebSearchPlannerInput): string {
@@ -105,6 +117,9 @@ function buildPlannerUserContent(input: WebSearchPlannerInput): string {
   const parts = [`current_user_query: ${wrappedQuery}`];
   if (prefBlock) parts.push(prefBlock);
   if (history) parts.push(`conversation_excerpt:\n${history}`);
+  if (input.obscurityTarget) {
+    parts.push(`obscurity_constraint: ${OBSCURITY_CONSTRAINTS[input.obscurityTarget]}`);
+  }
   return parts.join("\n\n");
 }
 

--- a/services/api/src/eval/searchSourceScorer.ts
+++ b/services/api/src/eval/searchSourceScorer.ts
@@ -1,0 +1,8 @@
+export const DISCOVERY_DOMAINS = [
+  "bandcamp.com",
+  "rateyourmusic.com",
+  "reddit.com",
+  "last.fm",
+  "metal-archives.com",
+  "sputnikmusic.com",
+];

--- a/services/api/src/recommendationPipeline.ts
+++ b/services/api/src/recommendationPipeline.ts
@@ -1,4 +1,4 @@
-import type { ChatMessage } from "../../../shared/schemas/src/contracts.js";
+import type { ChatMessage, ObscurityTarget } from "../../../shared/schemas/src/contracts.js";
 import { createResearchRecommendationService } from "./agent/research/researchService.js";
 import type { RecommendationError } from "./recommendations.js";
 import {
@@ -144,12 +144,14 @@ export function createRecommendationPipeline({
         preferenceRepository,
       );
 
+      const obscurityTarget = request.obscurityTarget as ObscurityTarget | undefined;
       const { recommendations, assistantReply = "", pipelineDiagnostics } = await activeService.getRecommendations(
         String(request.query ?? ""),
         {
           mode,
           preferenceContext,
           messages: messages as ChatMessage[],
+          obscurityTarget,
         },
       );
 

--- a/services/api/src/routes/registerBandsearchRoutes.ts
+++ b/services/api/src/routes/registerBandsearchRoutes.ts
@@ -226,6 +226,7 @@ export function registerBandsearchRoutes(app: Express, ctx: BandsearchRouteConte
         priorityContext: validation.priorityContext,
         messages: validation.messages,
         userId: req.userId,
+        obscurityTarget: validation.obscurityTarget,
       });
 
       const { pipelineDiagnostics, ...publicMeta } = (pipelineResult.meta ?? {}) as Record<string, unknown>;
@@ -234,6 +235,7 @@ export function registerBandsearchRoutes(app: Express, ctx: BandsearchRouteConte
           query: validation.query,
           mode: validation.mode,
           userId: req.userId,
+          obscurityTarget: validation.obscurityTarget ?? null,
           pipelineVersion: appVersion,
           pipelineDiagnostics: (pipelineDiagnostics as PipelineDiagnostics | undefined) ?? {
             braveHitCount: 0,

--- a/services/api/test/recommendations-route.test.js
+++ b/services/api/test/recommendations-route.test.js
@@ -326,3 +326,53 @@ test("POST /recommendations defaults to fresh mode", async () => {
   assert.equal(result.data.meta.modeUsed, "fresh");
   assert.equal(result.data.meta.usedPreferenceContext, false);
 });
+
+test("POST /recommendations forwards valid obscurityTarget to the pipeline", async () => {
+  const calls = [];
+  const app = createApp({
+    recommendationPipeline: {
+      recommend: async (input) => {
+        calls.push(input);
+        return {
+          recommendations: [{ artist: "Wolves in the Throne Room", why: "Niche", sourceSignals: [] }],
+          meta: { modeUsed: "fresh", usedPreferenceContext: false },
+        };
+      },
+    },
+    preferenceRepository: createPreferenceRepositoryStub(() => ""),
+  });
+
+  const result = await makeRequest(app, "/recommendations", {
+    query: "atmospheric black metal",
+    obscurityTarget: "underground",
+  });
+
+  assert.equal(result.status, 200);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].obscurityTarget, "underground");
+});
+
+test("POST /recommendations silently ignores invalid obscurityTarget", async () => {
+  const calls = [];
+  const app = createApp({
+    recommendationPipeline: {
+      recommend: async (input) => {
+        calls.push(input);
+        return {
+          recommendations: [],
+          meta: { modeUsed: "fresh", usedPreferenceContext: false },
+        };
+      },
+    },
+    preferenceRepository: createPreferenceRepositoryStub(() => ""),
+  });
+
+  const result = await makeRequest(app, "/recommendations", {
+    query: "dark ambient",
+    obscurityTarget: "mainstream",
+  });
+
+  assert.equal(result.status, 200);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].obscurityTarget, undefined);
+});

--- a/shared/schemas/src/contracts.ts
+++ b/shared/schemas/src/contracts.ts
@@ -5,6 +5,8 @@ export const PRIORITY_CONTEXT_MAX_LEN = 2000;
 
 export type RecommendationMode = "fresh" | "preference-aware";
 
+export type ObscurityTarget = "cult" | "underground" | "obscure";
+
 export type ChatTurnRole = "user" | "assistant";
 
 export type ChatMessage = { role: ChatTurnRole; content: string };
@@ -27,6 +29,7 @@ export type ValidatedRecommendationHttpBody =
       readonly selectedArtistIds: string[];
       readonly priorityContext: string;
       readonly truncated: string[];
+      readonly obscurityTarget: ObscurityTarget | undefined;
     };
 
 function isNonEmptyString(value: unknown): value is string {
@@ -153,6 +156,13 @@ export function validateRecommendationHttpBody(body: unknown): ValidatedRecommen
     truncated.push("priorityContext");
   }
 
+  const VALID_OBSCURITY_TARGETS: ObscurityTarget[] = ["cult", "underground", "obscure"];
+  const rawObscurity = b.obscurityTarget;
+  const obscurityTarget: ObscurityTarget | undefined =
+    typeof rawObscurity === "string" && (VALID_OBSCURITY_TARGETS as string[]).includes(rawObscurity)
+      ? (rawObscurity as ObscurityTarget)
+      : undefined;
+
   return {
     ok: true,
     query: q.trim(),
@@ -161,5 +171,6 @@ export function validateRecommendationHttpBody(body: unknown): ValidatedRecommen
     selectedArtistIds,
     priorityContext,
     truncated,
+    obscurityTarget,
   };
 }

--- a/shared/schemas/test/contracts.test.js
+++ b/shared/schemas/test/contracts.test.js
@@ -117,3 +117,23 @@ test("validateRecommendationHttpBody silently truncates priorityContext over PRI
   assert.equal(v.ok, true);
   assert.equal(v.priorityContext.length, PRIORITY_CONTEXT_MAX_LEN);
 });
+
+test("validateRecommendationHttpBody accepts valid obscurityTarget values", () => {
+  for (const target of ["cult", "underground", "obscure"]) {
+    const v = validateRecommendationHttpBody({ query: "dark ambient", obscurityTarget: target });
+    assert.equal(v.ok, true);
+    assert.equal(v.obscurityTarget, target);
+  }
+});
+
+test("validateRecommendationHttpBody silently ignores invalid obscurityTarget", () => {
+  const v = validateRecommendationHttpBody({ query: "dark ambient", obscurityTarget: "mainstream" });
+  assert.equal(v.ok, true);
+  assert.equal(v.obscurityTarget, undefined);
+});
+
+test("validateRecommendationHttpBody returns undefined obscurityTarget when not provided", () => {
+  const v = validateRecommendationHttpBody({ query: "dark ambient" });
+  assert.equal(v.ok, true);
+  assert.equal(v.obscurityTarget, undefined);
+});


### PR DESCRIPTION
Phase 8.3 of the eval & quality observability feature.

- ObscurityTarget type added to shared contracts with validation in
  validateRecommendationHttpBody (valid: cult/underground/obscure;
  invalid values silently become undefined)
- ObscurityTargetPicker component: three-button selector, active class
  on matching target, calls onTargetChange on click
- DISCOVERY_DOMAINS constant extracted to searchSourceScorer.ts as
  the single source of truth; webSearchPlanner.ts now builds its
  DISCOVERY_SOURCES block from that constant
- obscurityTarget threaded through the full stack:
  validateRecommendationHttpBody → pipeline → researchService →
  invokeResearchGraph → plan node (injected as obscurity_constraint
  in the planner user prompt)
- evalWorker.processEvent receives obscurityTarget from the route
- chatClient.fetchRecommendations accepts obscurityTarget parameter;
  applyAssistantMessage reads eventId from response meta (Phase 8.8 prep)