### PR TITLE
docs: add 2026-06-03 weekly maintenance note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,16 @@ docs/             — architecture docs, ADRs, design specs, roadmap
 
 In development (browser or embedded webview), the chat UI chooses **mobile vs desktop layout** from window width (`matchMedia`, max-width **767px**), so you do not need to pass a `viewport` option manually when resizing the window.
 
+---
+
+## Maintenance notes
+
+**2026-06-03 — Weekly maintenance**
+
+All CI checks pass on `ubuntu-latest` and `windows-latest`. No dependency updates required — all packages are at current versions (TypeScript 6, ESLint 10, Express 5, Zod 4, `@langchain/google-genai` 2.x, Tauri 2.x). No outstanding action required.
+
+---
+
 ## Acknowledgements
 
 - [MusicBrainz](https://musicbrainz.org) — open music encyclopedia providing artist and release metadata. Data used under the [CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/) licence.


### PR DESCRIPTION
## Weekly maintenance check — 2026-06-03\n\n### What was checked\n\nAll three repositories were reviewed for broken CI, outdated dependencies, and general health.\n\n---\n\n## Changes in this PR\n\n### 📄 README — Maintenance notes section added\n\nAdded a new `## Maintenance notes` section to the README (between Monorepo Structure and Acknowledgements) with a `2026-06-03` entry noting the healthy state of the repository.\n\n---\n\n## Health summary (no other action needed)\n\n| Area | Status |\n|---|---|\n| CI (last 5 runs, ubuntu + windows matrix) | ✅ All passing |\n| TypeScript | ✅ 6.x |\n| ESLint | ✅ 10.x |\n| Express | ✅ 5.x |\n| Zod | ✅ 4.x |\n| `@langchain/google-genai` | ✅ 2.x |\n| `@langchain/langgraph` | ✅ 1.x |\n| Tauri | ✅ 2.x |\n| GitHub Actions (checkout@v6, setup-node@v6, setup-python@v6) | ✅ Current |\n\nNo dependency updates or code changes are required at this time.\n

---
_Generated by [Claude Code](https://claude.ai/code/session_018orkZfmNyor4fZmoQKqFAR)_