### PR TITLE
feat(eval): batched LLM-as-judge via Claude with prompt caching (Phase 8.5)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -88,7 +88,7 @@ Three-layer system to measure recommendation quality over time: automatic obscur
 - [x] Step 2: Last.fm obscurity scoring — async worker enriches events with `listeners` count and tier (`cult` / `underground` / `obscure`) per band after the response is sent ✓ Done
 - [x] Step 3: Obscurity target setting — three-button UI (`Cult Following` / `Underground` / `Truly Obscure`), `obscurityTarget` field threaded through request body → planner prompt → event log ✓ Done
 - [x] Step 4: Search source quality + deterministic evidence checks — URL heuristic for discovery sources plus `citation_support_rate` and `generic_why_flag` per band; stored per event, no LLM needed ✓ Done
-- [ ] Step 5: LLM-as-judge worker — async Claude judge scoring each band on relevance, obscurity fit, evidence quality, and discovery value; activated by `ANTHROPIC_API_KEY`; silently skipped if absent
+- [x] Step 5: LLM-as-judge worker — async Claude judge scoring each band on relevance, obscurity fit, evidence quality, and discovery value; activated by `ANTHROPIC_API_KEY`; silently skipped if absent ✓ Done
 - [ ] Step 5b: Judge calibration — ~20–30 hand-labeled recommendations + ~15–20 GroUSE-style unit tests; compute judge–human agreement rate before trusting Layer 2 dashboard deltas
 - [ ] Step 6: Baseline snapshots — `eval_baselines` table + `POST /eval/baseline` endpoint; named snapshots of aggregated metrics before experiments; filterable by `pipeline_version`
 - [ ] Step 7: Developer dashboard — `GET /eval/dashboard` serving a standalone HTML+Chart.js page with overview panel (current vs. baseline delta), pipeline funnel panel, human–LLM alignment metrics, trend charts, obscurity distribution, and event log; guarded by `EVAL_DASHBOARD_ENABLED=true`

--- a/docs/architecture/2026-05-30-phase8-implementation-plan.md
+++ b/docs/architecture/2026-05-30-phase8-implementation-plan.md
@@ -24,7 +24,7 @@ critical path.
 | 8.2 — Last.fm obscurity scoring | ✓ Done |
 | 8.3 — Obscurity target UI + API threading | ✓ Done |
 | 8.4 — Search source quality + evidence checks | ✓ Done |
-| 8.5 — LLM-as-judge (batched) | — |
+| 8.5 — LLM-as-judge (batched) | ✓ Done |
 | 8.5b — Judge calibration | — |
 | 8.6 — Baseline snapshots + eval API | — |
 | 8.7 — Developer dashboard | — |

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -12,6 +12,7 @@ import type { EvalRepository } from "./eval/evalRepository.js";
 import { createNoOpEvalWorker, createEvalWorker } from "./eval/evalWorker.js";
 import type { EvalWorker } from "./eval/evalWorker.js";
 import { createLastFmClient } from "./eval/lastFmClient.js";
+import { createJudgeWorker, createNoOpJudgeWorker } from "./eval/judgeWorker.js";
 
 // ESM/CJS interop — these modules may wrap their export in a .default in some build environments
 const helmet = ((helmetLib as unknown as { default?: typeof helmetLib }).default) ?? helmetLib;
@@ -46,6 +47,7 @@ type AppRuntimeConfig = {
   musicBrainzRetries?: number;
   wikidataTimeoutMs?: number;
   lastFmApiKey?: string;
+  anthropicApiKey?: string;
   jwtSecret?: string;
   evalDashboardEnabled?: boolean;
 };
@@ -176,6 +178,13 @@ export function createApp({
   // in memory while the dashboard is enabled, otherwise everything is a no-op.
   const resolvedEvalRepository: EvalRepository =
     evalRepository ?? (runtimeConfig.evalDashboardEnabled ? createInMemoryEvalRepository() : createNoOpEvalRepository());
+  const resolvedJudgeWorker = runtimeConfig.anthropicApiKey
+    ? createJudgeWorker({
+        anthropicApiKey: runtimeConfig.anthropicApiKey,
+        evalRepository: resolvedEvalRepository,
+      })
+    : createNoOpJudgeWorker();
+
   const resolvedEvalWorker: EvalWorker =
     evalWorker ??
     (runtimeConfig.evalDashboardEnabled
@@ -184,6 +193,7 @@ export function createApp({
           lastFmClient: runtimeConfig.lastFmApiKey
             ? createLastFmClient({ apiKey: runtimeConfig.lastFmApiKey })
             : undefined,
+          judgeWorker: resolvedJudgeWorker,
         })
       : createNoOpEvalWorker());
 

--- a/services/api/src/config/env.ts
+++ b/services/api/src/config/env.ts
@@ -74,6 +74,8 @@ export function validateRuntimeEnv(env: NodeJS.ProcessEnv = process.env) {
   return {
     geminiApiKey,
     lastFmApiKey: String(env.LASTFM_API_KEY ?? "").trim(),
+    anthropicApiKey: String(env.ANTHROPIC_API_KEY ?? "").trim(),
+    evalDashboardPassword: String(env.EVAL_DASHBOARD_PASSWORD ?? "").trim(),
     braveApiKey,
     pipelineReadyTimeoutMs,
     researchMaxInitialSearches,

--- a/services/api/src/eval/evalRepository.ts
+++ b/services/api/src/eval/evalRepository.ts
@@ -35,6 +35,14 @@ export type BandEvalScoreInput = {
   sourceQuality?: string;
   citationSupportRate?: number;
   genericWhyFlag?: boolean;
+  // LLM judge fields (Phase 8.5) — upserted after automatic scoring
+  relevance?: number;
+  obscurityFit?: number;
+  evidenceQuality?: number;
+  discoveryValue?: number;
+  judgeReasoning?: string;
+  judgePromptHash?: string;
+  modelId?: string;
 };
 
 export type BandEvalScore = BandEvalScoreInput & {

--- a/services/api/src/eval/evalWorker.ts
+++ b/services/api/src/eval/evalWorker.ts
@@ -1,5 +1,6 @@
 import type { EvalRepository, PipelineDiagnostics } from "./evalRepository.js";
 import type { LastFmClient } from "./lastFmClient.js";
+import type { JudgeWorker, JudgeInput } from "./judgeWorker.js";
 import { classifyObscurityTier } from "./obscurityScorer.js";
 import { scoreSearchSources, ratioToSourceQuality } from "./searchSourceScorer.js";
 import { checkEvidence } from "./evidenceChecker.js";
@@ -52,9 +53,11 @@ function extractRecommendations(recommendations: unknown[]): RecommendationItem[
 export function createEvalWorker({
   evalRepository,
   lastFmClient,
+  judgeWorker,
 }: {
   evalRepository: EvalRepository;
   lastFmClient?: LastFmClient;
+  judgeWorker?: JudgeWorker;
 }): EvalWorker {
   async function scoreObscurity(eventId: string, recs: RecommendationItem[]) {
     if (!lastFmClient) return;
@@ -105,7 +108,24 @@ export function createEvalWorker({
 
       await scoreObscurity(eventId, recs);
       await scoreHeuristics(eventId, recs);
-      // Phase 8.5: judgeEvent
+
+      if (judgeWorker && recs.length > 0) {
+        const bandScores = await evalRepository.listBandEvalScores(eventId);
+        const judgeInputs: JudgeInput[] = recs.map((r) => {
+          const dbScore = bandScores.find((s) => s.bandName === r.artist);
+          return {
+            bandName: r.artist,
+            query: ctx.query,
+            obscurityTarget: ctx.obscurityTarget,
+            why: r.why,
+            sourceSignals: r.sourceSignals,
+            listeners: dbScore?.listeners,
+            citationSupportRate: dbScore?.citationSupportRate,
+            genericWhyFlag: dbScore?.genericWhyFlag,
+          };
+        });
+        await judgeWorker.judgeEvent(eventId, judgeInputs);
+      }
     },
   };
 }

--- a/services/api/src/eval/judgeWorker.ts
+++ b/services/api/src/eval/judgeWorker.ts
@@ -1,0 +1,184 @@
+import { createHash } from "node:crypto";
+import type { EvalRepository } from "./evalRepository.js";
+import { writeStructuredLog } from "../http/structuredLog.js";
+
+export type JudgeInput = {
+  bandName: string;
+  query: string;
+  obscurityTarget?: string | null;
+  why?: string;
+  sourceSignals?: string[];
+  listeners?: number | null;
+  citationSupportRate?: number;
+  genericWhyFlag?: boolean;
+};
+
+type JudgeScoreObject = {
+  relevance?: unknown;
+  obscurity_fit?: unknown;
+  evidence_quality?: unknown;
+  discovery_value?: unknown;
+  reasoning?: unknown;
+};
+
+const JUDGE_SYSTEM_PROMPT = `You are an expert music recommendation quality judge. Your task is to evaluate a list of band recommendations against a user's query and produce a JSON object with one score entry per band.
+
+Scoring dimensions (each 0.0–1.0):
+- relevance: Does the band genuinely fit the requested genre/style/mood described in the query?
+- obscurity_fit: How well does the band match the requested obscurity target? (cult < 500k listeners, underground < 100k, obscure < 10k). Ignore this if no target given.
+- evidence_quality: Is the why-text specific and grounded in cited sources, or generic boilerplate? Penalise generic_why_flag=true and uncited claims.
+- discovery_value: Would a curious music fan be genuinely surprised and pleased? Penalise extremely well-known mainstream bands for discovery-focused queries.
+
+Return ONLY a JSON object with this exact structure — no prose, no markdown fences:
+{
+  "Band Name": {
+    "relevance": 0.0,
+    "obscurity_fit": 0.0,
+    "evidence_quality": 0.0,
+    "discovery_value": 0.0,
+    "reasoning": "One sentence explanation."
+  }
+}
+
+Use the exact band names from the input. If a band is unrecognised, score conservatively at 0.5 across all dimensions.`;
+
+export function buildJudgePrompt(bands: JudgeInput[]): { system: string; user: string } {
+  const user = JSON.stringify(
+    bands.map((b) => ({
+      band_name: b.bandName,
+      query: b.query,
+      obscurity_target: b.obscurityTarget ?? null,
+      why: b.why ?? "",
+      source_signals: b.sourceSignals ?? [],
+      listeners: b.listeners ?? null,
+      citation_support_rate: b.citationSupportRate ?? null,
+      generic_why_flag: b.genericWhyFlag ?? null,
+    })),
+    null,
+    2,
+  );
+  return { system: JUDGE_SYSTEM_PROMPT, user };
+}
+
+export type JudgeWorker = {
+  judgeEvent(eventId: string, bands: JudgeInput[]): Promise<void>;
+};
+
+export function createNoOpJudgeWorker(): JudgeWorker {
+  return { async judgeEvent() {} };
+}
+
+export function createJudgeWorker({
+  anthropicApiKey,
+  evalRepository,
+  fetchImpl = globalThis.fetch,
+}: {
+  anthropicApiKey: string;
+  evalRepository: EvalRepository;
+  fetchImpl?: typeof globalThis.fetch;
+}): JudgeWorker {
+  if (!anthropicApiKey) return createNoOpJudgeWorker();
+
+  return {
+    async judgeEvent(eventId, bands) {
+      if (bands.length === 0) return;
+
+      const { system: systemText, user: userText } = buildJudgePrompt(bands);
+      const promptHash = createHash("sha256").update(systemText + userText).digest("hex");
+
+      const requestBody = {
+        model: "claude-opus-4-8",
+        max_tokens: 4096,
+        system: [
+          {
+            type: "text",
+            text: systemText,
+            cache_control: { type: "ephemeral" },
+          },
+        ],
+        messages: [{ role: "user", content: userText }],
+      };
+
+      const controller = new AbortController();
+      const timeoutHandle = setTimeout(() => controller.abort(), 10_000);
+
+      try {
+        const response = await fetchImpl("https://api.anthropic.com/v1/messages", {
+          method: "POST",
+          headers: {
+            "x-api-key": anthropicApiKey,
+            "anthropic-version": "2023-06-01",
+            "anthropic-beta": "prompt-caching-2024-07-31",
+            "content-type": "application/json",
+          },
+          body: JSON.stringify(requestBody),
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          writeStructuredLog("warn", {
+            component: "judge_worker",
+            message: `Anthropic API returned ${response.status}`,
+            eventId,
+          });
+          return;
+        }
+
+        const data = (await response.json()) as { content?: Array<{ type?: string; text?: string }> };
+        const text = data?.content?.find((c) => c.type === "text")?.text ?? "";
+
+        let scores: Record<string, JudgeScoreObject>;
+        try {
+          const parsed: unknown = JSON.parse(text);
+          if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+            return;
+          }
+          scores = parsed as Record<string, JudgeScoreObject>;
+        } catch {
+          writeStructuredLog("warn", {
+            component: "judge_worker",
+            message: "Failed to parse judge response JSON",
+            eventId,
+            text: text.slice(0, 200),
+          });
+          return;
+        }
+
+        await Promise.allSettled(
+          bands.map(async ({ bandName }) => {
+            const score = scores[bandName];
+            if (!score || typeof score !== "object") return;
+            await evalRepository.upsertBandEvalScore({
+              eventId,
+              bandName,
+              relevance: typeof score.relevance === "number" ? score.relevance : undefined,
+              obscurityFit: typeof score.obscurity_fit === "number" ? score.obscurity_fit : undefined,
+              evidenceQuality: typeof score.evidence_quality === "number" ? score.evidence_quality : undefined,
+              discoveryValue: typeof score.discovery_value === "number" ? score.discovery_value : undefined,
+              judgeReasoning: typeof score.reasoning === "string" ? score.reasoning : undefined,
+              judgePromptHash: promptHash,
+              modelId: "claude-opus-4-8",
+            });
+          }),
+        );
+      } catch (error) {
+        if (error instanceof Error && error.name === "AbortError") {
+          writeStructuredLog("warn", {
+            component: "judge_worker",
+            message: "Judge request timed out",
+            eventId,
+          });
+          return;
+        }
+        writeStructuredLog("warn", {
+          component: "judge_worker",
+          message: "Judge request failed",
+          eventId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      } finally {
+        clearTimeout(timeoutHandle);
+      }
+    },
+  };
+}

--- a/services/api/test/eval/eval-worker.test.js
+++ b/services/api/test/eval/eval-worker.test.js
@@ -204,3 +204,57 @@ test("createEvalWorker: scoreHeuristics does not throw when why/sourceSignals ar
 
   await assert.doesNotReject(() => worker.processEvent(ctxWithMissingFields));
 });
+
+// ─── Phase 8.5: judge integration ──────────────────────────────────────────
+
+test("createEvalWorker: processEvent calls judgeWorker.judgeEvent with enriched band data", async () => {
+  const { createEvalWorker } = require("../../src/eval/evalWorker");
+  const { createInMemoryEvalRepository } = require("../../src/eval/evalRepository");
+  const repo = createInMemoryEvalRepository();
+  const judgeEventCalls = [];
+  const judgeWorker = {
+    judgeEvent: async (eventId, bands) => { judgeEventCalls.push({ eventId, bands }); },
+  };
+
+  const worker = createEvalWorker({ evalRepository: repo, judgeWorker });
+  await worker.processEvent(heuristicsCtx);
+
+  assert.equal(judgeEventCalls.length, 1, "judgeEvent should be called once");
+  assert.ok(typeof judgeEventCalls[0].eventId === "string", "eventId should be a string");
+  assert.equal(judgeEventCalls[0].bands.length, 2, "both bands should be passed to judge");
+  assert.ok(judgeEventCalls[0].bands.every((b) => typeof b.bandName === "string"), "each entry has bandName");
+  assert.ok(judgeEventCalls[0].bands.every((b) => b.query === heuristicsCtx.query), "query is threaded");
+});
+
+test("createEvalWorker: processEvent does not call judgeEvent when no judgeWorker provided", async () => {
+  const { createEvalWorker } = require("../../src/eval/evalWorker");
+  const { createInMemoryEvalRepository } = require("../../src/eval/evalRepository");
+  const repo = createInMemoryEvalRepository();
+  const worker = createEvalWorker({ evalRepository: repo });
+
+  await assert.doesNotReject(() => worker.processEvent(heuristicsCtx));
+  const events = await repo.listEvents();
+  assert.equal(events.length, 1, "event still logged without judge");
+});
+
+test("createEvalWorker: processEvent passes listener and heuristic data to judgeWorker", async () => {
+  const { createEvalWorker } = require("../../src/eval/evalWorker");
+  const { createInMemoryEvalRepository } = require("../../src/eval/evalRepository");
+  const repo = createInMemoryEvalRepository();
+  const lastFmClient = {
+    getListenerCount: async (name) => (name === "Wolves in the Throne Room" ? 80000 : 600000),
+  };
+  const judgeEventCalls = [];
+  const judgeWorker = {
+    judgeEvent: async (eventId, bands) => { judgeEventCalls.push({ eventId, bands }); },
+  };
+
+  const worker = createEvalWorker({ evalRepository: repo, lastFmClient, judgeWorker });
+  await worker.processEvent(heuristicsCtx);
+
+  const wittr = judgeEventCalls[0].bands.find((b) => b.bandName === "Wolves in the Throne Room");
+  assert.ok(wittr, "WITTR should be in judge inputs");
+  assert.equal(wittr.listeners, 80000, "listeners enriched from Last.fm scoring");
+  assert.ok(typeof wittr.citationSupportRate === "number", "citationSupportRate populated from heuristics");
+  assert.ok(typeof wittr.genericWhyFlag === "boolean", "genericWhyFlag populated from heuristics");
+});

--- a/services/api/test/eval/judge-worker.test.js
+++ b/services/api/test/eval/judge-worker.test.js
@@ -1,0 +1,262 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const sampleBands = [
+  {
+    bandName: "Wolves in the Throne Room",
+    query: "atmospheric black metal",
+    obscurityTarget: "underground",
+    why: "Atmospheric DSBM from the Pacific Northwest.",
+    sourceSignals: ["https://bandcamp.com/wittr"],
+    listeners: 80000,
+    citationSupportRate: 1.0,
+    genericWhyFlag: false,
+  },
+  {
+    bandName: "Deafheaven",
+    query: "atmospheric black metal",
+    obscurityTarget: "underground",
+    why: "Known for their blackgaze sound.",
+    sourceSignals: [],
+    listeners: 600000,
+    citationSupportRate: 1.0,
+    genericWhyFlag: true,
+  },
+];
+
+const successResponseBody = {
+  content: [
+    {
+      type: "text",
+      text: JSON.stringify({
+        "Wolves in the Throne Room": {
+          relevance: 0.9,
+          obscurity_fit: 0.8,
+          evidence_quality: 0.7,
+          discovery_value: 0.85,
+          reasoning: "Excellent atmospheric black metal, fits underground target.",
+        },
+        Deafheaven: {
+          relevance: 0.8,
+          obscurity_fit: 0.3,
+          evidence_quality: 0.4,
+          discovery_value: 0.6,
+          reasoning: "Well-known band, generic why-text.",
+        },
+      }),
+    },
+  ],
+};
+
+test("buildJudgePrompt: includes all bands in one user message", () => {
+  const { buildJudgePrompt } = require("../../src/eval/judgeWorker");
+  const { system, user } = buildJudgePrompt(sampleBands);
+
+  assert.ok(typeof system === "string" && system.length > 0, "system prompt should be non-empty");
+  const parsed = JSON.parse(user);
+  assert.equal(parsed.length, 2);
+  assert.ok(parsed.some((b) => b.band_name === "Wolves in the Throne Room"));
+  assert.ok(parsed.some((b) => b.band_name === "Deafheaven"));
+});
+
+test("buildJudgePrompt: includes all required fields per band", () => {
+  const { buildJudgePrompt } = require("../../src/eval/judgeWorker");
+  const { user } = buildJudgePrompt(sampleBands);
+  const parsed = JSON.parse(user);
+  const wittr = parsed.find((b) => b.band_name === "Wolves in the Throne Room");
+  assert.ok(wittr, "WITTR should be in parsed output");
+  assert.ok("query" in wittr);
+  assert.ok("obscurity_target" in wittr);
+  assert.ok("why" in wittr);
+  assert.ok("source_signals" in wittr);
+  assert.ok("listeners" in wittr);
+  assert.ok("citation_support_rate" in wittr);
+  assert.ok("generic_why_flag" in wittr);
+});
+
+test("createJudgeWorker: no-op when anthropicApiKey is empty", async () => {
+  const { createJudgeWorker } = require("../../src/eval/judgeWorker");
+  const { createInMemoryEvalRepository } = require("../../src/eval/evalRepository");
+  const fetchCalls = [];
+  const fetchStub = async (...args) => {
+    fetchCalls.push(args);
+    return { ok: true, json: async () => successResponseBody };
+  };
+
+  const repo = createInMemoryEvalRepository();
+  const worker = createJudgeWorker({ anthropicApiKey: "", evalRepository: repo, fetchImpl: fetchStub });
+  await worker.judgeEvent("event-1", sampleBands);
+
+  assert.equal(fetchCalls.length, 0, "no fetch call when API key is absent");
+});
+
+test("createJudgeWorker: sends all bands in one batched request (not per-band)", async () => {
+  const { createJudgeWorker } = require("../../src/eval/judgeWorker");
+  const { createInMemoryEvalRepository } = require("../../src/eval/evalRepository");
+  const fetchCalls = [];
+  const fetchStub = async (url, options) => {
+    fetchCalls.push({ url, body: JSON.parse(options.body) });
+    return { ok: true, json: async () => successResponseBody };
+  };
+
+  const repo = createInMemoryEvalRepository();
+  const worker = createJudgeWorker({ anthropicApiKey: "test-key", evalRepository: repo, fetchImpl: fetchStub });
+  await worker.judgeEvent("event-1", sampleBands);
+
+  assert.equal(fetchCalls.length, 1, "exactly one API call for all bands");
+  const body = fetchCalls[0].body;
+  assert.equal(body.model, "claude-opus-4-8");
+  const userContent = body.messages[0].content;
+  assert.ok(userContent.includes("Wolves in the Throne Room"), "user message should contain WITTR");
+  assert.ok(userContent.includes("Deafheaven"), "user message should contain Deafheaven");
+});
+
+test("createJudgeWorker: parses batch response and upserts scores per band", async () => {
+  const { createJudgeWorker } = require("../../src/eval/judgeWorker");
+  const { createInMemoryEvalRepository } = require("../../src/eval/evalRepository");
+  const fetchStub = async () => ({ ok: true, json: async () => successResponseBody });
+
+  const repo = createInMemoryEvalRepository();
+  const eventId = await repo.logEvent({
+    query: "atmospheric black metal",
+    mode: "fresh",
+    pipelineVersion: "1.0.0",
+    pipelineDiagnostics: {
+      braveHitCount: 0,
+      extractedCandidateCount: 0,
+      verifiedCount: 0,
+      reflectionTriggered: false,
+      searchBudgetUsed: 0,
+    },
+    recommendationCount: 2,
+  });
+
+  const worker = createJudgeWorker({ anthropicApiKey: "test-key", evalRepository: repo, fetchImpl: fetchStub });
+  await worker.judgeEvent(eventId, sampleBands);
+
+  const scores = await repo.listBandEvalScores(eventId);
+  const wittr = scores.find((s) => s.bandName === "Wolves in the Throne Room");
+  assert.ok(wittr, "WITTR score should exist");
+  assert.equal(wittr.relevance, 0.9);
+  assert.equal(wittr.obscurityFit, 0.8);
+  assert.equal(wittr.evidenceQuality, 0.7);
+  assert.equal(wittr.discoveryValue, 0.85);
+  assert.ok(typeof wittr.judgePromptHash === "string" && wittr.judgePromptHash.length > 0, "judgePromptHash should be set");
+  assert.equal(wittr.modelId, "claude-opus-4-8");
+
+  const deafheaven = scores.find((s) => s.bandName === "Deafheaven");
+  assert.ok(deafheaven, "Deafheaven score should exist");
+  assert.equal(deafheaven.relevance, 0.8);
+  assert.equal(deafheaven.obscurityFit, 0.3);
+});
+
+test("createJudgeWorker: upsertBandEvalScore called once per band with parsed scores", async () => {
+  const { createJudgeWorker } = require("../../src/eval/judgeWorker");
+  const upsertCalls = [];
+  const repoStub = {
+    upsertBandEvalScore: async (input) => { upsertCalls.push(input); },
+    logEvent: async () => "event-1",
+    listEvents: async () => [],
+    listBandEvalScores: async () => [],
+  };
+  const fetchStub = async () => ({ ok: true, json: async () => successResponseBody });
+
+  const worker = createJudgeWorker({ anthropicApiKey: "test-key", evalRepository: repoStub, fetchImpl: fetchStub });
+  await worker.judgeEvent("event-1", sampleBands);
+
+  assert.equal(upsertCalls.length, 2, "upsert called once per band");
+  assert.ok(upsertCalls.some((c) => c.bandName === "Wolves in the Throne Room"));
+  assert.ok(upsertCalls.some((c) => c.bandName === "Deafheaven"));
+});
+
+test("createJudgeWorker: does not throw on AbortError (timeout)", async () => {
+  const { createJudgeWorker } = require("../../src/eval/judgeWorker");
+  const { createInMemoryEvalRepository } = require("../../src/eval/evalRepository");
+  const fetchStub = async () => {
+    const error = new Error("The operation was aborted");
+    error.name = "AbortError";
+    throw error;
+  };
+
+  const repo = createInMemoryEvalRepository();
+  const worker = createJudgeWorker({ anthropicApiKey: "test-key", evalRepository: repo, fetchImpl: fetchStub });
+
+  await assert.doesNotReject(() => worker.judgeEvent("event-1", sampleBands));
+});
+
+test("createJudgeWorker: does not throw on malformed JSON response", async () => {
+  const { createJudgeWorker } = require("../../src/eval/judgeWorker");
+  const { createInMemoryEvalRepository } = require("../../src/eval/evalRepository");
+  const fetchStub = async () => ({
+    ok: true,
+    json: async () => ({ content: [{ type: "text", text: "not valid json {{{" }] }),
+  });
+
+  const repo = createInMemoryEvalRepository();
+  const worker = createJudgeWorker({ anthropicApiKey: "test-key", evalRepository: repo, fetchImpl: fetchStub });
+
+  await assert.doesNotReject(() => worker.judgeEvent("event-1", sampleBands));
+});
+
+test("createJudgeWorker: does not throw on non-ok API response", async () => {
+  const { createJudgeWorker } = require("../../src/eval/judgeWorker");
+  const { createInMemoryEvalRepository } = require("../../src/eval/evalRepository");
+  const fetchStub = async () => ({ ok: false, status: 429, json: async () => ({}) });
+
+  const repo = createInMemoryEvalRepository();
+  const worker = createJudgeWorker({ anthropicApiKey: "test-key", evalRepository: repo, fetchImpl: fetchStub });
+
+  await assert.doesNotReject(() => worker.judgeEvent("event-1", sampleBands));
+});
+
+test("createJudgeWorker: does not call fetch when bands array is empty", async () => {
+  const { createJudgeWorker } = require("../../src/eval/judgeWorker");
+  const { createInMemoryEvalRepository } = require("../../src/eval/evalRepository");
+  const fetchCalls = [];
+  const fetchStub = async (...args) => {
+    fetchCalls.push(args);
+    return { ok: true, json: async () => ({}) };
+  };
+
+  const repo = createInMemoryEvalRepository();
+  const worker = createJudgeWorker({ anthropicApiKey: "test-key", evalRepository: repo, fetchImpl: fetchStub });
+  await worker.judgeEvent("event-1", []);
+
+  assert.equal(fetchCalls.length, 0, "no fetch call for empty band list");
+});
+
+test("createJudgeWorker: prompt caching header is sent with request", async () => {
+  const { createJudgeWorker } = require("../../src/eval/judgeWorker");
+  const { createInMemoryEvalRepository } = require("../../src/eval/evalRepository");
+  const capturedHeaders = [];
+  const fetchStub = async (_url, options) => {
+    capturedHeaders.push(options.headers);
+    return { ok: true, json: async () => successResponseBody };
+  };
+
+  const repo = createInMemoryEvalRepository();
+  const worker = createJudgeWorker({ anthropicApiKey: "test-key", evalRepository: repo, fetchImpl: fetchStub });
+  await worker.judgeEvent("event-1", sampleBands);
+
+  assert.equal(capturedHeaders.length, 1);
+  assert.ok(capturedHeaders[0]["anthropic-beta"]?.includes("prompt-caching"), "prompt-caching beta header should be sent");
+});
+
+test("createJudgeWorker: system message has cache_control ephemeral", async () => {
+  const { createJudgeWorker } = require("../../src/eval/judgeWorker");
+  const { createInMemoryEvalRepository } = require("../../src/eval/evalRepository");
+  const capturedBodies = [];
+  const fetchStub = async (_url, options) => {
+    capturedBodies.push(JSON.parse(options.body));
+    return { ok: true, json: async () => successResponseBody };
+  };
+
+  const repo = createInMemoryEvalRepository();
+  const worker = createJudgeWorker({ anthropicApiKey: "test-key", evalRepository: repo, fetchImpl: fetchStub });
+  await worker.judgeEvent("event-1", sampleBands);
+
+  const body = capturedBodies[0];
+  const systemBlocks = Array.isArray(body.system) ? body.system : [];
+  const cacheBlock = systemBlocks.find((b) => b.cache_control?.type === "ephemeral");
+  assert.ok(cacheBlock, "system prompt should have cache_control: ephemeral block");
+});


### PR DESCRIPTION
Implements the LLM-as-judge eval layer activated by ANTHROPIC_API_KEY:

- judgeWorker.ts: buildJudgePrompt (pure, snapshot-testable) + createJudgeWorker
  One batched Anthropic API call per event (not per band); system prompt cached
  via cache_control: ephemeral. AbortController 10s timeout; all failures are
  silent (warn log only) so eval loss never surfaces as a system error.
- evalRepository.ts: adds LLM judge fields to BandEvalScoreInput
  (relevance, obscurityFit, evidenceQuality, discoveryValue, judgeReasoning,
  judgePromptHash, modelId); upserted after automatic scoring.
- evalWorker.ts: chains judgeEvent as the final step in processEvent; reads
  back band scores from the repository to enrich judge inputs with listeners
  and heuristic data already computed in earlier layers.
- env.ts: adds anthropicApiKey + evalDashboardPassword env vars.
- app.ts: creates judgeWorker when ANTHROPIC_API_KEY is set; wires into
  createEvalWorker; no-op when key absent (zero config change needed).

15 new tests; all 315 pass.

https://claude.ai/code/session_01V2RxHEWUwcDAXUScEBvTX1