### PR TITLE
docs: add missing auto-update plan to docs index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ Navigation guide for the `docs/` folder.
 | [architecture/ARCHITECTURE.md](architecture/ARCHITECTURE.md) | System architecture — graph pipeline, state fields, integrations, storage, auth |
 | [architecture/2026-05-29-eval-architecture.md](architecture/2026-05-29-eval-architecture.md) | Evaluation layer design — three-tier scoring, LLM-as-judge, feedback loop |
 | [architecture/2026-05-30-phase8-implementation-plan.md](architecture/2026-05-30-phase8-implementation-plan.md) | Phase 8 step-by-step implementation plan (eval & quality observability) |
+| [architecture/2026-06-03-auto-update-plan.md](architecture/2026-06-03-auto-update-plan.md) | Auto-update design — Tauri desktop updater implementation plan |
 | [adr/0001-prompt-injection-guardrails.md](adr/0001-prompt-injection-guardrails.md) | ADR: prompt injection defence — bracket-marker envelope and length caps |
 | [design/UI_GUIDELINES.md](design/UI_GUIDELINES.md) | UI design guidelines — layout, components, responsive behaviour |
 | [design/UI_EXAMPLES.md](design/UI_EXAMPLES.md) | UI copy examples and interaction patterns |


### PR DESCRIPTION
## What changed

`docs/README.md` was missing an entry for `architecture/2026-06-03-auto-update-plan.md`, which exists in the repo but wasn't listed in the navigation table.

**Added:**
```
| architecture/2026-06-03-auto-update-plan.md | Auto-update design — Tauri desktop updater implementation plan |
```

## Why no other changes

The main `README.md` is already in great shape — it has a mermaid pipeline diagram, a comprehensive API reference, and clear setup instructions for all three platforms. `docs/architecture/ARCHITECTURE.md` is detailed and current. Everything else in `docs/` is up to date. Only this one missing index entry needed fixing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQEGZwQ2L8WsLCYddqEmev)_