### PR TITLE
docs: add missing auto-update-plan to docs navigation index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ Navigation guide for the `docs/` folder.
 | [architecture/ARCHITECTURE.md](architecture/ARCHITECTURE.md) | System architecture — graph pipeline, state fields, integrations, storage, auth |
 | [architecture/2026-05-29-eval-architecture.md](architecture/2026-05-29-eval-architecture.md) | Evaluation layer design — three-tier scoring, LLM-as-judge, feedback loop |
 | [architecture/2026-05-30-phase8-implementation-plan.md](architecture/2026-05-30-phase8-implementation-plan.md) | Phase 8 step-by-step implementation plan (eval & quality observability) |
+| [architecture/2026-06-03-auto-update-plan.md](architecture/2026-06-03-auto-update-plan.md) | Auto-update design — Tauri desktop client update flow and release channel strategy |
 | [adr/0001-prompt-injection-guardrails.md](adr/0001-prompt-injection-guardrails.md) | ADR: prompt injection defence — bracket-marker envelope and length caps |
 | [design/UI_GUIDELINES.md](design/UI_GUIDELINES.md) | UI design guidelines — layout, components, responsive behaviour |
 | [design/UI_EXAMPLES.md](design/UI_EXAMPLES.md) | UI copy examples and interaction patterns |


### PR DESCRIPTION
## Summary

- `docs/README.md` — adds the missing `architecture/2026-06-03-auto-update-plan.md` entry to the navigation table. This file already exists in the repo but was not listed in the docs index.

## Why no other changes?

The bandsearch README is current and already contains a Mermaid pipeline diagram. `docs/architecture/ARCHITECTURE.md` is accurate and up to date. All other docs entries in `docs/README.md` are valid. Only the missing navigation entry needed fixing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1WDYWHunGxxpk2piah4dN)_