### PR TITLE
refactor: single source of truth for discovery domains and ObscurityTarget type

### DIFF
--- a/apps/desktop/src/ui/ObscurityTargetPicker.ts
+++ b/apps/desktop/src/ui/ObscurityTargetPicker.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-export type ObscurityTarget = "cult" | "underground" | "obscure";
+import type { ObscurityTarget } from "../../../../shared/schemas/src/contracts.js";
 
 const BUTTONS: Array<{ value: ObscurityTarget; label: string }> = [
   { value: "cult", label: "Cult Following" },

--- a/services/api/src/agent/research/webSearchPlanner.ts
+++ b/services/api/src/agent/research/webSearchPlanner.ts
@@ -1,6 +1,7 @@
 import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
 
 import type { ChatMessage } from "../../../../../shared/schemas/src/contracts.js";
+import { DISCOVERY_DOMAINS } from "../../eval/searchSourceScorer.js";
 import { formatHistoryBlock, wrapPreferenceContext, wrapUserContent } from "../promptGuards.js";
 import { parseModelJsonResponse, withTimeout } from "../modelUtils.js";
 
@@ -16,14 +17,20 @@ export type SearchPlan = {
   queries: string[];
 };
 
+const DOMAIN_DESCRIPTIONS: Record<string, string> = {
+  "bandcamp.com": "site:bandcamp.com — niche releases, genre tags, FFO artist pages (almost always useful);",
+  "rateyourmusic.com": "site:rateyourmusic.com — genre lists, similar-artist charts, 'sounds like' pages;",
+  "rym.xyz": "site:rym.xyz — RYM mirror, same genre lists and charts;",
+  "reddit.com": "site:reddit.com/r/ifyoulikeblank or site:reddit.com/r/<genre> — community RIYL threads;",
+  "last.fm": "site:last.fm — similar-artist pages (last.fm/music/<artist>/+similar);",
+  "lastfm.com": "site:lastfm.com — similar-artist pages;",
+  "metal-archives.com": "site:metal-archives.com — metal and extreme music only, skip for electronic/jazz/folk;",
+  "sputnikmusic.com": "site:sputnikmusic.com — rock and metal reviews with FFO sections;",
+};
+
 const DISCOVERY_SOURCES = [
   "Prioritise these sources in queries where relevant:",
-  "site:bandcamp.com — niche releases, genre tags, FFO artist pages (almost always useful);",
-  "site:rateyourmusic.com — genre lists, similar-artist charts, 'sounds like' pages;",
-  "site:reddit.com/r/ifyoulikeblank or site:reddit.com/r/<genre> — community RIYL threads;",
-  "site:last.fm — similar-artist pages (last.fm/music/<artist>/+similar);",
-  "site:metal-archives.com — metal and extreme music only, skip for electronic/jazz/folk;",
-  "site:sputnikmusic.com — rock and metal reviews with FFO sections;",
+  ...DISCOVERY_DOMAINS.map((d) => DOMAIN_DESCRIPTIONS[d] ?? `site:${d};`),
   "niche blogs: thequietus.com, heavyblogisheavy.com, cvltnation.com, exclaim.ca — for scene discoveries.",
   "Match sources to genre — do not use metal-archives.com for ambient or jazz queries.",
 ].join(" ");


### PR DESCRIPTION
## Problem

Zwei Duplikationsfehler die beim Vergleich von PR #24 (nicht gemergt) mit dem gemergten Stand auf `main` aufgefallen sind:

### 1. `webSearchPlanner.ts` — Domain-Beschreibungen dupliziert

`searchSourceScorer.ts` definiert `DISCOVERY_DOMAINS` als kanonische Liste der Discovery-Quellen. `webSearchPlanner.ts` hatte dieselben Domains aber als hartkodierten String mit Beschreibungen — komplett unabhängig.

**Konkrete Folge:** `rym.xyz` und `lastfm.com` standen in `DISCOVERY_DOMAINS` (werden also beim Scoring gezählt), aber fehlten im Planner-Prompt vollständig. Der Planner wusste nicht, dass er diese Quellen nutzen soll.

### 2. `ObscurityTargetPicker.ts` — Typ lokal dupliziert

```ts
// vorher: lokal definiert
export type ObscurityTarget = "cult" | "underground" | "obscure";

// nachher: aus shared/schemas importiert
import type { ObscurityTarget } from "../../../../shared/schemas/src/contracts.js";
```

Der kanonische Typ lebt in `shared/schemas/src/contracts.ts` — dort wird er validiert und von der gesamten API verwendet. Die lokale Kopie konnte still auseinanderdriften.

---

## Änderungen

### `services/api/src/agent/research/webSearchPlanner.ts`

- Importiert `DISCOVERY_DOMAINS` aus `searchSourceScorer.ts`
- Fügt `DOMAIN_DESCRIPTIONS`-Map hinzu (Domain → Beschreibungsstring)
- Baut `DISCOVERY_SOURCES` dynamisch: `DISCOVERY_DOMAINS.map(d => DOMAIN_DESCRIPTIONS[d] ?? \`site:\${d};\`)`
- Neue Domain in `searchSourceScorer.ts` → automatisch im Planner-Prompt, kein manuelles Nachziehen nötig
- `rym.xyz` und `lastfm.com` erscheinen jetzt korrekt im Prompt

### `apps/desktop/src/ui/ObscurityTargetPicker.ts`

- `export type ObscurityTarget = ...` → `import type { ObscurityTarget } from "../../../../shared/schemas/src/contracts.js"`
- Keine funktionale Änderung, kein Re-Export nötig (keine externen Imports aus dem Picker)

---

## Tests

Alle bestehenden Tests unverändert grün — 346 API-Tests, 158 Desktop-Tests, TypeScript-Check fehlerfrei.

Closes #24 (war Duplikat von #28; dieser Fix enthält den einzigen echten Vorteil aus #24).

---
_Generated by [Claude Code](https://claude.ai/code/session_01YN6X4LQr377kTUaMn6qiuY)_