### PR TITLE
docs: fix Node.js prerequisite (20+ → 22+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ See [`docs/architecture/ARCHITECTURE.md`](docs/architecture/ARCHITECTURE.md) for
 
 ## Quick Start
 
-**Prerequisites:** Node.js 20+
+**Prerequisites:** Node.js 22+
 
 ```bash
 git clone https://github.com/eikrad/bandsearch-app


### PR DESCRIPTION
## What changed

`package.json` declares `"engines": { "node": ">=22" }` but the README Quick Start section said **Node.js 20+**. Fixed to **Node.js 22+** so the docs match the actual requirement.

## Why

A reader who installs Node 20 or 21 and tries `npm run dev` will hit an engine mismatch error. The README should tell them the correct version upfront.

## Review checklist

- [ ] `package.json` `engines.node` is `>=22` — confirmed
- [ ] No other occurrences of "Node.js 20+" in this repo that refer to bandsearch's own requirement

https://claude.ai/code/session_017AJdcdiMPdBAtkEVeU5V3i

---
_Generated by [Claude Code](https://claude.ai/code/session_017AJdcdiMPdBAtkEVeU5V3i)_