### PR TITLE
docs: update README and CONTEXT.md to reflect current state

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -4,4 +4,34 @@ AI-powered music recommendations for niche and lesser-known artists. Combines co
 
 ## Glossary
 
-- **Recommendation pipeline** — the end-to-end flow that turns a user query (plus optional preference context) into final recommendation items.
+- **Recommendation pipeline** — the end-to-end flow that turns a user query (plus optional preference context) into final recommendation items. The only pipeline is the research pipeline (Brave + LangGraph + MusicBrainz); there is no classic fallback. `BRAVE_API_KEY` is required.
+
+- **Research graph** — the LangGraph state machine in `agent/research/researchGraph.ts` that orchestrates: web search planning, Brave search execution, candidate extraction, MusicBrainz verification, optional reflection, and final ranking.
+
+- **Search plan** — the structured output of the `plan` node: a list of targeted Brave search queries derived from the user's taste (FFO/Bandcamp-style signals, anchor artists, style descriptors).
+
+- **Extracted candidate** — a band name pulled from Brave search snippets by the `extract` node. Not yet verified against MusicBrainz.
+
+- **Verified candidate** — an extracted candidate confirmed by MusicBrainz `lookupArtist` and enriched with `mbid`, genres, tags, and URL relations.
+
+- **Reflection subgraph** — a nested LangGraph subgraph that runs up to `maxRounds` additional search-extract-verify cycles when the initial pass yields fewer than `RESEARCH_TARGET_VERIFIED_CANDIDATES` verified hits.
+
+- **Research budget** — a wall-clock time limit (`RESEARCH_TIMEOUT_MS`) shared across all graph nodes. When exhausted, conditional edges route directly to `END` gracefully instead of timing out mid-flight.
+
+- **Preference context** — a formatted string built from the user's saved bands (ratings, categories, notes) and injected into Gemini prompts for `preference-aware` mode recommendations.
+
+- **Obscurity target** — a user-selectable signal (`Cult Following` / `Underground` / `Truly Obscure`) passed to the planner to tune search queries toward less or more obscure artists. Stored per recommendation event.
+
+- **Eval layer** — an async, non-blocking quality-scoring system that runs after the HTTP response is sent. Three tiers: (1) automatic metrics — Last.fm obscurity score and pipeline funnel counts; (1.5) deterministic checks — citation support rate and generic-why detection; (2) LLM-as-judge — Claude scores each band asynchronously (optional, requires `ANTHROPIC_API_KEY`).
+
+- **LLM-as-judge** — an async eval worker using Claude to score each recommended band on relevance, obscurity fit, evidence quality, and discovery value. Only active when `ANTHROPIC_API_KEY` is set; never on the critical response path.
+
+- **Golden dataset** — a curated set of queries in `services/eval/golden-set.json` with expected `nuggets` (bands that should appear) and `antiBands` (bands that should not). The eval runner (`run-golden.ts`) computes `antiBandRate@8` and fails CI if it exceeds 50%.
+
+- **Progressive auth** — a three-mode auth scheme determined at runtime by the number of registered users: 0 users → pass-through (no token needed), 1 user → auto-attach (all requests associated with the single user), ≥2 users → JWT enforced (`Authorization: Bearer <token>`).
+
+- **Preference repository** — the abstract storage interface for saved bands, artist groups, and user accounts. Concrete adapters: SQLite (`better-sqlite3`), Postgres, Turso/libSQL, and in-memory.
+
+- **Session store** — separate from the preference store; holds `chat_sessions` and `chat_messages`. Currently only has a SQLite and in-memory adapter (Turso adapter is planned in Phase 9).
+
+- **Sidecar** — the Node.js API process spawned as a child process by the Tauri desktop shell. In development, it uses the system `node`. In production bundles, a bundled Node binary named `node-<target-triple>[.exe]` is expected in `apps/desktop/src-tauri/binaries/`.

--- a/README.md
+++ b/README.md
@@ -192,7 +192,9 @@ Turso URL and auth token can also be saved through the **Settings** screen in th
 | `RECOMMENDATION_PIPELINE_READY_TIMEOUT_MS` | `45000` | Max wait before HTTP listen while the pipeline initializes |
 | `MUSICBRAINZ_TIMEOUT_MS` | `5000` | MusicBrainz request timeout |
 | `MUSICBRAINZ_RETRIES` | `1` | MusicBrainz retry attempts |
-| `LASTFM_API_KEY` | — | Optional — Last.fm fallback for artist images |
+| `LASTFM_API_KEY` | — | Optional — Last.fm fallback for artist images and obscurity scoring (listener counts) |
+| `ANTHROPIC_API_KEY` | — | Optional — activates the async LLM-as-judge eval worker (Claude scores recommendations after the response is sent) |
+| `EVAL_DASHBOARD_ENABLED` | — | Set `true` to enable the developer eval dashboard at `/eval/dashboard` |
 | `LANGSMITH_API_KEY` | — | Optional LangSmith tracing |
 | `LANGSMITH_TRACING` | — | Set `true` to enable tracing |
 | `LANGSMITH_PROJECT` | — | LangSmith project name |
@@ -285,6 +287,15 @@ Response includes `recommendations`, optional `assistantReply` (conversational p
 | `GET` | `/artists/search?query=...` | Search artists via MusicBrainz |
 | `GET` | `/artists/image?name=...` | Resolve artist image URL (Wikidata + Last.fm fallback) |
 
+### Eval
+
+Requires `EVAL_DASHBOARD_ENABLED=true` in the environment.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/eval/dashboard` | Developer quality dashboard — pipeline funnel, obscurity distribution, LLM-judge alignment, trend charts, and event log |
+| `POST` | `/eval/baseline` | Save a named snapshot of current aggregated metrics for before/after comparison |
+
 ---
 
 ## Development
@@ -309,6 +320,7 @@ Tests run automatically before every commit via a pre-commit hook (installed by 
 ```
 apps/desktop/     — Tauri + React desktop client
 services/api/     — Express API
+services/eval/    — golden dataset and eval runner (anti-band gate, nugget coverage)
 shared/schemas/   — shared validation contracts (TypeScript contracts.ts + tests)
 docs/             — architecture docs, ADRs, design specs, roadmap
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,3 +23,13 @@ Navigation guide for the `docs/` folder.
 - **Changing the UI?** Consult [UI_GUIDELINES.md](design/UI_GUIDELINES.md) before writing new components.
 - **Security or prompt design?** See [ADR 0001](adr/0001-prompt-injection-guardrails.md) for the injection defence rationale.
 - **Planning a new feature?** Check [ROADMAP.md](ROADMAP.md) for phase status and open steps before starting.
+
+## Historical planning docs
+
+The `superpowers/` folder contains implementation plans and design specs from earlier development phases. These are reference material, not actively maintained.
+
+| Path | What it covers |
+|------|----------------|
+| [superpowers/plans/2026-04-30-ui-redesign.md](superpowers/plans/2026-04-30-ui-redesign.md) | UI redesign plan (Phase 3 era) |
+| [superpowers/specs/2026-04-30-tauri-scaffold-design.md](superpowers/specs/2026-04-30-tauri-scaffold-design.md) | Tauri desktop scaffold design spec |
+| [superpowers/specs/2026-05-12-llm-musicbrainz-query-design.md](superpowers/specs/2026-05-12-llm-musicbrainz-query-design.md) | LLM + MusicBrainz query design spec |


### PR DESCRIPTION
## What changed and why

Phase 8 (Eval & Quality Observability) is fully shipped but the README and CONTEXT.md did not reflect it. This PR brings the documentation up to date with the actual state of the codebase — no code changes.

### README.md

- **Env vars table**: Added `ANTHROPIC_API_KEY` (LLM-as-judge eval worker) and `EVAL_DASHBOARD_ENABLED` (developer dashboard gate), both introduced in Phase 8. Fixed the `LASTFM_API_KEY` description — it was listed only as "artist image fallback" but it also drives Phase 8 obscurity scoring.
- **API Reference**: Added an **Eval** section documenting `GET /eval/dashboard` and `POST /eval/baseline`, which exist in the codebase but were missing from the docs.
- **Monorepo Structure**: Added `services/eval/` (golden dataset + eval runner) to the tree.

### CONTEXT.md

The glossary had a single entry. It now covers all key domain terms so both humans and LLMs new to the repo have a shared vocabulary: recommendation pipeline, research graph, extracted/verified candidate, reflection subgraph, research budget, preference context, obscurity target, eval layer, LLM-as-judge, golden dataset, progressive auth, preference repository, session store, and sidecar.

### docs/README.md

Added a **Historical planning docs** section at the bottom listing the `superpowers/` folder contents (UI redesign plan, Tauri scaffold spec, LLM + MusicBrainz query design spec). These existed but had no entry point in the nav guide.

## What was intentionally not changed

- `docs/architecture/ARCHITECTURE.md` — already accurate and up to date.
- `docs/ROADMAP.md` — all Phase 8 steps already marked ✓ Done; Phase 9 laid out correctly.
- `CONTRIBUTING.md`, `AGENTS.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md` — all current, no changes needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_0151FF1UC1YNpAkbr99p3yL8)_