### PR TITLE
fix(eval): Phase 8 review follow-ups — judge thresholds (F3) and obscurity distribution (F4)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -98,6 +98,11 @@ Three-layer system to measure recommendation quality over time: automatic obscur
 **Future (after data exists):**
 - `search_quality_check` node in LangGraph loop: if search source quality is low, planner receives feedback and regenerates queries before extraction — only worth building once dashboard data confirms the correlation
 
+**Polish — deferred from the 2026-06-01 implementation review** (see `docs/architecture/2026-05-30-phase8-implementation-plan.md`, findings F1–F8; F1–F5 already fixed):
+- [ ] F6 — Reconcile the plan's stale Design Decision #2: `evalWorker.processEvent` is invoked from `routes/registerBandsearchRoutes.ts`, not `recommendationPipeline.ts`. Docs-only; update the architecture spec so it matches the code.
+- [ ] F7 — Event table stores no `recommendations_json`, prompt hashes, model ids, or `user_id`, so the dashboard cannot link to the full recommendation payload and baselines cannot be filtered by prompt hash / model. Add at least `recommendations_json` + `user_id` to `recommendation_events`; treat prompt-hash filtering as a separate later step. (`eval/evalRepository.ts`)
+- [ ] F8 — Tune evidence heuristics: `GENERIC_PHRASES` flags common comparison phrasing ("fans of", "similar to", "in the vein of") that also appears in good why-text → noisy `generic_why_flag`; and `citationSupportRate` defaults to 1.0 when a why has no URLs, inflating evidence metrics. Only flag generic phrasing when it co-occurs with zero citations; distinguish "no URLs" from "all URLs supported". Validate against the calibration set before locking in. (`eval/evidenceChecker.ts`)
+
 ---
 
 ## Phase 9 — Cloud Deployment (Render + Turso)

--- a/docs/architecture/2026-05-30-phase8-implementation-plan.md
+++ b/docs/architecture/2026-05-30-phase8-implementation-plan.md
@@ -43,11 +43,11 @@ effect on recommendations or on the logged data.
 
 | # | Severity | Finding | Where |
 |---|----------|---------|-------|
-| F1 | 🔴 Critical | `validation.obscurityTarget` is computed but **never passed** to `recommend()` **nor** to `evalWorker.processEvent()`. Planner never receives the constraint; `obscurity_target` column is always NULL. | `routes/registerBandsearchRoutes.ts` (`POST /recommendations`) |
-| F2 | 🔴 Critical | `ObscurityTargetPicker.ts` exists but is **never imported/rendered** in `ChatAppView`; no caller passes `obscurityTarget` into `chatClient`. The user cannot set a target. | `apps/desktop/src/ui/` |
-| F3 | 🟠 Medium | Judge system prompt states "cult < 500k, underground < 100k, obscure < 10k" — **contradicts** `obscurityScorer.ts` (cult 20k–500k, underground 2k–20k, obscure < 2k). Calibration measures the judge against a different definition than the deterministic tier. | `eval/judgeWorker.ts` vs `eval/obscurityScorer.ts` |
-| F4 | 🟠 Medium | `obscurityDistribution` counts only cult/underground/obscure — **drops `mainstream` and `unknown`**, hiding the "too mainstream" signal that justifies the whole layer. | `eval/evalAggregator.ts` |
-| F5 | 🟠 Medium (blocks 8.8) | `eventId` is generated inside `processEvent` (fire-and-forget) and **never reaches the HTTP response**, so feedback in 8.8 has nothing to bind to. | `eval/evalWorker.ts`, route |
+| F1 | ✅ Fixed (8.3b) | `validation.obscurityTarget` was computed but **never passed** to `recommend()` nor `processEvent()`. Now forwarded at both call sites. | `routes/registerBandsearchRoutes.ts` (`POST /recommendations`) |
+| F2 | ✅ Fixed (8.3b) | `ObscurityTargetPicker` is now imported/rendered in `ChatAppView`; the model holds the target (default `underground`) and passes it to `chatClient`. | `apps/desktop/src/ui/` |
+| F3 | ✅ Fixed | Judge prompt thresholds now derived from `OBSCURITY_THRESHOLDS` (single source of truth); `obscurityTier` passed into `JudgeInput`. Re-run `run-calibration.ts` (prompt hash changed). | `eval/judgeWorker.ts` |
+| F4 | ✅ Fixed | `obscurityDistribution` now counts all five tiers incl. `mainstream` + `unknown`; dashboard doughnut shows mainstream in red. | `eval/evalAggregator.ts`, dashboard |
+| F5 | ✅ Fixed (8.8) | `eventId` is pre-generated in the route and returned in response `meta`; `logEvent` accepts a supplied id. | `eval/evalWorker.ts`, route |
 | F6 | 🟡 Low | Integration point moved: `processEvent` is called from `registerBandsearchRoutes.ts`, not `recommendationPipeline.ts`. Plan's Design Decision #2 is stale. | this doc |
 | F7 | 🟡 Low | Event table stores no `recommendations_json`, prompt hashes, model ids, or `user_id`. Spec's "link to full recommendations" and prompt-hash filtering are not possible. | `eval/evalRepository.ts` |
 | F8 | 🟡 Low | `GENERIC_PHRASES` flags common comparison phrasing ("fans of", "similar to", "in the vein of") that appears in legitimately good why-text → noisy `genericWhyFlag`. `citationSupportRate` also defaults to 1.0 when a why has no URLs, inflating evidence metrics. | `eval/evidenceChecker.ts` |

--- a/services/api/src/eval/dashboard/index.html
+++ b/services/api/src/eval/dashboard/index.html
@@ -164,8 +164,11 @@
       new Chart(document.getElementById('chart-obscurity'), {
         type: 'doughnut',
         data: {
-          labels: ['Cult', 'Underground', 'Obscure'],
-          datasets: [{ data: [dist.cult, dist.underground, dist.obscure], backgroundColor: ['#1d4ed8', '#15803d', '#7c3aed'] }],
+          labels: ['Mainstream', 'Cult', 'Underground', 'Obscure', 'Unknown'],
+          datasets: [{
+            data: [dist.mainstream || 0, dist.cult, dist.underground, dist.obscure, dist.unknown || 0],
+            backgroundColor: ['#b91c1c', '#1d4ed8', '#15803d', '#7c3aed', '#475569'],
+          }],
         },
         options: {
           responsive: true,

--- a/services/api/src/eval/evalAggregator.ts
+++ b/services/api/src/eval/evalAggregator.ts
@@ -7,7 +7,7 @@ export type AggregatedMetrics = {
   meanObscurityFit: number | null;
   meanEvidenceQuality: number | null;
   meanDiscoveryValue: number | null;
-  obscurityDistribution: { cult: number; underground: number; obscure: number };
+  obscurityDistribution: { mainstream: number; cult: number; underground: number; obscure: number; unknown: number };
   sourceQualityDistribution: { high: number; medium: number; low: number };
   meanCitationSupportRate: number | null;
   genericWhyRate: number | null;
@@ -36,7 +36,7 @@ export function aggregateMetrics(
   events: RecommendationEvent[],
   bandScores: BandEvalScore[],
 ): AggregatedMetrics {
-  const obscurityDistribution = { cult: 0, underground: 0, obscure: 0 };
+  const obscurityDistribution = { mainstream: 0, cult: 0, underground: 0, obscure: 0, unknown: 0 };
   const sourceQualityDistribution = { high: 0, medium: 0, low: 0 };
 
   const relevances: number[] = [];
@@ -48,7 +48,13 @@ export function aggregateMetrics(
   let genericWhyTotal = 0;
 
   for (const score of bandScores) {
-    if (score.obscurityTier === "cult" || score.obscurityTier === "underground" || score.obscurityTier === "obscure") {
+    if (
+      score.obscurityTier === "mainstream" ||
+      score.obscurityTier === "cult" ||
+      score.obscurityTier === "underground" ||
+      score.obscurityTier === "obscure" ||
+      score.obscurityTier === "unknown"
+    ) {
       obscurityDistribution[score.obscurityTier]++;
     }
     if (score.sourceQuality === "high" || score.sourceQuality === "medium" || score.sourceQuality === "low") {

--- a/services/api/src/eval/evalWorker.ts
+++ b/services/api/src/eval/evalWorker.ts
@@ -122,6 +122,7 @@ export function createEvalWorker({
             why: r.why,
             sourceSignals: r.sourceSignals,
             listeners: dbScore?.listeners,
+            obscurityTier: dbScore?.obscurityTier,
             citationSupportRate: dbScore?.citationSupportRate,
             genericWhyFlag: dbScore?.genericWhyFlag,
           };

--- a/services/api/src/eval/judgeWorker.ts
+++ b/services/api/src/eval/judgeWorker.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import type { EvalRepository } from "./evalRepository.js";
+import { OBSCURITY_THRESHOLDS } from "./obscurityScorer.js";
 import { writeStructuredLog } from "../http/structuredLog.js";
 
 export type JudgeInput = {
@@ -9,6 +10,7 @@ export type JudgeInput = {
   why?: string;
   sourceSignals?: string[];
   listeners?: number | null;
+  obscurityTier?: string | null;
   citationSupportRate?: number;
   genericWhyFlag?: boolean;
 };
@@ -21,11 +23,25 @@ type JudgeScoreObject = {
   reasoning?: unknown;
 };
 
+// Derive the tier description from OBSCURITY_THRESHOLDS so the judge's notion of
+// each tier stays identical to the deterministic classifier (obscurityScorer).
+// Changing the thresholds in one place keeps the prompt — and calibration — in sync.
+const fmt = (n: number) => n.toLocaleString("en-US");
+const OBSCURITY_FIT_GUIDANCE =
+  `How well does the band match the requested obscurity target? ` +
+  `Tiers by Last.fm listeners — ` +
+  `cult = ${fmt(OBSCURITY_THRESHOLDS.cult)}–${fmt(OBSCURITY_THRESHOLDS.mainstream)}, ` +
+  `underground = ${fmt(OBSCURITY_THRESHOLDS.underground)}–${fmt(OBSCURITY_THRESHOLDS.cult)}, ` +
+  `obscure = under ${fmt(OBSCURITY_THRESHOLDS.underground)}, ` +
+  `mainstream = over ${fmt(OBSCURITY_THRESHOLDS.mainstream)}. ` +
+  `Each band includes its computed obscurity_tier; reward a tier at or below the target ` +
+  `and penalise bands more mainstream than requested. Ignore this if no target given.`;
+
 const JUDGE_SYSTEM_PROMPT = `You are an expert music recommendation quality judge. Your task is to evaluate a list of band recommendations against a user's query and produce a JSON object with one score entry per band.
 
 Scoring dimensions (each 0.0–1.0):
 - relevance: Does the band genuinely fit the requested genre/style/mood described in the query?
-- obscurity_fit: How well does the band match the requested obscurity target? (cult < 500k listeners, underground < 100k, obscure < 10k). Ignore this if no target given.
+- obscurity_fit: ${OBSCURITY_FIT_GUIDANCE}
 - evidence_quality: Is the why-text specific and grounded in cited sources, or generic boilerplate? Penalise generic_why_flag=true and uncited claims.
 - discovery_value: Would a curious music fan be genuinely surprised and pleased? Penalise extremely well-known mainstream bands for discovery-focused queries.
 
@@ -51,6 +67,7 @@ export function buildJudgePrompt(bands: JudgeInput[]): { system: string; user: s
       why: b.why ?? "",
       source_signals: b.sourceSignals ?? [],
       listeners: b.listeners ?? null,
+      obscurity_tier: b.obscurityTier ?? null,
       citation_support_rate: b.citationSupportRate ?? null,
       generic_why_flag: b.genericWhyFlag ?? null,
     })),

--- a/services/api/test/eval/eval-aggregator.test.js
+++ b/services/api/test/eval/eval-aggregator.test.js
@@ -100,6 +100,21 @@ test("aggregateMetrics: obscurity tier distribution counts correctly", () => {
   assert.equal(result.obscurityDistribution.obscure, 1);
 });
 
+test("aggregateMetrics: obscurity distribution counts mainstream and unknown (F4)", () => {
+  const events = [makeEvent({ id: "e1" })];
+  const scores = [
+    makeScore({ eventId: "e1", bandName: "A", obscurityTier: "mainstream" }),
+    makeScore({ eventId: "e1", bandName: "B", obscurityTier: "mainstream" }),
+    makeScore({ eventId: "e1", bandName: "C", obscurityTier: "unknown" }),
+    makeScore({ eventId: "e1", bandName: "D", obscurityTier: "obscure" }),
+  ];
+  const result = aggregateMetrics(events, scores);
+  assert.equal(result.obscurityDistribution.mainstream, 2, "mainstream bands must be visible");
+  assert.equal(result.obscurityDistribution.unknown, 1, "unknown (not on Last.fm) tracked as its own bucket");
+  assert.equal(result.obscurityDistribution.obscure, 1);
+  assert.equal(result.obscurityDistribution.cult, 0);
+});
+
 test("aggregateMetrics: source quality distribution counts correctly", () => {
   const events = [makeEvent({ id: "e1" })];
   const scores = [

--- a/services/api/test/eval/judge-worker.test.js
+++ b/services/api/test/eval/judge-worker.test.js
@@ -74,6 +74,27 @@ test("buildJudgePrompt: includes all required fields per band", () => {
   assert.ok("generic_why_flag" in wittr);
 });
 
+// ─── F3: judge thresholds aligned with obscurityScorer ──────────────────────
+
+test("buildJudgePrompt: system prompt thresholds match OBSCURITY_THRESHOLDS", () => {
+  const { buildJudgePrompt } = require("../../src/eval/judgeWorker");
+  const { system } = buildJudgePrompt(sampleBands);
+  // Correct tier floors from obscurityScorer: cult 20k, underground 2k, mainstream 500k
+  assert.ok(system.includes("20,000"), "cult floor 20,000 should appear");
+  assert.ok(system.includes("2,000"), "underground floor 2,000 should appear");
+  assert.ok(system.includes("500,000"), "mainstream floor 500,000 should appear");
+  // The old, wrong numbers must be gone
+  assert.ok(!/100k|under 100,000|< 100,000/.test(system), "stale 100k underground threshold removed");
+  assert.ok(!/\b10k\b|under 10,000|< 10,000/.test(system), "stale 10k obscure threshold removed");
+});
+
+test("buildJudgePrompt: includes obscurity_tier per band when provided", () => {
+  const { buildJudgePrompt } = require("../../src/eval/judgeWorker");
+  const bands = [{ ...sampleBands[0], obscurityTier: "cult" }];
+  const parsed = JSON.parse(buildJudgePrompt(bands).user);
+  assert.equal(parsed[0].obscurity_tier, "cult");
+});
+
 test("createJudgeWorker: no-op when anthropicApiKey is empty", async () => {
   const { createJudgeWorker } = require("../../src/eval/judgeWorker");
   const { createInMemoryEvalRepository } = require("../../src/eval/evalRepository");


### PR DESCRIPTION
## What & why

Closes the two remaining medium-severity findings from the 2026-06-01 Phase 8 implementation review (F3, F4). The other findings were already resolved on `main`: F1/F2 by the 8.3b wiring, F5 by the 8.8 feedback work. F6–F8 are docs/tuning items now tracked on the roadmap.

## Changes

**F3 — Align judge obscurity thresholds with `obscurityScorer`**
- The judge system prompt hardcoded "cult < 500k, underground < 100k, obscure < 10k", contradicting `OBSCURITY_THRESHOLDS` (cult 20k–500k, underground 2k–20k, obscure < 2k). The judge was scoring `obscurity_fit` against a different definition than the deterministic tier.
- Prompt tier guidance is now **derived from `OBSCURITY_THRESHOLDS`** (single source of truth).
- `obscurityTier` added to `JudgeInput`; `evalWorker` threads the computed tier from the DB score into the judge so it sees the same tier the deterministic layer assigned.
- ⚠️ `judge_prompt_hash` changes → re-run `run-calibration.ts`.

**F4 — Include `mainstream` and `unknown` in obscurity distribution**
- `obscurityDistribution` counted only cult/underground/obscure, silently dropping `mainstream` and `unknown` — hiding the "too mainstream" signal the layer exists to catch.
- Aggregator now tracks all five tiers; dashboard doughnut shows mainstream in red (regression signal) and unknown in neutral gray.

**Docs**
- Plan findings table updated (F1–F5 marked resolved).
- Roadmap gains trackable entries for the deferred F6–F8.

## Testing

TDD throughout (red → green). Full suites green:
- `services/api`: 376 ✓
- `apps/desktop`: 167 ✓
- `shared/schemas`: 17 ✓
- `services/eval`: 16 ✓

## Known gaps (deferred, tracked on roadmap)
- F6 — reconcile stale Design Decision #2 in the architecture spec (docs only)
- F7 — add `recommendations_json` + `user_id` to the event table
- F8 — tune `generic_why_flag` / `citationSupportRate` heuristics against the calibration set

https://claude.ai/code/session_01RPJ779uG76QgFkH4oRCsWx

---
_Generated by [Claude Code](https://claude.ai/code/session_01RPJ779uG76QgFkH4oRCsWx)_