### PR TITLE
Migrate research graphs from LangChain Annotation to Zod schemas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4366,7 +4366,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -4386,7 +4385,8 @@
         "express-rate-limit": "^8.5.2",
         "helmet": "^8.2.0",
         "jsonwebtoken": "^9.0.3",
-        "pg": "^8.21.0"
+        "pg": "^8.21.0",
+        "zod": "^4.4.3"
       }
     },
     "shared/schemas": {

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -21,6 +21,7 @@
     "express-rate-limit": "^8.5.2",
     "helmet": "^8.2.0",
     "jsonwebtoken": "^9.0.3",
-    "pg": "^8.21.0"
+    "pg": "^8.21.0",
+    "zod": "^4.4.3"
   }
 }

--- a/services/api/src/agent/research/reflectionSubgraph.ts
+++ b/services/api/src/agent/research/reflectionSubgraph.ts
@@ -1,4 +1,5 @@
-import { Annotation, END, START, StateGraph } from "@langchain/langgraph";
+import { END, START, StateGraph } from "@langchain/langgraph";
+import * as z from "zod";
 
 import { createCandidateExtractor, mergeExtractedCandidates, type ExtractedCandidate, type SearchHitInput } from "./candidateExtractor.js";
 import { mergeVerifiedCandidates, verifyCandidatesWithMusicBrainz, type MusicBrainzVerifyClient, type VerifiedCandidate } from "./candidateVerifier.js";
@@ -22,23 +23,23 @@ export type ReflectionSubgraphDeps = {
   onLog?: (level: "info" | "warn", event: string, details: Record<string, unknown>) => void;
 };
 
-const ReflectionAnnotation = Annotation.Root({
-  braveHits: Annotation<SearchHitInput[]>(),
-  newHits: Annotation<SearchHitInput[]>(),
-  verifiedCandidates: Annotation<VerifiedCandidate[]>(),
-  extractedCandidates: Annotation<ExtractedCandidate[]>(),
-  searchCallsUsed: Annotation<number>(),
-  searchPlan: Annotation<SearchPlan | undefined>(),
-  userQuery: Annotation<string>(),
-  reflectionUsed: Annotation<boolean>(),
-  roundsCompleted: Annotation<number>(),
-  nextExtraQueries: Annotation<string[]>(),
+export const REFLECTION_SCHEMA = z.object({
+  braveHits: z.custom<SearchHitInput[]>(),
+  newHits: z.custom<SearchHitInput[]>(),
+  verifiedCandidates: z.custom<VerifiedCandidate[]>(),
+  extractedCandidates: z.custom<ExtractedCandidate[]>(),
+  searchCallsUsed: z.number(),
+  searchPlan: z.custom<SearchPlan | undefined>(),
+  userQuery: z.string(),
+  reflectionUsed: z.boolean(),
+  roundsCompleted: z.number(),
+  nextExtraQueries: z.array(z.string()),
 });
 
 export function buildReflectionSubgraph(deps: ReflectionSubgraphDeps) {
   const log = deps.onLog ?? (() => {});
 
-  return new StateGraph(ReflectionAnnotation)
+  return new StateGraph(REFLECTION_SCHEMA)
     .addNode("assess", async (state) => {
       const reflector = await createRecommendationReflector({
         apiKey: deps.geminiApiKey,

--- a/services/api/src/agent/research/researchGraph.ts
+++ b/services/api/src/agent/research/researchGraph.ts
@@ -1,9 +1,10 @@
-import { Annotation, END, START, StateGraph } from "@langchain/langgraph";
+import { END, START, StateGraph } from "@langchain/langgraph";
+import * as z from "zod";
 
 import type { ChatMessage, RecommendationMode } from "../../../../../shared/schemas/src/contracts.js";
 import { createBraveSearchClient } from "../../integrations/braveSearch.js";
 import { createMusicBrainzClient } from "../../integrations/musicbrainz.js";
-import { createCandidateExtractor, type SearchHitInput } from "./candidateExtractor.js";
+import { createCandidateExtractor, type ExtractedCandidate, type SearchHitInput } from "./candidateExtractor.js";
 import { verifyCandidatesWithMusicBrainz, type VerifiedCandidate } from "./candidateVerifier.js";
 import { createRecommendationRanker } from "./recommendationRanker.js";
 import { buildReflectionSubgraph } from "./reflectionSubgraph.js";
@@ -34,41 +35,25 @@ export type ResearchGraphInput = {
   mode: RecommendationMode;
 };
 
-export type ResearchGraphState = {
-  userQuery: string;
-  preferenceContext: string;
-  messages: ChatMessage[];
-  mode: RecommendationMode;
-  searchPlan?: SearchPlan;
-  braveHits: SearchHitInput[];
-  newHits: SearchHitInput[];
-  searchCallsUsed: number;
-  extractedCandidates: import("./candidateExtractor.js").ExtractedCandidate[];
-  verifiedCandidates: VerifiedCandidate[];
-  reflectionUsed: boolean;
-  roundsCompleted: number;
-  nextExtraQueries: string[];
-  recommendations: unknown[];
-  assistantReply: string;
-};
-
-const ResearchAnnotation = Annotation.Root({
-  userQuery: Annotation<string>(),
-  preferenceContext: Annotation<string>(),
-  messages: Annotation<ChatMessage[]>(),
-  mode: Annotation<RecommendationMode>(),
-  searchPlan: Annotation<SearchPlan | undefined>(),
-  braveHits: Annotation<SearchHitInput[]>(),
-  newHits: Annotation<SearchHitInput[]>(),
-  searchCallsUsed: Annotation<number>(),
-  extractedCandidates: Annotation<import("./candidateExtractor.js").ExtractedCandidate[]>(),
-  verifiedCandidates: Annotation<VerifiedCandidate[]>(),
-  reflectionUsed: Annotation<boolean>(),
-  roundsCompleted: Annotation<number>(),
-  nextExtraQueries: Annotation<string[]>(),
-  recommendations: Annotation<unknown[]>(),
-  assistantReply: Annotation<string>(),
+export const RESEARCH_SCHEMA = z.object({
+  userQuery: z.string(),
+  preferenceContext: z.string(),
+  messages: z.custom<ChatMessage[]>(),
+  mode: z.custom<RecommendationMode>(),
+  searchPlan: z.custom<SearchPlan | undefined>(),
+  braveHits: z.custom<SearchHitInput[]>(),
+  newHits: z.custom<SearchHitInput[]>(),
+  searchCallsUsed: z.number(),
+  extractedCandidates: z.custom<ExtractedCandidate[]>(),
+  verifiedCandidates: z.custom<VerifiedCandidate[]>(),
+  reflectionUsed: z.boolean(),
+  roundsCompleted: z.number(),
+  nextExtraQueries: z.array(z.string()),
+  recommendations: z.custom<unknown[]>(),
+  assistantReply: z.string(),
 });
+
+export type ResearchGraphState = z.infer<typeof RESEARCH_SCHEMA>;
 
 type BraveDedupCache = Map<string, { results: Array<{ title: string; url: string; description: string }> }>;
 
@@ -121,7 +106,7 @@ export async function buildResearchGraph(deps: ResearchGraphDeps, budget: Resear
     onLog: deps.onLog,
   });
 
-  const graph = new StateGraph(ResearchAnnotation)
+  const graph = new StateGraph(RESEARCH_SCHEMA)
     .addNode("plan", async (state) => {
       const planWeb = await createWebSearchPlanner({
         apiKey: deps.geminiApiKey,

--- a/services/api/test/research/research-graph-zod-schema.test.js
+++ b/services/api/test/research/research-graph-zod-schema.test.js
@@ -1,0 +1,184 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { buildResearchGraph, RESEARCH_SCHEMA } = require("../../src/agent/research/researchGraph");
+const { buildReflectionSubgraph, REFLECTION_SCHEMA } = require("../../src/agent/research/reflectionSubgraph");
+const { createResearchBudget } = require("../../src/agent/research/researchBudget");
+
+const BASE_DEPS = {
+  geminiApiKey: "x",
+  braveApiKey: "y",
+  maxInitialSearches: 2,
+  maxReflectionSearches: 2,
+  totalSearchBudget: 5,
+  targetVerifiedCount: 8,
+  researchTimeoutMs: 5000,
+};
+
+const STUB_MB = {
+  async searchArtists() { return []; },
+  async lookupArtist() { throw new Error("unexpected lookup"); },
+};
+
+const STUB_RUN_QUERIES = async () => ({ hits: [], calls: 0 });
+
+// --- Schema export tests ---
+
+test("RESEARCH_SCHEMA is exported from researchGraph", () => {
+  assert.ok(RESEARCH_SCHEMA !== undefined, "RESEARCH_SCHEMA must be exported");
+});
+
+test("REFLECTION_SCHEMA is exported from reflectionSubgraph", () => {
+  assert.ok(REFLECTION_SCHEMA !== undefined, "REFLECTION_SCHEMA must be exported");
+});
+
+test("RESEARCH_SCHEMA is a Zod schema (has _def.typeName)", () => {
+  assert.ok(
+    RESEARCH_SCHEMA !== null &&
+    typeof RESEARCH_SCHEMA === "object" &&
+    "_def" in RESEARCH_SCHEMA,
+    "RESEARCH_SCHEMA must be a Zod schema object with a _def property",
+  );
+});
+
+test("REFLECTION_SCHEMA is a Zod schema (has _def.typeName)", () => {
+  assert.ok(
+    REFLECTION_SCHEMA !== null &&
+    typeof REFLECTION_SCHEMA === "object" &&
+    "_def" in REFLECTION_SCHEMA,
+    "REFLECTION_SCHEMA must be a Zod schema object with a _def property",
+  );
+});
+
+// --- Zod parse tests ---
+
+const VALID_RESEARCH_STATE = {
+  userQuery: "bands like Neurosis",
+  preferenceContext: "",
+  messages: [],
+  mode: "discover",
+  searchPlan: undefined,
+  braveHits: [],
+  newHits: [],
+  searchCallsUsed: 0,
+  extractedCandidates: [],
+  verifiedCandidates: [],
+  reflectionUsed: false,
+  roundsCompleted: 0,
+  nextExtraQueries: [],
+  recommendations: [],
+  assistantReply: "",
+};
+
+test("RESEARCH_SCHEMA.safeParse accepts a valid full state object", () => {
+  const result = RESEARCH_SCHEMA.safeParse(VALID_RESEARCH_STATE);
+  assert.ok(result.success, `safeParse should succeed but got: ${JSON.stringify(result.error)}`);
+});
+
+test("RESEARCH_SCHEMA.safeParse rejects when userQuery is not a string", () => {
+  const result = RESEARCH_SCHEMA.safeParse({ ...VALID_RESEARCH_STATE, userQuery: 42 });
+  assert.strictEqual(result.success, false, "safeParse should fail when userQuery is a number");
+});
+
+test("RESEARCH_SCHEMA.safeParse rejects when searchCallsUsed is not a number", () => {
+  const result = RESEARCH_SCHEMA.safeParse({ ...VALID_RESEARCH_STATE, searchCallsUsed: "five" });
+  assert.strictEqual(result.success, false, "safeParse should fail when searchCallsUsed is a string");
+});
+
+test("RESEARCH_SCHEMA.safeParse rejects when reflectionUsed is not a boolean", () => {
+  const result = RESEARCH_SCHEMA.safeParse({ ...VALID_RESEARCH_STATE, reflectionUsed: "yes" });
+  assert.strictEqual(result.success, false, "safeParse should fail when reflectionUsed is a string");
+});
+
+const VALID_REFLECTION_STATE = {
+  braveHits: [],
+  newHits: [],
+  verifiedCandidates: [],
+  extractedCandidates: [],
+  searchCallsUsed: 0,
+  searchPlan: undefined,
+  userQuery: "bands like Neurosis",
+  reflectionUsed: false,
+  roundsCompleted: 0,
+  nextExtraQueries: [],
+};
+
+test("REFLECTION_SCHEMA.safeParse accepts a valid full state object", () => {
+  const result = REFLECTION_SCHEMA.safeParse(VALID_REFLECTION_STATE);
+  assert.ok(result.success, `safeParse should succeed but got: ${JSON.stringify(result.error)}`);
+});
+
+test("REFLECTION_SCHEMA.safeParse rejects when userQuery is not a string", () => {
+  const result = REFLECTION_SCHEMA.safeParse({ ...VALID_REFLECTION_STATE, userQuery: null });
+  assert.strictEqual(result.success, false, "safeParse should fail when userQuery is null");
+});
+
+// --- Schema shape tests ---
+
+test("RESEARCH_SCHEMA contains all expected field keys", () => {
+  const expectedKeys = [
+    "userQuery", "preferenceContext", "messages", "mode",
+    "searchPlan", "braveHits", "newHits", "searchCallsUsed",
+    "extractedCandidates", "verifiedCandidates", "reflectionUsed",
+    "roundsCompleted", "nextExtraQueries", "recommendations", "assistantReply",
+  ];
+  const shape = RESEARCH_SCHEMA.shape ?? RESEARCH_SCHEMA._def?.shape?.();
+  assert.ok(shape, "RESEARCH_SCHEMA must expose a shape property");
+  for (const key of expectedKeys) {
+    assert.ok(key in shape, `RESEARCH_SCHEMA is missing field: ${key}`);
+  }
+});
+
+test("REFLECTION_SCHEMA contains all expected field keys", () => {
+  const expectedKeys = [
+    "braveHits", "newHits", "verifiedCandidates", "extractedCandidates",
+    "searchCallsUsed", "searchPlan", "userQuery", "reflectionUsed",
+    "roundsCompleted", "nextExtraQueries",
+  ];
+  const shape = REFLECTION_SCHEMA.shape ?? REFLECTION_SCHEMA._def?.shape?.();
+  assert.ok(shape, "REFLECTION_SCHEMA must expose a shape property");
+  for (const key of expectedKeys) {
+    assert.ok(key in shape, `REFLECTION_SCHEMA is missing field: ${key}`);
+  }
+});
+
+// --- Graph channel invariants still hold after migration ---
+
+test("parent graph channels still include all required keys after Zod migration", async () => {
+  const budget = createResearchBudget(5000);
+  const g = await buildResearchGraph(BASE_DEPS, budget);
+  const required = ["roundsCompleted", "nextExtraQueries", "newHits", "braveHits", "reflectionUsed"];
+  for (const key of required) {
+    assert.ok(
+      Object.keys(g.channels).includes(key),
+      `channel "${key}" must be present in compiled graph after Zod migration`,
+    );
+  }
+});
+
+test("all reflection subgraph channels still present in parent after Zod migration", async () => {
+  const budget = createResearchBudget(5000);
+  const parentGraph = await buildResearchGraph(BASE_DEPS, budget);
+  const subgraph = buildReflectionSubgraph({
+    geminiApiKey: "x",
+    mb: STUB_MB,
+    runQueries: STUB_RUN_QUERIES,
+    budget,
+    maxRounds: 2,
+    maxReflectionSearches: 2,
+    targetVerifiedCount: 8,
+    totalSearchBudget: 5,
+  });
+
+  const parentChannels = new Set(Object.keys(parentGraph.channels));
+  const subgraphChannels = Object.keys(subgraph.channels).filter(
+    (k) => !k.startsWith("__") && !k.startsWith("branch:"),
+  );
+
+  for (const ch of subgraphChannels) {
+    assert.ok(
+      parentChannels.has(ch),
+      `reflection subgraph channel "${ch}" is missing from parent after Zod migration`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary
Migrates the research and reflection subgraph state definitions from LangChain's `Annotation` API to Zod schemas for improved type safety and validation. This change modernizes the state management approach while maintaining full backward compatibility with existing graph channels and behavior.

## Key Changes
- **Replaced LangChain Annotation with Zod schemas**: Converted `ResearchAnnotation` and `ReflectionAnnotation` to `RESEARCH_SCHEMA` and `REFLECTION_SCHEMA` Zod objects respectively
- **Exported schemas**: Both schemas are now exported from their respective modules for external validation and testing
- **Updated StateGraph initialization**: Changed `StateGraph(ResearchAnnotation)` and `StateGraph(ReflectionAnnotation)` to use the new Zod schemas
- **Derived TypeScript types from schemas**: `ResearchGraphState` now uses `z.infer<typeof RESEARCH_SCHEMA>` for type derivation
- **Added comprehensive test suite**: Created 184 lines of tests validating:
  - Schema exports and structure
  - Zod parsing with valid and invalid inputs
  - Schema field completeness
  - Graph channel invariants post-migration
- **Added Zod dependency**: Added `zod@^4.4.3` to package.json

## Implementation Details
- Used `z.custom<T>()` for complex types (ChatMessage[], RecommendationMode, SearchPlan, etc.) that don't have direct Zod equivalents
- Maintained all existing field definitions and types without behavioral changes
- Tests verify both positive cases (valid state objects) and negative cases (type mismatches)
- Ensured all parent graph and reflection subgraph channels remain accessible after migration

https://claude.ai/code/session_01AMwMdqKCpTPtrgHk4ChhUf