### PR TITLE
fix: migrate StateGraph schemas to StateSchema, thread sessionId to eval worker

### DIFF
--- a/services/api/src/agent/research/reflectionSubgraph.ts
+++ b/services/api/src/agent/research/reflectionSubgraph.ts
@@ -1,4 +1,4 @@
-import { END, START, StateGraph } from "@langchain/langgraph";
+import { END, START, StateGraph, StateSchema } from "@langchain/langgraph";
 import * as z from "zod";
 
 import { createCandidateExtractor, mergeExtractedCandidates, type ExtractedCandidate, type SearchHitInput } from "./candidateExtractor.js";
@@ -23,7 +23,7 @@ export type ReflectionSubgraphDeps = {
   onLog?: (level: "info" | "warn", event: string, details: Record<string, unknown>) => void;
 };
 
-export const REFLECTION_SCHEMA = z.object({
+export const REFLECTION_SCHEMA = new StateSchema({
   braveHits: z.custom<SearchHitInput[]>(),
   newHits: z.custom<SearchHitInput[]>(),
   verifiedCandidates: z.custom<VerifiedCandidate[]>(),

--- a/services/api/src/agent/research/researchGraph.ts
+++ b/services/api/src/agent/research/researchGraph.ts
@@ -1,4 +1,4 @@
-import { END, START, StateGraph } from "@langchain/langgraph";
+import { END, START, StateGraph, StateSchema } from "@langchain/langgraph";
 import * as z from "zod";
 
 import type { ChatMessage, RecommendationMode } from "../../../../../shared/schemas/src/contracts.js";
@@ -35,7 +35,7 @@ export type ResearchGraphInput = {
   mode: RecommendationMode;
 };
 
-export const RESEARCH_SCHEMA = z.object({
+export const RESEARCH_SCHEMA = new StateSchema({
   userQuery: z.string(),
   preferenceContext: z.string(),
   messages: z.custom<ChatMessage[]>(),
@@ -53,7 +53,7 @@ export const RESEARCH_SCHEMA = z.object({
   assistantReply: z.string(),
 });
 
-export type ResearchGraphState = z.infer<typeof RESEARCH_SCHEMA>;
+export type ResearchGraphState = typeof RESEARCH_SCHEMA.State;
 
 type BraveDedupCache = Map<string, { results: Array<{ title: string; url: string; description: string }> }>;
 

--- a/services/api/src/eval/evalRepository.ts
+++ b/services/api/src/eval/evalRepository.ts
@@ -11,6 +11,7 @@ export type PipelineDiagnostics = {
 export type RecommendationEventInput = {
   query: string;
   mode: string;
+  sessionId?: string | null;
   obscurityTarget?: string | null;
   pipelineVersion: string;
   pipelineDiagnostics: PipelineDiagnostics;

--- a/services/api/src/eval/evalWorker.ts
+++ b/services/api/src/eval/evalWorker.ts
@@ -5,6 +5,7 @@ import { classifyObscurityTier } from "./obscurityScorer.js";
 export type EvalEventContext = {
   query: string;
   mode: string;
+  sessionId?: string | null;
   userId?: string;
   obscurityTarget?: string | null;
   pipelineVersion: string;
@@ -67,6 +68,7 @@ export function createEvalWorker({
       const eventId = await evalRepository.logEvent({
         query: ctx.query,
         mode: ctx.mode,
+        sessionId: ctx.sessionId ?? null,
         obscurityTarget: ctx.obscurityTarget ?? null,
         pipelineVersion: ctx.pipelineVersion,
         pipelineDiagnostics: ctx.pipelineDiagnostics,

--- a/services/api/src/routes/registerBandsearchRoutes.ts
+++ b/services/api/src/routes/registerBandsearchRoutes.ts
@@ -233,6 +233,7 @@ export function registerBandsearchRoutes(app: Express, ctx: BandsearchRouteConte
         void evalWorker.processEvent({
           query: validation.query,
           mode: validation.mode,
+          sessionId: typeof req.body?.sessionId === "string" ? req.body.sessionId : null,
           userId: req.userId,
           pipelineVersion: appVersion,
           pipelineDiagnostics: (pipelineDiagnostics as PipelineDiagnostics | undefined) ?? {

--- a/services/api/test/research/research-graph-zod-schema.test.js
+++ b/services/api/test/research/research-graph-zod-schema.test.js
@@ -32,25 +32,27 @@ test("REFLECTION_SCHEMA is exported from reflectionSubgraph", () => {
   assert.ok(REFLECTION_SCHEMA !== undefined, "REFLECTION_SCHEMA must be exported");
 });
 
-test("RESEARCH_SCHEMA is a Zod schema (has _def.typeName)", () => {
+test("RESEARCH_SCHEMA is a StateSchema (has fields property and getChannelKeys method)", () => {
   assert.ok(
     RESEARCH_SCHEMA !== null &&
     typeof RESEARCH_SCHEMA === "object" &&
-    "_def" in RESEARCH_SCHEMA,
-    "RESEARCH_SCHEMA must be a Zod schema object with a _def property",
+    "fields" in RESEARCH_SCHEMA &&
+    typeof RESEARCH_SCHEMA.getChannelKeys === "function",
+    "RESEARCH_SCHEMA must be a StateSchema instance",
   );
 });
 
-test("REFLECTION_SCHEMA is a Zod schema (has _def.typeName)", () => {
+test("REFLECTION_SCHEMA is a StateSchema (has fields property and getChannelKeys method)", () => {
   assert.ok(
     REFLECTION_SCHEMA !== null &&
     typeof REFLECTION_SCHEMA === "object" &&
-    "_def" in REFLECTION_SCHEMA,
-    "REFLECTION_SCHEMA must be a Zod schema object with a _def property",
+    "fields" in REFLECTION_SCHEMA &&
+    typeof REFLECTION_SCHEMA.getChannelKeys === "function",
+    "REFLECTION_SCHEMA must be a StateSchema instance",
   );
 });
 
-// --- Zod parse tests ---
+// --- Schema validation tests ---
 
 const VALID_RESEARCH_STATE = {
   userQuery: "bands like Neurosis",
@@ -70,24 +72,35 @@ const VALID_RESEARCH_STATE = {
   assistantReply: "",
 };
 
-test("RESEARCH_SCHEMA.safeParse accepts a valid full state object", () => {
-  const result = RESEARCH_SCHEMA.safeParse(VALID_RESEARCH_STATE);
-  assert.ok(result.success, `safeParse should succeed but got: ${JSON.stringify(result.error)}`);
+test("RESEARCH_SCHEMA.validateInput accepts a valid full state object", async () => {
+  await assert.doesNotReject(
+    async () => RESEARCH_SCHEMA.validateInput(VALID_RESEARCH_STATE),
+    "validateInput should not reject for a valid state",
+  );
 });
 
-test("RESEARCH_SCHEMA.safeParse rejects when userQuery is not a string", () => {
-  const result = RESEARCH_SCHEMA.safeParse({ ...VALID_RESEARCH_STATE, userQuery: 42 });
-  assert.strictEqual(result.success, false, "safeParse should fail when userQuery is a number");
+test("RESEARCH_SCHEMA.validateInput rejects when userQuery is not a string", async () => {
+  await assert.rejects(
+    async () => RESEARCH_SCHEMA.validateInput({ ...VALID_RESEARCH_STATE, userQuery: 42 }),
+    /userQuery/,
+    "validateInput should reject for non-string userQuery",
+  );
 });
 
-test("RESEARCH_SCHEMA.safeParse rejects when searchCallsUsed is not a number", () => {
-  const result = RESEARCH_SCHEMA.safeParse({ ...VALID_RESEARCH_STATE, searchCallsUsed: "five" });
-  assert.strictEqual(result.success, false, "safeParse should fail when searchCallsUsed is a string");
+test("RESEARCH_SCHEMA.validateInput rejects when searchCallsUsed is not a number", async () => {
+  await assert.rejects(
+    async () => RESEARCH_SCHEMA.validateInput({ ...VALID_RESEARCH_STATE, searchCallsUsed: "five" }),
+    /searchCallsUsed/,
+    "validateInput should reject for non-number searchCallsUsed",
+  );
 });
 
-test("RESEARCH_SCHEMA.safeParse rejects when reflectionUsed is not a boolean", () => {
-  const result = RESEARCH_SCHEMA.safeParse({ ...VALID_RESEARCH_STATE, reflectionUsed: "yes" });
-  assert.strictEqual(result.success, false, "safeParse should fail when reflectionUsed is a string");
+test("RESEARCH_SCHEMA.validateInput rejects when reflectionUsed is not a boolean", async () => {
+  await assert.rejects(
+    async () => RESEARCH_SCHEMA.validateInput({ ...VALID_RESEARCH_STATE, reflectionUsed: "yes" }),
+    /reflectionUsed/,
+    "validateInput should reject for non-boolean reflectionUsed",
+  );
 });
 
 const VALID_REFLECTION_STATE = {
@@ -103,14 +116,19 @@ const VALID_REFLECTION_STATE = {
   nextExtraQueries: [],
 };
 
-test("REFLECTION_SCHEMA.safeParse accepts a valid full state object", () => {
-  const result = REFLECTION_SCHEMA.safeParse(VALID_REFLECTION_STATE);
-  assert.ok(result.success, `safeParse should succeed but got: ${JSON.stringify(result.error)}`);
+test("REFLECTION_SCHEMA.validateInput accepts a valid full state object", async () => {
+  await assert.doesNotReject(
+    async () => REFLECTION_SCHEMA.validateInput(VALID_REFLECTION_STATE),
+    "validateInput should not reject for a valid state",
+  );
 });
 
-test("REFLECTION_SCHEMA.safeParse rejects when userQuery is not a string", () => {
-  const result = REFLECTION_SCHEMA.safeParse({ ...VALID_REFLECTION_STATE, userQuery: null });
-  assert.strictEqual(result.success, false, "safeParse should fail when userQuery is null");
+test("REFLECTION_SCHEMA.validateInput rejects when userQuery is not a string", async () => {
+  await assert.rejects(
+    async () => REFLECTION_SCHEMA.validateInput({ ...VALID_REFLECTION_STATE, userQuery: null }),
+    /userQuery/,
+    "validateInput should reject for null userQuery",
+  );
 });
 
 // --- Schema shape tests ---
@@ -122,10 +140,9 @@ test("RESEARCH_SCHEMA contains all expected field keys", () => {
     "extractedCandidates", "verifiedCandidates", "reflectionUsed",
     "roundsCompleted", "nextExtraQueries", "recommendations", "assistantReply",
   ];
-  const shape = RESEARCH_SCHEMA.shape ?? RESEARCH_SCHEMA._def?.shape?.();
-  assert.ok(shape, "RESEARCH_SCHEMA must expose a shape property");
+  const keys = RESEARCH_SCHEMA.getChannelKeys();
   for (const key of expectedKeys) {
-    assert.ok(key in shape, `RESEARCH_SCHEMA is missing field: ${key}`);
+    assert.ok(keys.includes(key), `RESEARCH_SCHEMA is missing field: ${key}`);
   }
 });
 
@@ -135,28 +152,27 @@ test("REFLECTION_SCHEMA contains all expected field keys", () => {
     "searchCallsUsed", "searchPlan", "userQuery", "reflectionUsed",
     "roundsCompleted", "nextExtraQueries",
   ];
-  const shape = REFLECTION_SCHEMA.shape ?? REFLECTION_SCHEMA._def?.shape?.();
-  assert.ok(shape, "REFLECTION_SCHEMA must expose a shape property");
+  const keys = REFLECTION_SCHEMA.getChannelKeys();
   for (const key of expectedKeys) {
-    assert.ok(key in shape, `REFLECTION_SCHEMA is missing field: ${key}`);
+    assert.ok(keys.includes(key), `REFLECTION_SCHEMA is missing field: ${key}`);
   }
 });
 
 // --- Graph channel invariants still hold after migration ---
 
-test("parent graph channels still include all required keys after Zod migration", async () => {
+test("parent graph channels still include all required keys after StateSchema migration", async () => {
   const budget = createResearchBudget(5000);
   const g = await buildResearchGraph(BASE_DEPS, budget);
   const required = ["roundsCompleted", "nextExtraQueries", "newHits", "braveHits", "reflectionUsed"];
   for (const key of required) {
     assert.ok(
       Object.keys(g.channels).includes(key),
-      `channel "${key}" must be present in compiled graph after Zod migration`,
+      `channel "${key}" must be present in compiled graph after StateSchema migration`,
     );
   }
 });
 
-test("all reflection subgraph channels still present in parent after Zod migration", async () => {
+test("all reflection subgraph channels still present in parent after StateSchema migration", async () => {
   const budget = createResearchBudget(5000);
   const parentGraph = await buildResearchGraph(BASE_DEPS, budget);
   const subgraph = buildReflectionSubgraph({
@@ -178,7 +194,7 @@ test("all reflection subgraph channels still present in parent after Zod migrati
   for (const ch of subgraphChannels) {
     assert.ok(
       parentChannels.has(ch),
-      `reflection subgraph channel "${ch}" is missing from parent after Zod migration`,
+      `reflection subgraph channel "${ch}" is missing from parent — subgraph is a blackbox`,
     );
   }
 });


### PR DESCRIPTION
- researchGraph.ts, reflectionSubgraph.ts: replace raw z.object() with
  new StateSchema() from @langchain/langgraph — the recommended API per
  current LangGraph docs; ResearchGraphState type now derived via
  typeof RESEARCH_SCHEMA.State instead of z.infer<>
- evalRepository.ts: add optional sessionId to RecommendationEventInput
  so recommendation_events rows can be correlated with chat sessions
- evalWorker.ts: add sessionId to EvalEventContext; thread through to logEvent
- registerBandsearchRoutes.ts: extract req.body.sessionId and pass to
  evalWorker.processEvent so the field is populated at the call site
- research-graph-zod-schema.test.js: update tests from Zod-internal APIs
  (_def, safeParse, shape) to StateSchema APIs (fields, getChannelKeys,
  validateInput with assert.rejects); all 281 tests pass

https://claude.ai/code/session_01XggoUND5UvPQFDdL7XTvY1