### PR TITLE
fix: make reflection subgraph transparent so LangSmith can trace its loop

### DIFF
--- a/services/api/src/agent/research/researchGraph.ts
+++ b/services/api/src/agent/research/researchGraph.ts
@@ -41,10 +41,13 @@ export type ResearchGraphState = {
   mode: RecommendationMode;
   searchPlan?: SearchPlan;
   braveHits: SearchHitInput[];
+  newHits: SearchHitInput[];
   searchCallsUsed: number;
   extractedCandidates: import("./candidateExtractor.js").ExtractedCandidate[];
   verifiedCandidates: VerifiedCandidate[];
   reflectionUsed: boolean;
+  roundsCompleted: number;
+  nextExtraQueries: string[];
   recommendations: unknown[];
   assistantReply: string;
 };
@@ -56,10 +59,13 @@ const ResearchAnnotation = Annotation.Root({
   mode: Annotation<RecommendationMode>(),
   searchPlan: Annotation<SearchPlan | undefined>(),
   braveHits: Annotation<SearchHitInput[]>(),
+  newHits: Annotation<SearchHitInput[]>(),
   searchCallsUsed: Annotation<number>(),
   extractedCandidates: Annotation<import("./candidateExtractor.js").ExtractedCandidate[]>(),
   verifiedCandidates: Annotation<VerifiedCandidate[]>(),
   reflectionUsed: Annotation<boolean>(),
+  roundsCompleted: Annotation<number>(),
+  nextExtraQueries: Annotation<string[]>(),
   recommendations: Annotation<unknown[]>(),
   assistantReply: Annotation<string>(),
 });
@@ -159,8 +165,7 @@ export async function buildResearchGraph(deps: ResearchGraphDeps, budget: Resear
       });
       return { verifiedCandidates: verified };
     })
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    .addNode("reflect_if_needed", reflectionSubgraph as any)
+    .addNode("reflect_if_needed", reflectionSubgraph)
     .addNode("rank", async (state) => {
       const ranker = await createRecommendationRanker({
         apiKey: deps.geminiApiKey,
@@ -209,10 +214,13 @@ export async function invokeResearchGraph(
     messages: input.messages,
     mode: input.mode,
     braveHits: [],
+    newHits: [],
     searchCallsUsed: 0,
     extractedCandidates: [],
     verifiedCandidates: [],
     reflectionUsed: false,
+    roundsCompleted: 0,
+    nextExtraQueries: [],
     recommendations: [],
     assistantReply: "",
   });

--- a/services/api/test/research/research-graph-observability.test.js
+++ b/services/api/test/research/research-graph-observability.test.js
@@ -1,0 +1,80 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { buildResearchGraph } = require("../../src/agent/research/researchGraph");
+const { buildReflectionSubgraph } = require("../../src/agent/research/reflectionSubgraph");
+const { createResearchBudget } = require("../../src/agent/research/researchBudget");
+
+const BASE_DEPS = {
+  geminiApiKey: "x",
+  braveApiKey: "y",
+  maxInitialSearches: 2,
+  maxReflectionSearches: 2,
+  totalSearchBudget: 5,
+  targetVerifiedCount: 8,
+  researchTimeoutMs: 5000,
+};
+
+const STUB_MB = {
+  async searchArtists() { return []; },
+  async lookupArtist() { throw new Error("unexpected lookup"); },
+};
+
+const STUB_RUN_QUERIES = async () => ({ hits: [], calls: 0 });
+
+test("parent graph channels include roundsCompleted", async () => {
+  const budget = createResearchBudget(5000);
+  const g = await buildResearchGraph(BASE_DEPS, budget);
+  assert.ok(
+    Object.keys(g.channels).includes("roundsCompleted"),
+    "roundsCompleted must be a channel in the parent graph state",
+  );
+});
+
+test("parent graph channels include nextExtraQueries", async () => {
+  const budget = createResearchBudget(5000);
+  const g = await buildResearchGraph(BASE_DEPS, budget);
+  assert.ok(
+    Object.keys(g.channels).includes("nextExtraQueries"),
+    "nextExtraQueries must be a channel in the parent graph state",
+  );
+});
+
+test("parent graph channels include newHits", async () => {
+  const budget = createResearchBudget(5000);
+  const g = await buildResearchGraph(BASE_DEPS, budget);
+  assert.ok(
+    Object.keys(g.channels).includes("newHits"),
+    "newHits must be a channel in the parent graph state",
+  );
+});
+
+test("all reflection subgraph channels are present in the parent graph", async () => {
+  // This is the key invariant for a transparent (non-blackbox) subgraph:
+  // every field the subgraph writes must exist as a channel in the parent
+  // so LangGraph can route values back up and LangSmith can trace them.
+  const budget = createResearchBudget(5000);
+  const parentGraph = await buildResearchGraph(BASE_DEPS, budget);
+  const subgraph = buildReflectionSubgraph({
+    geminiApiKey: "x",
+    mb: STUB_MB,
+    runQueries: STUB_RUN_QUERIES,
+    budget,
+    maxRounds: 2,
+    maxReflectionSearches: 2,
+    targetVerifiedCount: 8,
+    totalSearchBudget: 5,
+  });
+
+  const parentChannels = new Set(Object.keys(parentGraph.channels));
+  const subgraphChannels = Object.keys(subgraph.channels).filter(
+    (k) => !k.startsWith("__") && !k.startsWith("branch:"),
+  );
+
+  for (const ch of subgraphChannels) {
+    assert.ok(
+      parentChannels.has(ch),
+      `reflection subgraph channel "${ch}" is missing from parent graph — subgraph is a blackbox`,
+    );
+  }
+});


### PR DESCRIPTION
The reflection subgraph was added to the parent graph with an `as any`
cast because its state annotation included fields (`newHits`,
`roundsCompleted`, `nextExtraQueries`) that were absent from
`ResearchAnnotation`. LangGraph treats such a subgraph as a blackbox —
its internal nodes are invisible to LangSmith tracing.

Add the three missing fields to `ResearchAnnotation` (and the
corresponding `ResearchGraphState` type and initial invoke state), and
remove the `as any` cast. The subgraph is now a transparent node: every
round of the assess→search→extract_r→verify_r loop will appear as
distinct steps in LangSmith.

https://claude.ai/code/session_01P9ggAFz183aTt3C84bDkE1