### PR TITLE
docs: clean up README and add docs navigation index

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,44 +325,6 @@ In development (browser or embedded webview), the chat UI chooses **mobile vs de
 
 ---
 
-## Maintenance notes
-
-**2026-05-30 — Reflection subgraph fixes + architecture docs**
-
-### Changes
-
-- **Research pipeline**: Fixed three bugs in the reflection subgraph — `extract_r` now processes only the new hits from each round (not all accumulated hits), `verify_r` skips already-verified candidates and merges results across rounds instead of overwriting, and `formatEvidenceForPrompt` defensively deduplicates candidates before building the LLM evidence block.
-- **Docs**: Added `docs/architecture/ARCHITECTURE.md` with a full description of the pipeline, state fields, integrations, storage, auth, and key design decisions. Added a Mermaid LangGraph diagram to `README.md`.
-
----
-
-**2026-05-28 — Phase 7 Windows support**
-
-### Changes
-
-- **CI**: Added `windows-latest` runner to the CI matrix alongside `ubuntu-latest`. `fail-fast: false` keeps both legs visible if one fails. All `run:` steps use `shell: bash` so scripts work identically on both platforms.
-- **Tauri sidecar**: `api_spawn_args` now probes for a Tauri-bundled Node sidecar next to the executable (`node-<target-triple>[.exe]`) via `env!("TARGET")` and falls back to system `node` in dev/CI. `externalBin: ["binaries/node"]` added to `tauri.conf.json`.
-- **Docs**: `apps/desktop/src-tauri/binaries/README` added — explains which Node binary to place there and where to download it before running `tauri build`.
-
----
-
-**2026-05-27 — Weekly maintenance**
-
-### Fixes applied
-
-- **CI**: `npm install` changed to `npm ci` for reproducible, locked installs in CI environments.
-- **CI**: Action versions bumped to current stable — `checkout@v6`, `setup-node@v6`, `setup-python@v6`.
-
-### Major upgrades available (not auto-applied — require testing)
-
-| Package | In use | Latest | Notes |
-|---|---|---|---|
-| `eslint` / `@eslint/js` | `^9.x` | `10.x` | Flat-config updates; review eslint v10 migration guide |
-| `globals` | `^16.5.0` | `17.x` | Breaking changes in the globals API |
-| `typescript` | `^5.9.x` | `6.x` | New type-system features; some breaking changes |
-
----
-
 ## License
 
 Apache 2.0 — see [LICENSE](LICENSE).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,25 @@
+# Documentation
+
+Navigation guide for the `docs/` folder.
+
+## Contents
+
+| Path | What it covers |
+|------|----------------|
+| [ROADMAP.md](ROADMAP.md) | Phase-by-phase feature roadmap with completion status |
+| [architecture/ARCHITECTURE.md](architecture/ARCHITECTURE.md) | System architecture — graph pipeline, state fields, integrations, storage, auth |
+| [architecture/2026-05-29-eval-architecture.md](architecture/2026-05-29-eval-architecture.md) | Evaluation layer design — three-tier scoring, LLM-as-judge, feedback loop |
+| [architecture/2026-05-30-phase8-implementation-plan.md](architecture/2026-05-30-phase8-implementation-plan.md) | Phase 8 step-by-step implementation plan (eval & quality observability) |
+| [adr/0001-prompt-injection-guardrails.md](adr/0001-prompt-injection-guardrails.md) | ADR: prompt injection defence — bracket-marker envelope and length caps |
+| [design/UI_GUIDELINES.md](design/UI_GUIDELINES.md) | UI design guidelines — layout, components, responsive behaviour |
+| [design/UI_EXAMPLES.md](design/UI_EXAMPLES.md) | UI copy examples and interaction patterns |
+| [agents/domain.md](agents/domain.md) | Domain knowledge for AI coding agents working in this repo |
+| [agents/issue-tracker.md](agents/issue-tracker.md) | Issue tracking conventions |
+| [agents/triage-labels.md](agents/triage-labels.md) | Triage label definitions |
+
+## Where to start
+
+- **New to the codebase?** Read [ARCHITECTURE.md](architecture/ARCHITECTURE.md) first, then [ROADMAP.md](ROADMAP.md) to see where the project stands.
+- **Changing the UI?** Consult [UI_GUIDELINES.md](design/UI_GUIDELINES.md) before writing new components.
+- **Security or prompt design?** See [ADR 0001](adr/0001-prompt-injection-guardrails.md) for the injection defence rationale.
+- **Planning a new feature?** Check [ROADMAP.md](ROADMAP.md) for phase status and open steps before starting.


### PR DESCRIPTION
## What changed

**README.md** — removed the `## Maintenance notes` section at the bottom. This section contained dated internal changelog entries (CI bumps, bug fix summaries, pending upgrade tables). That content is useful for contributors tracking changes but belongs in commit history or a CHANGELOG, not in the README that first-time visitors and external readers land on.

**docs/README.md** (new file) — a navigation index for the `docs/` folder. Lists every file/subdirectory with a one-line description and a "where to start" quick-guide. Useful for humans browsing GitHub and for LLMs reading the repo to orient quickly without scanning all files.

## What stayed the same

All docs content — ARCHITECTURE.md, ROADMAP.md, ADRs, design docs, agent guides — is unchanged. No information was deleted, only the internal maintenance log was removed from the public-facing README.

---
_Generated by [Claude Code](https://claude.ai/code/session_013oLUnT7xfAMghDWhbjciEb)_