### PR TITLE
feat(sessions): add Turso chat session repository (Phase 9.1)

### DIFF
--- a/services/api/migrations/002_full_schema.sql
+++ b/services/api/migrations/002_full_schema.sql
@@ -1,0 +1,112 @@
+-- Full schema for Turso/libSQL deployment.
+-- All tables use CREATE TABLE IF NOT EXISTS so the script is safe to run
+-- against a database that already has some tables created.
+
+CREATE TABLE IF NOT EXISTS users (
+  id                 TEXT PRIMARY KEY,
+  email              TEXT NOT NULL UNIQUE,
+  display_name       TEXT NOT NULL,
+  password_hash      TEXT NOT NULL,
+  recovery_code_hash TEXT NOT NULL,
+  created_at         TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS saved_bands (
+  id                     TEXT PRIMARY KEY,
+  user_id                TEXT NOT NULL DEFAULT 'anonymous',
+  musicbrainz_artist_id  TEXT NOT NULL,
+  name                   TEXT NOT NULL,
+  rating                 INTEGER NOT NULL CHECK (rating >= 1 AND rating <= 5),
+  categories             TEXT NOT NULL DEFAULT '[]',
+  note                   TEXT NOT NULL DEFAULT '',
+  created_at             TEXT NOT NULL,
+  updated_at             TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS artist_groups (
+  id         TEXT PRIMARY KEY,
+  user_id    TEXT NOT NULL DEFAULT 'anonymous',
+  name       TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS artist_group_members (
+  group_id      TEXT NOT NULL REFERENCES artist_groups(id) ON DELETE CASCADE,
+  saved_band_id TEXT NOT NULL REFERENCES saved_bands(id) ON DELETE CASCADE,
+  added_at      TEXT NOT NULL,
+  PRIMARY KEY (group_id, saved_band_id)
+);
+
+CREATE TABLE IF NOT EXISTS chat_sessions (
+  id         TEXT PRIMARY KEY,
+  user_id    TEXT NOT NULL DEFAULT 'anonymous',
+  title      TEXT NOT NULL DEFAULT 'Untitled',
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS chat_messages (
+  id         TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL REFERENCES chat_sessions(id),
+  role       TEXT NOT NULL,
+  content    TEXT NOT NULL,
+  created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_chat_messages_session_id ON chat_messages (session_id);
+
+CREATE TABLE IF NOT EXISTS recommendation_events (
+  id                    TEXT PRIMARY KEY,
+  session_id            TEXT,
+  query                 TEXT NOT NULL,
+  mode                  TEXT NOT NULL,
+  obscurity_target      TEXT,
+  pipeline_version      TEXT NOT NULL,
+  brave_hit_count       INTEGER NOT NULL DEFAULT 0,
+  extracted_count       INTEGER NOT NULL DEFAULT 0,
+  verified_count        INTEGER NOT NULL DEFAULT 0,
+  reflection_triggered  INTEGER NOT NULL DEFAULT 0,
+  search_budget_used    INTEGER NOT NULL DEFAULT 0,
+  recommendation_count  INTEGER NOT NULL DEFAULT 0,
+  created_at            TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS band_eval_scores (
+  id                    TEXT PRIMARY KEY,
+  event_id              TEXT NOT NULL REFERENCES recommendation_events(id),
+  band_name             TEXT NOT NULL,
+  listeners             INTEGER,
+  obscurity_tier        TEXT,
+  source_quality        TEXT,
+  citation_support_rate REAL,
+  generic_why_flag      INTEGER,
+  relevance             REAL,
+  obscurity_fit         REAL,
+  evidence_quality      REAL,
+  discovery_value       REAL,
+  judge_reasoning       TEXT,
+  judge_prompt_hash     TEXT,
+  model_id              TEXT,
+  created_at            TEXT NOT NULL,
+  UNIQUE(event_id, band_name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_band_eval_scores_event_id ON band_eval_scores (event_id);
+
+CREATE TABLE IF NOT EXISTS recommendation_feedback (
+  id            TEXT PRIMARY KEY,
+  event_id      TEXT NOT NULL REFERENCES recommendation_events(id),
+  user_id       TEXT NOT NULL DEFAULT 'anonymous',
+  feedback_type TEXT NOT NULL,
+  created_at    TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_recommendation_feedback_event_id ON recommendation_feedback (event_id);
+
+CREATE TABLE IF NOT EXISTS eval_baselines (
+  id           TEXT PRIMARY KEY,
+  label        TEXT NOT NULL,
+  metrics_json TEXT NOT NULL,
+  created_at   TEXT NOT NULL
+);

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -4,11 +4,11 @@
   "private": true,
   "description": "Bandsearch Express API",
   "scripts": {
-    "lint": "eslint \"src/**/*.{js,ts}\" \"test/**/*.{js,ts}\" --max-warnings=0 --no-error-on-unmatched-pattern",
+    "lint": "eslint \"src/**/*.{js,ts}\" \"test/**/*.{js,ts}\" \"scripts/**/*.ts\" --max-warnings=0 --no-error-on-unmatched-pattern",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "test": "tsx --test",
-    "migrate": "node scripts/migrate.js",
-    "create-user": "node scripts/create-user.js"
+    "migrate": "tsx scripts/migrate.ts",
+    "create-user": "tsx scripts/create-user.ts"
   },
   "dependencies": {
     "@langchain/google-genai": "^2.1.31",

--- a/services/api/scripts/create-user.ts
+++ b/services/api/scripts/create-user.ts
@@ -1,17 +1,17 @@
-#!/usr/bin/env node
+#!/usr/bin/env tsx
 // Creates a user directly in the database (SQLite or Turso).
 // Usage:
-//   node scripts/create-user.js --email user@example.com --name "Max" --password "secret"
+//   tsx scripts/create-user.ts --email user@example.com --name "Max" --password "secret"
 // For Turso:
-//   PREFERENCE_STORE=turso TURSO_DATABASE_URL=... TURSO_AUTH_TOKEN=... node scripts/create-user.js ...
+//   PREFERENCE_STORE=turso TURSO_DATABASE_URL=... TURSO_AUTH_TOKEN=... tsx scripts/create-user.ts ...
 
-require("dotenv").config();
-const { randomUUID, randomBytes } = require("node:crypto");
-const bcrypt = require("bcryptjs");
+import "dotenv/config";
+import { randomUUID, randomBytes } from "node:crypto";
+import bcrypt from "bcryptjs";
 
-function parseArgs() {
+function parseArgs(): { email?: string; name?: string; password?: string } {
   const args = process.argv.slice(2);
-  const result = {};
+  const result: Record<string, string> = {};
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--email") result.email = args[++i];
     else if (args[i] === "--name") result.name = args[++i];
@@ -20,14 +20,14 @@ function parseArgs() {
   return result;
 }
 
-function generateRecoveryCode() {
+function generateRecoveryCode(): string {
   const hex = randomBytes(20).toString("hex");
-  return hex.match(/.{1,5}/g).join("-");
+  return (hex.match(/.{1,5}/g) ?? []).join("-");
 }
 
-async function createUserSqlite({ email, name, password }) {
-  const Database = require("better-sqlite3");
-  const path = require("node:path");
+async function createUserSqlite({ email, name, password }: { email: string; name: string; password: string }) {
+  const Database = (await import("better-sqlite3")).default;
+  const path = await import("node:path");
   const dbPath = process.env.SQLITE_PATH ?? path.join(__dirname, "..", "bandsearch.db");
   const db = new Database(dbPath);
 
@@ -39,17 +39,17 @@ async function createUserSqlite({ email, name, password }) {
   const createdAt = new Date().toISOString();
 
   db.prepare(
-    "INSERT INTO users (id, email, display_name, password_hash, recovery_code_hash, created_at) VALUES (?, ?, ?, ?, ?, ?)"
+    "INSERT INTO users (id, email, display_name, password_hash, recovery_code_hash, created_at) VALUES (?, ?, ?, ?, ?, ?)",
   ).run(id, normalizedEmail, name, passwordHash, recoveryCodeHash, createdAt);
 
   db.close();
   return { id, email: normalizedEmail, recoveryCode };
 }
 
-async function createUserTurso({ email, name, password }) {
-  const { createClient } = require("@libsql/client");
+async function createUserTurso({ email, name, password }: { email: string; name: string; password: string }) {
+  const { createClient } = await import("@libsql/client");
   const client = createClient({
-    url: process.env.TURSO_DATABASE_URL,
+    url: process.env.TURSO_DATABASE_URL ?? "",
     authToken: process.env.TURSO_AUTH_TOKEN ?? "",
   });
 
@@ -69,11 +69,11 @@ async function createUserTurso({ email, name, password }) {
   return { id, email: normalizedEmail, recoveryCode };
 }
 
-async function main() {
+async function main(): Promise<void> {
   const { email, name, password } = parseArgs();
 
   if (!email || !name || !password) {
-    console.error("Usage: node scripts/create-user.js --email <email> --name <name> --password <password>");
+    console.error("Usage: tsx scripts/create-user.ts --email <email> --name <name> --password <password>");
     process.exitCode = 1;
     return;
   }
@@ -89,7 +89,7 @@ async function main() {
     console.log(`\nRecovery code (save this — it won't be shown again):`);
     console.log(`  ${user.recoveryCode}\n`);
   } catch (err) {
-    console.error("Error:", err.message);
+    console.error("Error:", err instanceof Error ? err.message : String(err));
     process.exitCode = 1;
   }
 }

--- a/services/api/scripts/migrate.ts
+++ b/services/api/scripts/migrate.ts
@@ -1,9 +1,10 @@
-require("dotenv").config();
-const fs = require("node:fs/promises");
-const path = require("node:path");
-const { Pool } = require("pg");
+import "dotenv/config";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { Pool } from "pg";
+import { createClient } from "@libsql/client";
 
-async function migratePostgres() {
+async function migratePostgres(): Promise<void> {
   const databaseUrl = process.env.DATABASE_URL;
   if (!databaseUrl) {
     throw new Error("DATABASE_URL is required to run migrations");
@@ -25,31 +26,30 @@ async function migratePostgres() {
   }
 }
 
-async function migrateTurso() {
+async function migrateTurso(): Promise<void> {
   const databaseUrl = process.env.TURSO_DATABASE_URL;
   if (!databaseUrl) {
     throw new Error("TURSO_DATABASE_URL is required to run Turso migrations");
   }
 
-  const { createClient } = require("@libsql/client");
   const client = createClient({
     url: databaseUrl,
-    authToken: process.env.TURSO_AUTH_TOKEN || "",
+    authToken: process.env.TURSO_AUTH_TOKEN ?? "",
   });
 
-  const migrationPath = path.join(__dirname, "..", "migrations", "001_create_saved_bands_sqlite.sql");
+  const migrationPath = path.join(__dirname, "..", "migrations", "002_full_schema.sql");
   const sql = await fs.readFile(migrationPath, "utf8");
 
   try {
     await client.executeMultiple(sql);
-    console.log("Migration applied: 001_create_saved_bands_sqlite.sql");
+    console.log("Migration applied: 002_full_schema.sql");
   } finally {
     client.close();
   }
 }
 
-async function runMigrations() {
-  const store = process.env.PREFERENCE_STORE || "sqlite";
+async function runMigrations(): Promise<void> {
+  const store = process.env.PREFERENCE_STORE ?? "sqlite";
   if (store === "turso") {
     await migrateTurso();
   } else {
@@ -57,7 +57,7 @@ async function runMigrations() {
   }
 }
 
-runMigrations().catch((error) => {
+runMigrations().catch((error: Error) => {
   console.error(error.message);
   process.exitCode = 1;
 });

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -26,6 +26,7 @@ import { createMusicBrainzClient } from "./integrations/musicbrainz.js";
 import { createWikidataImageClient } from "./integrations/wikidataImageClient.js";
 import { assertPreferenceRepository, createPreferenceRepository } from "./preferences/preferenceRepository.js";
 import { createInMemoryChatSessionRepository, createSqliteChatSessionRepository } from "./sessions/chatSessionRepository.js";
+import { createTursoChatSessionRepository } from "./sessions/tursoChatSessionRepository.js";
 import { createSqliteUserRepository, createInMemoryUserRepository } from "./auth/userRepository.js";
 import { createTursoUserRepository } from "./auth/tursoUserRepository.js";
 import { createAuthService } from "./auth/authService.js";
@@ -140,6 +141,13 @@ export function createApp({
   const resolvedChatSessionRepository =
     chatSessionRepository ||
     (() => {
+      if (runtimeConfig.preferenceStore === "turso") {
+        const client = createClient({
+          url: runtimeConfig.tursoDatabaseUrl ?? "",
+          authToken: runtimeConfig.tursoAuthToken,
+        });
+        return createTursoChatSessionRepository({ client });
+      }
       try {
         const db = new Database(runtimeConfig.databasePath || "bandsearch.db");
         return createSqliteChatSessionRepository({ db });

--- a/services/api/src/sessions/tursoChatSessionRepository.ts
+++ b/services/api/src/sessions/tursoChatSessionRepository.ts
@@ -1,0 +1,61 @@
+import { randomUUID } from "node:crypto";
+import type { Client as LibSQLClient } from "@libsql/client";
+
+const DEFAULT_USER = "anonymous";
+const DEFAULT_TITLE = "Untitled";
+
+export function createTursoChatSessionRepository({ client }: { client: LibSQLClient }) {
+  return {
+    async createSession({ title = DEFAULT_TITLE } = {}, userId = DEFAULT_USER) {
+      const id = randomUUID();
+      const now = new Date().toISOString();
+      const result = await client.execute({
+        sql: `INSERT INTO chat_sessions (id, title, user_id, created_at, updated_at)
+              VALUES (?, ?, ?, ?, ?)
+              RETURNING *`,
+        args: [id, title, userId, now, now],
+      });
+      return result.rows[0];
+    },
+
+    async listSessions(userId = DEFAULT_USER) {
+      const result = await client.execute({
+        sql: "SELECT * FROM chat_sessions WHERE user_id = ? ORDER BY updated_at DESC",
+        args: [userId],
+      });
+      return result.rows;
+    },
+
+    async getSession(id: string, userId = DEFAULT_USER) {
+      const result = await client.execute({
+        sql: "SELECT * FROM chat_sessions WHERE id = ? AND user_id = ?",
+        args: [id, userId],
+      });
+      return result.rows.length > 0 ? result.rows[0] : null;
+    },
+
+    async addMessage(sessionId: string, { role, content }: { role: string; content: string }) {
+      const id = randomUUID();
+      const now = new Date().toISOString();
+      const result = await client.execute({
+        sql: `INSERT INTO chat_messages (id, session_id, role, content, created_at)
+              VALUES (?, ?, ?, ?, ?)
+              RETURNING *`,
+        args: [id, sessionId, role, String(content), now],
+      });
+      await client.execute({
+        sql: "UPDATE chat_sessions SET updated_at = ? WHERE id = ?",
+        args: [now, sessionId],
+      });
+      return result.rows[0];
+    },
+
+    async getMessages(sessionId: string) {
+      const result = await client.execute({
+        sql: "SELECT * FROM chat_messages WHERE session_id = ? ORDER BY created_at ASC",
+        args: [sessionId],
+      });
+      return result.rows;
+    },
+  };
+}

--- a/services/api/test/turso-chat-session-repository.test.js
+++ b/services/api/test/turso-chat-session-repository.test.js
@@ -1,0 +1,189 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { createTursoChatSessionRepository } = require("../src/sessions/tursoChatSessionRepository");
+
+function makeSessionRow(overrides = {}) {
+  return {
+    id: "sess-1",
+    user_id: "user-a",
+    title: "Test session",
+    created_at: "2026-01-01T10:00:00.000Z",
+    updated_at: "2026-01-01T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeMessageRow(overrides = {}) {
+  return {
+    id: "msg-1",
+    session_id: "sess-1",
+    role: "user",
+    content: "I like atmospheric black metal",
+    created_at: "2026-01-01T10:01:00.000Z",
+    ...overrides,
+  };
+}
+
+test("turso session repository: createSession inserts and returns row", async () => {
+  const row = makeSessionRow({ title: "New session" });
+  const calls = [];
+  const repo = createTursoChatSessionRepository({
+    client: {
+      execute: async (stmt) => {
+        calls.push(stmt);
+        return { rows: [row], rowsAffected: 1 };
+      },
+    },
+  });
+
+  const result = await repo.createSession({ title: "New session" }, "user-a");
+
+  assert.equal(result.id, "sess-1");
+  assert.equal(result.title, "New session");
+  assert.ok(result.created_at, "created_at must be set");
+  assert.equal(calls.length, 1);
+  assert.ok(calls[0].sql.includes("INSERT INTO chat_sessions"), "must issue INSERT");
+});
+
+test("turso session repository: createSession uses default title and user", async () => {
+  const calls = [];
+  const repo = createTursoChatSessionRepository({
+    client: {
+      execute: async (stmt) => {
+        calls.push(stmt);
+        return { rows: [makeSessionRow()], rowsAffected: 1 };
+      },
+    },
+  });
+
+  await repo.createSession();
+
+  const args = calls[0].args;
+  assert.equal(args[1], "Untitled");
+  assert.equal(args[2], "anonymous");
+});
+
+test("turso session repository: listSessions queries by userId", async () => {
+  const rows = [
+    makeSessionRow({ id: "s-1", title: "A" }),
+    makeSessionRow({ id: "s-2", title: "B" }),
+  ];
+  const calls = [];
+  const repo = createTursoChatSessionRepository({
+    client: {
+      execute: async (stmt) => {
+        calls.push(stmt);
+        return { rows, rowsAffected: 0 };
+      },
+    },
+  });
+
+  const result = await repo.listSessions("user-a");
+
+  assert.equal(result.length, 2);
+  assert.ok(calls[0].sql.includes("SELECT"), "must issue SELECT");
+  assert.ok(calls[0].args.includes("user-a"), "must filter by userId");
+});
+
+test("turso session repository: getSession returns row when found", async () => {
+  const row = makeSessionRow({ id: "sess-1" });
+  const repo = createTursoChatSessionRepository({
+    client: { execute: async () => ({ rows: [row], rowsAffected: 0 }) },
+  });
+
+  const result = await repo.getSession("sess-1", "user-a");
+
+  assert.equal(result.id, "sess-1");
+});
+
+test("turso session repository: getSession returns null when not found", async () => {
+  const repo = createTursoChatSessionRepository({
+    client: { execute: async () => ({ rows: [], rowsAffected: 0 }) },
+  });
+
+  const result = await repo.getSession("does-not-exist", "user-a");
+
+  assert.equal(result, null);
+});
+
+test("turso session repository: getSession scopes by userId", async () => {
+  const calls = [];
+  const repo = createTursoChatSessionRepository({
+    client: {
+      execute: async (stmt) => {
+        calls.push(stmt);
+        return { rows: [], rowsAffected: 0 };
+      },
+    },
+  });
+
+  await repo.getSession("sess-1", "user-b");
+
+  assert.ok(calls[0].args.includes("user-b"), "must include userId in query args");
+});
+
+test("turso session repository: addMessage inserts message and updates session", async () => {
+  const msgRow = makeMessageRow({ content: "I like Alcest" });
+  let callCount = 0;
+  const calls = [];
+  const repo = createTursoChatSessionRepository({
+    client: {
+      execute: async (stmt) => {
+        calls.push(stmt);
+        callCount++;
+        return { rows: callCount === 1 ? [msgRow] : [], rowsAffected: 1 };
+      },
+    },
+  });
+
+  const result = await repo.addMessage("sess-1", { role: "user", content: "I like Alcest" });
+
+  assert.equal(result.id, "msg-1");
+  assert.equal(result.role, "user");
+  assert.equal(result.content, "I like Alcest");
+  assert.ok(result.created_at, "created_at must be set");
+  assert.equal(calls.length, 2, "must INSERT message and UPDATE session");
+  assert.ok(calls[0].sql.includes("INSERT INTO chat_messages"), "first call must INSERT");
+  assert.ok(calls[1].sql.includes("UPDATE chat_sessions"), "second call must UPDATE session timestamp");
+});
+
+test("turso session repository: getMessages returns ordered rows", async () => {
+  const rows = [
+    makeMessageRow({ id: "m-1", created_at: "2026-01-01T10:00:00.000Z" }),
+    makeMessageRow({ id: "m-2", created_at: "2026-01-01T10:01:00.000Z" }),
+  ];
+  const calls = [];
+  const repo = createTursoChatSessionRepository({
+    client: {
+      execute: async (stmt) => {
+        calls.push(stmt);
+        return { rows, rowsAffected: 0 };
+      },
+    },
+  });
+
+  const result = await repo.getMessages("sess-1");
+
+  assert.equal(result.length, 2);
+  assert.ok(calls[0].sql.includes("SELECT"), "must issue SELECT");
+  assert.ok(calls[0].args.includes("sess-1"), "must filter by sessionId");
+});
+
+// --- User isolation ---
+
+test("turso session repository: listSessions scopes by user", async () => {
+  const calls = [];
+  const repo = createTursoChatSessionRepository({
+    client: {
+      execute: async (stmt) => {
+        calls.push(stmt);
+        return { rows: [], rowsAffected: 0 };
+      },
+    },
+  });
+
+  await repo.listSessions("user-c");
+
+  assert.ok(calls[0].args.includes("user-c"), "must pass userId as filter arg");
+});

--- a/services/api/test/turso-full-schema.test.js
+++ b/services/api/test/turso-full-schema.test.js
@@ -1,0 +1,48 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs/promises");
+const path = require("node:path");
+
+const SCHEMA_PATH = path.join(__dirname, "..", "migrations", "002_full_schema.sql");
+
+const REQUIRED_TABLES = [
+  "saved_bands",
+  "artist_groups",
+  "artist_group_members",
+  "users",
+  "chat_sessions",
+  "chat_messages",
+  "recommendation_events",
+  "band_eval_scores",
+  "recommendation_feedback",
+  "eval_baselines",
+];
+
+test("002_full_schema.sql exists and creates all required tables", async () => {
+  const sql = await fs.readFile(SCHEMA_PATH, "utf8");
+
+  for (const table of REQUIRED_TABLES) {
+    assert.ok(
+      sql.includes(`CREATE TABLE IF NOT EXISTS ${table}`),
+      `schema must contain CREATE TABLE IF NOT EXISTS ${table}`,
+    );
+  }
+});
+
+test("002_full_schema.sql: saved_bands has user_id column", async () => {
+  const sql = await fs.readFile(SCHEMA_PATH, "utf8");
+  const savedBandsBlock = sql.slice(sql.indexOf("CREATE TABLE IF NOT EXISTS saved_bands"));
+  assert.ok(savedBandsBlock.includes("user_id"), "saved_bands must have user_id column");
+});
+
+test("002_full_schema.sql: chat_sessions has user_id column", async () => {
+  const sql = await fs.readFile(SCHEMA_PATH, "utf8");
+  const block = sql.slice(sql.indexOf("CREATE TABLE IF NOT EXISTS chat_sessions"));
+  assert.ok(block.includes("user_id"), "chat_sessions must have user_id column");
+});
+
+test("002_full_schema.sql: artist_group_members has ON DELETE CASCADE", async () => {
+  const sql = await fs.readFile(SCHEMA_PATH, "utf8");
+  const block = sql.slice(sql.indexOf("CREATE TABLE IF NOT EXISTS artist_group_members"));
+  assert.ok(block.includes("ON DELETE CASCADE"), "artist_group_members must have cascade deletes");
+});

--- a/services/api/tsconfig.json
+++ b/services/api/tsconfig.json
@@ -12,5 +12,5 @@
     "types": ["node"],
     "noEmit": true
   },
-  "include": ["src/**/*.js", "src/**/*.ts"]
+  "include": ["src/**/*.js", "src/**/*.ts", "scripts/**/*.ts"]
 }


### PR DESCRIPTION
Implements `createTursoChatSessionRepository` using `@libsql/client`,
mirroring the SQLite adapter. Wires it into the app factory so that
`PREFERENCE_STORE=turso` now selects the Turso adapter for sessions —
making the session layer fully Turso-backed alongside preferences and
users. Includes mock-client unit tests covering all five operations and
user-scoping behaviour.

https://claude.ai/code/session_01E2ppjMHRhHjDybxpbqyG2y