### PR TITLE
docs(eval): demote precision@8 from CI gate to informational metric

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -93,7 +93,7 @@ Three-layer system to measure recommendation quality over time: automatic obscur
 - [ ] Step 6: Baseline snapshots — `eval_baselines` table + `POST /eval/baseline` endpoint; named snapshots of aggregated metrics before experiments; filterable by `pipeline_version`
 - [ ] Step 7: Developer dashboard — `GET /eval/dashboard` serving a standalone HTML+Chart.js page with overview panel (current vs. baseline delta), pipeline funnel panel, human–LLM alignment metrics, trend charts, obscurity distribution, and event log; guarded by `EVAL_DASHBOARD_ENABLED=true`
 - [ ] Step 8: User feedback button — single batch-level reaction bar after recommendations render (`Spot on` / `Too mainstream` / `Wrong direction`); disappears after 12 s or next user input
-- [ ] Step 9: Golden dataset — `services/eval/golden-set.json` with 10–15 curated queries including `nuggets` and `antiBands`; `run-golden.ts` computing precision@8, antiBandRate@8 (CI fail if > 0), and nuggetCoverage@8
+- [ ] Step 9: Golden dataset — `services/eval/golden-set.json` with 10–15 curated queries including `nuggets` and `antiBands`; `run-golden.ts` computing `antiBandRate@8` (CI fail if > 0), `nuggetCoverage@8` (CI fail if below threshold), and `precision@8` (informational trend only — exact band-name matching is not a regression gate because many valid answers exist for any query)
 
 **Future (after data exists):**
 - `search_quality_check` node in LangGraph loop: if search source quality is low, planner receives feedback and regenerates queries before extraction — only worth building once dashboard data confirms the correlation

--- a/docs/architecture/2026-05-29-eval-architecture.md
+++ b/docs/architecture/2026-05-29-eval-architecture.md
@@ -341,22 +341,24 @@ File: `services/eval/golden-set.json`
 ]
 ```
 
-**`expectedBands`** — bands a good pipeline should surface (direction matters more than exact overlap).
+**`expectedBands`** — example bands that illustrate the direction a good pipeline should take. **Not used for automated pass/fail.** Many equally valid answers exist for any query; exact-match metrics against this list would penalise correct responses that happen to pick different but equivalent bands. Used as calibration anchors in `judge-calibration.json` so human labellers know what "good" looks like.
 
-**`antiBands`** — explicitly too well-known bands that reveal when the pipeline takes an easy path instead of searching.
+**`antiBands`** — explicitly too well-known bands that reveal when the pipeline takes an easy path instead of searching. Hard constraint: any hit here is a clear, unambiguous failure.
 
-**`nuggets`** — atomic sonic properties (genre, era, trait) inspired by nugget evaluation (NuggetRecall / TREC methodology). Manual curation for v1; full AutoNuggetizer pipeline deferred.
+**`nuggets`** — atomic sonic properties (genre, era, trait) inspired by nugget evaluation (NuggetRecall / TREC methodology). Evaluated against MusicBrainz genres/tags of recommended bands. This is the primary positive quality gate: it tests whether the pipeline covered the *right sonic space*, not whether it named specific bands. Manual curation for v1; full AutoNuggetizer pipeline deferred.
 
 **Metrics for `run-golden.ts`:**
 
 | Metric | Description | CI gate |
 |--------|-------------|---------|
-| `precision@8` | Fraction of `expectedBands` in top-8 | Warn if drops >10% vs last run |
 | `antiBandRate@8` | Fraction of top-8 that hit `antiBands` | **Fail if > 0** |
-| `nuggetCoverage@8` | Fraction of `nuggets` covered by recommended bands' MB genres/tags | Fail if below `minNuggetCoverage` |
+| `nuggetCoverage@8` | Fraction of `nuggets` covered by recommended bands' MB genres/tags | **Fail if below `minNuggetCoverage`** |
+| `precision@8` | Fraction of `expectedBands` in top-8 (exact name match) | Informational only — tracked as trend, never a CI gate |
 | `ndcg@8` (optional) | Ranking-aware partial credit for expected bands | Informational only |
 
-**Usage:** CI-runnable script (`services/eval/run-golden.ts`) that calls the recommendation API with each golden query and computes all metrics. Run manually before/after significant prompt changes; binary gates (`antiBandRate@8`, `nuggetCoverage@8`) provide pass/fail for regression runs.
+**Rationale for demoting `precision@8`:** Band recommendations are an open-ended retrieval task — there is no single correct answer. A pipeline that returns Celeste and Les Discrets instead of Lantlôs and Amesoeurs may be equally correct. Exact-match precision against a predefined list would generate false regression failures and reward memorisation over genuine quality. `nuggetCoverage@8` and `antiBandRate@8` test the *properties* a response must have rather than comparing it to a reference answer.
+
+**Usage:** CI-runnable script (`services/eval/run-golden.ts`) that calls the recommendation API with each golden query and computes all metrics. Run manually before/after significant prompt changes; only `antiBandRate@8` and `nuggetCoverage@8` are hard pass/fail gates.
 
 ---
 


### PR DESCRIPTION
Band recommendations are open-ended: many valid answers exist for any
query. Exact-match precision against a predefined expectedBands list
penalises correct responses that pick different but equivalent bands.

- antiBandRate@8 and nuggetCoverage@8 remain the only hard CI gates
- precision@8 tracked as trend only, never pass/fail
- expectedBands renamed in semantics to calibration examples, not
  reference answers
- Added rationale section in eval-architecture.md explaining the
  open-ended retrieval problem

https://claude.ai/code/session_01AqqTRRREU8AEaPc9m2iQ8f