### PR TITLE
feat: last.fm similar-artist enrichment in research pipeline

### DIFF
--- a/services/api/src/agent/research/researchGraph.ts
+++ b/services/api/src/agent/research/researchGraph.ts
@@ -3,6 +3,7 @@ import * as z from "zod";
 
 import type { ChatMessage, RecommendationMode } from "../../../../../shared/schemas/src/contracts.js";
 import { createBraveSearchClient } from "../../integrations/braveSearch.js";
+import { createLastFmClient, type LastFmClient } from "../../eval/lastFmClient.js";
 import { createMusicBrainzClient } from "../../integrations/musicbrainz.js";
 import { createCandidateExtractor, type ExtractedCandidate, type SearchHitInput } from "./candidateExtractor.js";
 import { verifyCandidatesWithMusicBrainz, type VerifiedCandidate } from "./candidateVerifier.js";
@@ -14,6 +15,7 @@ import { createWebSearchPlanner, type SearchPlan } from "./webSearchPlanner.js";
 export type ResearchGraphDeps = {
   geminiApiKey: string;
   braveApiKey: string;
+  lastFmApiKey?: string;
   maxInitialSearches: number;
   maxReflectionSearches: number;
   totalSearchBudget: number;
@@ -92,6 +94,10 @@ export async function buildResearchGraph(deps: ResearchGraphDeps, budget: Resear
     retries: deps.musicBrainzRetries ?? 1,
   });
 
+  const lastFm: LastFmClient | null = deps.lastFmApiKey
+    ? createLastFmClient({ apiKey: deps.lastFmApiKey, timeoutMs: 5000 })
+    : null;
+
   const braveDedup: BraveDedupCache = new Map();
   const runQueries = (queries: string[], budgetLeft: number, perQueryCount: number) =>
     runBraveQueries({ apiKey: deps.braveApiKey, dedupCache: braveDedup, budget }, queries, budgetLeft, perQueryCount);
@@ -154,6 +160,44 @@ export async function buildResearchGraph(deps: ResearchGraphDeps, budget: Resear
       return { verifiedCandidates: verified };
     })
     .addNode("reflect_if_needed", reflectionSubgraph)
+    .addNode("enrich_lastfm", async (state) => {
+      if (!lastFm) return {};
+      const anchors = state.searchPlan?.anchorArtists ?? [];
+      if (!anchors.length || !state.verifiedCandidates?.length) return {};
+
+      const similarMap = new Map<string, { anchor: string; match: number }>();
+      for (const anchor of anchors) {
+        const similar = await lastFm.getSimilarArtists(anchor);
+        for (const s of similar) {
+          const key = s.name.toLowerCase();
+          const existing = similarMap.get(key);
+          if (!existing || s.match > existing.match) {
+            similarMap.set(key, { anchor, match: s.match });
+          }
+        }
+      }
+
+      let matchCount = 0;
+      const enriched = state.verifiedCandidates.map((c) => {
+        const key = (c.canonicalName || c.name).trim().toLowerCase();
+        const hit = similarMap.get(key);
+        if (!hit) return c;
+        matchCount++;
+        const similarUrl = `https://www.last.fm/music/${encodeURIComponent(hit.anchor)}/+similar`;
+        return {
+          ...c,
+          evidenceUrls: [...c.evidenceUrls, similarUrl],
+          evidenceSnippets: [...c.evidenceSnippets, `Similar to ${hit.anchor} on last.fm (match: ${hit.match.toFixed(2)})`],
+        };
+      });
+
+      log("info", "research_lastfm_enrichment", {
+        anchorCount: anchors.length,
+        candidateCount: state.verifiedCandidates.length,
+        matchCount,
+      });
+      return { verifiedCandidates: enriched };
+    })
     .addNode("rank", async (state) => {
       const ranker = await createRecommendationRanker({
         apiKey: deps.geminiApiKey,
@@ -176,7 +220,8 @@ export async function buildResearchGraph(deps: ResearchGraphDeps, budget: Resear
     .addEdge("brave_initial", "extract")
     .addEdge("extract", "verify")
     .addEdge("verify", "reflect_if_needed")
-    .addEdge("reflect_if_needed", "rank")
+    .addEdge("reflect_if_needed", "enrich_lastfm")
+    .addEdge("enrich_lastfm", "rank")
     .addEdge("rank", END);
 
   return graph.compile();

--- a/services/api/src/eval/lastFmClient.ts
+++ b/services/api/src/eval/lastFmClient.ts
@@ -13,12 +13,20 @@ export type LastFmClientConfig = {
   fetchImpl?: FetchLike;
 };
 
+export type SimilarArtist = { name: string; match: number };
+
 export type LastFmClient = {
   getListenerCount(artistName: string): Promise<number | null>;
+  getSimilarArtists(artistName: string, limit?: number): Promise<SimilarArtist[]>;
 };
 
 type LastFmInfoResponse = {
   artist?: { stats?: { listeners?: string } };
+  error?: number;
+};
+
+type LastFmSimilarResponse = {
+  similarartists?: { artist?: Array<{ name?: string; match?: string }> };
   error?: number;
 };
 
@@ -58,6 +66,37 @@ export function createLastFmClient(config: LastFmClientConfig): LastFmClient {
         return Number.isFinite(listeners) ? listeners : null;
       } catch {
         return null;
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+
+    async getSimilarArtists(artistName: string, limit = 50): Promise<SimilarArtist[]> {
+      const trimmed = artistName.trim();
+      if (!apiKey || !trimmed) return [];
+
+      const url =
+        `${LASTFM_API_ENDPOINT}?method=artist.getSimilar` +
+        `&artist=${encodeURIComponent(trimmed)}` +
+        `&limit=${limit}` +
+        `&api_key=${encodeURIComponent(apiKey)}&format=json`;
+
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+      try {
+        const response = await fetchImpl(url, {
+          signal: controller.signal,
+          headers: { "User-Agent": "Bandsearch/1.0 (https://github.com/eikrad/bandsearch-app)" },
+        });
+        if (!response.ok) return [];
+        const body = (await response.json()) as LastFmSimilarResponse;
+        if (body.error) return [];
+        const raw = body.similarartists?.artist ?? [];
+        return raw
+          .filter((a) => a.name?.trim())
+          .map((a) => ({ name: a.name!.trim(), match: Number(a.match) || 0 }));
+      } catch {
+        return [];
       } finally {
         clearTimeout(timer);
       }

--- a/services/api/src/recommendationPipeline.ts
+++ b/services/api/src/recommendationPipeline.ts
@@ -12,6 +12,7 @@ export type RecommendationRuntimeConfig = {
   musicBrainzRetries?: number;
   geminiApiKey?: string;
   braveApiKey?: string;
+  lastFmApiKey?: string;
   researchMaxInitialSearches?: number;
   researchMaxReflectionSearches?: number;
   researchTotalSearchBudget?: number;
@@ -81,6 +82,7 @@ export function createRecommendationPipeline({
           totalSearchBudget: cfg.researchTotalSearchBudget ?? 10,
           targetVerifiedCount: cfg.researchTargetVerifiedCandidates ?? 8,
           researchTimeoutMs: cfg.researchTimeoutMs ?? 25000,
+          lastFmApiKey: String(cfg.lastFmApiKey ?? "").trim(),
           musicBrainzTimeoutMs: cfg.musicBrainzTimeoutMs,
           musicBrainzRetries: cfg.musicBrainzRetries,
           onLog: (level, event, details) => {

--- a/services/api/test/research/lastfm-enrichment.test.ts
+++ b/services/api/test/research/lastfm-enrichment.test.ts
@@ -1,0 +1,89 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createLastFmClient, type LastFmClientConfig } from "../../src/eval/lastFmClient.js";
+
+type FetchLike = LastFmClientConfig["fetchImpl"];
+
+function mockFetch(responses: Record<string, unknown>): FetchLike {
+  return async (url: string) => {
+    for (const [pattern, body] of Object.entries(responses)) {
+      if (url.includes(pattern)) {
+        return { ok: true, json: async () => body };
+      }
+    }
+    return { ok: false, json: async () => ({}) };
+  };
+}
+
+test("getSimilarArtists returns parsed similar artists", async () => {
+  const client = createLastFmClient({
+    apiKey: "test-key",
+    fetchImpl: mockFetch({
+      "method=artist.getSimilar": {
+        similarartists: {
+          artist: [
+            { name: "Band A", match: "0.85" },
+            { name: "Band B", match: "0.42" },
+          ],
+        },
+      },
+    }),
+  });
+
+  const result = await client.getSimilarArtists("Anchor Band");
+  assert.equal(result.length, 2);
+  assert.equal(result[0].name, "Band A");
+  assert.equal(result[0].match, 0.85);
+  assert.equal(result[1].name, "Band B");
+  assert.equal(result[1].match, 0.42);
+});
+
+test("getSimilarArtists returns empty array on API error", async () => {
+  const client = createLastFmClient({
+    apiKey: "test-key",
+    fetchImpl: mockFetch({
+      "method=artist.getSimilar": { error: 6 },
+    }),
+  });
+
+  const result = await client.getSimilarArtists("Unknown");
+  assert.deepEqual(result, []);
+});
+
+test("getSimilarArtists returns empty array when no API key", async () => {
+  const client = createLastFmClient({ apiKey: "" });
+  const result = await client.getSimilarArtists("Anything");
+  assert.deepEqual(result, []);
+});
+
+test("getSimilarArtists filters entries with empty names", async () => {
+  const client = createLastFmClient({
+    apiKey: "test-key",
+    fetchImpl: mockFetch({
+      "method=artist.getSimilar": {
+        similarartists: {
+          artist: [
+            { name: "Good", match: "0.9" },
+            { name: "", match: "0.5" },
+            { name: "  ", match: "0.3" },
+          ],
+        },
+      },
+    }),
+  });
+
+  const result = await client.getSimilarArtists("Anchor");
+  assert.equal(result.length, 1);
+  assert.equal(result[0].name, "Good");
+});
+
+test("getSimilarArtists returns empty array on network failure", async () => {
+  const client = createLastFmClient({
+    apiKey: "test-key",
+    fetchImpl: async () => { throw new Error("network down"); },
+  });
+
+  const result = await client.getSimilarArtists("Band");
+  assert.deepEqual(result, []);
+});


### PR DESCRIPTION
## Summary

- Adds `getSimilarArtists()` to the existing last.fm client (`lastFmClient.ts`), calling `artist.getSimilar` with the same timeout/abort pattern as `getListenerCount`
- Adds an `enrich_lastfm` node to the LangGraph research pipeline between `reflect_if_needed` and `rank` — for each anchor artist, fetches similar artists from last.fm and appends evidence URLs + snippets to any matching verified candidates
- Wires `lastFmApiKey` through `RecommendationRuntimeConfig` → `ResearchGraphDeps` (the env var was already extracted but never passed to the graph)

## Design

Last.fm is used as a **corroboration step, not a candidate source** — it never adds new candidates, only strengthens evidence for bands already found via web search. This avoids skewing results toward popular/mainstream associations. For underground queries where anchor artists are niche, last.fm's similar graph is naturally sparse, so it has minimal influence.

Works within the existing `VerifiedCandidate` shape — no new types needed. Evidence is appended to the existing `evidenceUrls[]` and `evidenceSnippets[]` fields, so the ranker picks it up for free without any changes.

## Test plan

- [x] 5 new TypeScript tests covering: happy path, API errors, missing key, empty names, network failures
- [x] All 53 existing research tests pass
- [x] Full monorepo lint + typecheck + test suite passes (pre-commit hook)
- [ ] Manual: run dev server with `LASTFM_API_KEY` set, search, confirm last.fm URLs appear in evidence for corroborated picks

🤖 Generated with [Claude Code](https://claude.com/claude-code)