### PR TITLE
docs: add mermaid diagrams to ARCHITECTURE.md, fix docs index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ Navigation guide for the `docs/` folder.
 | [architecture/ARCHITECTURE.md](architecture/ARCHITECTURE.md) | System architecture — graph pipeline, state fields, integrations, storage, auth |
 | [architecture/2026-05-29-eval-architecture.md](architecture/2026-05-29-eval-architecture.md) | Evaluation layer design — three-tier scoring, LLM-as-judge, feedback loop |
 | [architecture/2026-05-30-phase8-implementation-plan.md](architecture/2026-05-30-phase8-implementation-plan.md) | Phase 8 step-by-step implementation plan (eval & quality observability) |
+| [architecture/2026-06-03-auto-update-plan.md](architecture/2026-06-03-auto-update-plan.md) | Auto-update plan — Tauri updater integration and release pipeline |
 | [adr/0001-prompt-injection-guardrails.md](adr/0001-prompt-injection-guardrails.md) | ADR: prompt injection defence — bracket-marker envelope and length caps |
 | [design/UI_GUIDELINES.md](design/UI_GUIDELINES.md) | UI design guidelines — layout, components, responsive behaviour |
 | [design/UI_EXAMPLES.md](design/UI_EXAMPLES.md) | UI copy examples and interaction patterns |

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -6,7 +6,24 @@ Bandsearch is an AI-powered music recommendation system that discovers niche and
 
 ---
 
-## Monorepo Structure
+## System overview
+
+```mermaid
+graph LR
+    USER([User]) --> DESK[Tauri Desktop\nReact UI]
+    USER --> BROWSER[Browser UI]
+    DESK --> API[Express API\nNode.js :3001]
+    BROWSER --> API
+    API --> GRAPH[LangGraph\nResearch Pipeline]
+    GRAPH --> GEMINI[Google Gemini\nplan · extract · reflect · rank]
+    GRAPH --> BRAVE[Brave Search API\nniche artist discovery]
+    GRAPH --> MB[MusicBrainz\nartist verification]
+    GRAPH --> DB[(SQLite / Postgres\n/ Turso)]
+```
+
+---
+
+## Monorepo structure
 
 ```
 bandsearch-app/
@@ -23,7 +40,7 @@ bandsearch-app/
 
 ---
 
-## API Server (`services/api`)
+## API server (`services/api`)
 
 The API is an Express.js application structured as follows:
 
@@ -37,11 +54,11 @@ The API is an Express.js application structured as follows:
 
 ---
 
-## LangGraph Pipeline
+## LangGraph pipeline
 
 The core recommendation logic is a LangGraph state machine defined in `agent/research/researchGraph.ts`.
 
-### Graph State (`ResearchGraphState`)
+### Graph state (`ResearchGraphState`)
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -58,10 +75,17 @@ The core recommendation logic is a LangGraph state machine defined in `agent/res
 | `recommendations` | `unknown[]` | Final ranked output |
 | `assistantReply` | `string` | Optional conversational prose |
 
-### Main Graph
+### Main graph
 
-```
-START → plan → brave_initial → extract → verify → reflect_if_needed → rank → END
+```mermaid
+flowchart TD
+    START(["START"]) --> plan["plan\nGemini — builds Brave queries\nfrom user taste"]
+    plan --> brave_initial["brave_initial\nBrave Search API\nup to RESEARCH_MAX_INITIAL_SEARCHES"]
+    brave_initial --> extract["extract\nGemini — extracts band names\nfrom search snippets"]
+    extract --> verify["verify\nMusicBrainz — adds mbid,\ngenres, tags, URL relations"]
+    verify --> reflect_if_needed["reflect_if_needed\nReflection Subgraph\n(runs if verified count < target)"]
+    reflect_if_needed --> rank["rank\nGemini — final ranked list\nwith evidence-grounded why text"]
+    rank --> END(["END"])
 ```
 
 | Node | Model / Service | Description |
@@ -73,53 +97,56 @@ START → plan → brave_initial → extract → verify → reflect_if_needed �
 | `reflect_if_needed` | Reflection Subgraph | Conditionally runs extra searches when verified count < target |
 | `rank` | Gemini | Produces final ranked list with evidence-grounded `why` text and optional prose reply |
 
-### Reflection Subgraph (`reflectionSubgraph.ts`)
+### Reflection subgraph (`reflectionSubgraph.ts`)
 
 Embedded as a compiled LangGraph subgraph within `reflect_if_needed`. Runs up to `maxRounds` (default 2) additional search-extract-verify cycles when the initial pass does not yield enough verified candidates.
 
-```
-START → assess →(sufficient or budget gone)─────────────────────────────► END
-              │(needs more)
-              ▼
-            search → extract_r → verify_r →(maxRounds or budget gone)► END
-                                     │(rounds remaining)
-                                     └──────────────────► assess
+```mermaid
+flowchart TD
+    subSTART(["START"]) --> assess["assess\nGemini — evaluates results,\ngenerates extraQueries if gaps found"]
+    assess -->|"sufficient or budget gone"| subEND(["END"])
+    assess -->|"needs more data"| search["search\nBrave Search API\nexecutes extra queries"]
+    search --> extract_r["extract_r\nGemini — extracts from\nnew hits only"]
+    extract_r --> verify_r["verify_r\nMusicBrainz — verifies\nnew candidates only"]
+    verify_r -->|"maxRounds or budget gone"| subEND
+    verify_r -->|"rounds remaining"| assess
 ```
 
 | Node | Model / Service | Description |
 |------|----------------|-------------|
 | `assess` | Gemini | Evaluates current results; generates `extraQueries` when gaps are found |
 | `search` | Brave Search API | Executes extra queries against remaining budget; stores new hits in `newHits` separately from the accumulated `braveHits` |
-| `extract_r` | Gemini | Extracts candidates from `newHits` **only** (not all accumulated hits); merges result into existing `extractedCandidates` via `mergeExtractedCandidates` |
-| `verify_r` | MusicBrainz | Verifies only candidates not yet present in `verifiedCandidates` (by name/canonicalName); merges into existing set via `mergeVerifiedCandidates` — preserves all prior-round results |
+| `extract_r` | Gemini | Extracts candidates from `newHits` **only** (not all accumulated hits); merges into existing `extractedCandidates` via `mergeExtractedCandidates` |
+| `verify_r` | MusicBrainz | Verifies only candidates not yet present in `verifiedCandidates` (by name/canonicalName); merges via `mergeVerifiedCandidates` — preserves all prior-round results |
 
-### Budget Management (`researchBudget.ts`)
+### Budget management (`researchBudget.ts`)
 
 A shared `ResearchBudget` instance tracks wall-clock time against `RESEARCH_TIMEOUT_MS` (default 25 s). Each node calls `budget.allocate(ms)` to claim a per-operation slice. When the budget is exhausted, conditional edges route directly to `END` rather than timing out mid-flight.
 
 ---
 
-## External Integrations
+## External integrations
+
 | Integration | Used in | Purpose |
-|-------------|---------|---------|
-| **Brave Search API** | `brave_initial`, `search` | Web discovery for niche and underground artists
-| **Google Gemini** (`@langchain/google-genai`) | `plan`, `extract`, `assess`, `rank` | All structured reasoning and text generation
-| **MusicBrainz** | `verify`, `verify_r` | Artist metadata verification (mbid, genres, tags, URL relations)
-| **Wikidata + Last.fm** | `/artists/image` endpoint | Artist image resolution with Last.fm fallback
-| **Mistral** (optional) | Eval layer | Async LLM-as-Judge scoring — never on the critical path
-| **LangSmith** (optional) | Graph invocation | Distributed tracing for the LangGraph pipeline
+|-------------|---------|--------|
+| **Brave Search API** | `brave_initial`, `search` | Web discovery for niche and underground artists |
+| **Google Gemini** (`@langchain/google-genai`) | `plan`, `extract`, `assess`, `rank` | All structured reasoning and text generation |
+| **MusicBrainz** | `verify`, `verify_r` | Artist metadata verification (mbid, genres, tags, URL relations) |
+| **Wikidata + Last.fm** | `/artists/image` endpoint | Artist image resolution with Last.fm fallback |
+| **Mistral** (optional) | Eval layer | Async LLM-as-Judge scoring — never on the critical path |
+| **LangSmith** (optional) | Graph invocation | Distributed tracing for the LangGraph pipeline |
 
 ---
 
-## Evaluation Layer
+## Evaluation layer
 
-Defined in `docs/architecture/2026-05-29-eval-architecture.md`. An async, non-blocking quality-scoring system that runs after the HTTP response is sent.
+Full design in [2026-05-29-eval-architecture.md](2026-05-29-eval-architecture.md). An async, non-blocking quality-scoring system that runs after the HTTP response is sent.
 
 | Layer | Mechanism | Signals |
-|-------|-----------|---------|
+|-------|-----------|--------|
 | **1 — Automatic metrics** | Runs immediately | Obscurity score (Last.fm listener count), funnel counts (hits / extracted / verified), search source quality |
 | **1.5 — Deterministic checks** | Runs immediately | Citation support rate (evidence URLs per recommendation), generic-why detection |
-| **2 — LLM-as-Judge** | Async, fire-and-forget | Claude scores each band on `relevance`, `obscurity_fit`, `evidence_quality`, `discovery_value` — only when `ANTHROPIC_API_KEY` is set |
+| **2 — LLM-as-Judge** | Async, fire-and-forget | Mistral scores each band on `relevance`, `obscurity_fit`, `evidence_quality`, `discovery_value` — only when `MISTRAL_API_KEY` is set |
 | **3 — Human feedback** | Event-driven | Implicit saves + explicit one-tap batch reactions |
 
 Eval data is stored in `recommendation_events`, `llm_eval_scores`, `recommendation_feedback`, and `eval_baselines` tables.
@@ -130,10 +157,10 @@ Eval data is stored in `recommendation_events`, `llm_eval_scores`, `recommendati
 
 Two persistence domains, both backed by an abstract repository pattern to allow swapping backends without changing business logic.
 
-### Preferences Store (`PREFERENCE_STORE`)
+### Preferences store (`PREFERENCE_STORE`)
 
 | Backend | Config | Use case |
-|---------|--------|---------|
+|---------|--------|----------|
 | `sqlite` (default) | `DATABASE_PATH` | Local, zero-config |
 | `memory` | — | Ephemeral / testing |
 | `postgres` | `DATABASE_URL` | Shared or hosted deployment |
@@ -141,11 +168,11 @@ Two persistence domains, both backed by an abstract repository pattern to allow 
 
 Tables: `saved_bands` (rating, categories, notes), `artist_groups`
 
-### Session Store
+### Session store
 
 SQLite (`bandsearch.db`) with in-memory fallback. Tables: `chat_sessions`, `chat_messages`.
 
-### Auth Store
+### Auth store
 
 Same backend as preferences. Table: `users` (bcrypt-hashed passwords). JWTs with 30-day expiry; password recovery via single-use recovery codes.
 
@@ -163,7 +190,7 @@ Three-tier progressive auth — determined by the number of registered users at 
 
 ---
 
-## Desktop Client (`apps/desktop`)
+## Desktop client (`apps/desktop`)
 
 - **Stack:** Tauri (Rust shell) + React (TypeScript)
 - **API process:** spawned as a Node.js child process; production builds use a Tauri-bundled Node sidecar
@@ -172,18 +199,18 @@ Three-tier progressive auth — determined by the number of registered users at 
 
 ---
 
-## Prompt Guards
+## Prompt guards
 
-`agent/promptGuards.ts` wraps all user-controlled content before sending to models — escapes special characters, formats preference context blocks, and structures conversation history to prevent prompt injection. See `docs/adr/0001-prompt-injection-guardrails.md` for the design rationale.
+`agent/promptGuards.ts` wraps all user-controlled content before sending to models — escapes special characters, formats preference context blocks, and structures conversation history to prevent prompt injection. See [ADR 0001](../adr/0001-prompt-injection-guardrails.md) for the design rationale.
 
 ---
 
-## Key Design Decisions
+## Key design decisions
 
 | Decision | Rationale |
-|----------|-----------|
+|----------|----------|
 | **Gemini for all graph nodes** | Consistent structured-JSON output across plan / extract / reflect / rank; low temperature (0.2) for planning reduces variance |
-| **Claude as optional async judge only** | Keeps Claude off the critical response path; eval can be added/removed without touching the graph |
+| **Mistral as optional async judge only** | Keeps eval off the critical response path; can be added/removed without touching the graph |
 | **Budget-aware graph** | Hard wall-clock deadline enforced via `researchBudget.ts`; conditional edges bypass remaining nodes gracefully instead of timing out mid-flight |
 | **Pluggable storage** | Abstract repository pattern allows SQLite → Postgres → Turso swap without touching business logic |
 | **Progressive auth** | Single-user deployments require no configuration; auth activates as users are added |


### PR DESCRIPTION
## Summary\n\n- `docs/architecture/ARCHITECTURE.md` — replaced ASCII art flow diagrams with proper Mermaid flowcharts for the main graph, reflection subgraph, and added a high-level system overview diagram. Also fixed a minor inconsistency: the eval layer section referenced \"Claude\" as the LLM judge but the README and External Integrations table both say Mistral — aligned to Mistral throughout.\n- `docs/README.md` — added the missing `2026-06-03-auto-update-plan.md` entry to the doc index table.\n\n## What was not changed\n\n`README.md` is already comprehensive, accurate, and has a Mermaid diagram — no changes needed there.\n\n## Review notes\n\n- The Mistral/Claude fix in ARCHITECTURE.md is based on the root README's env variables table (`MISTRAL_API_KEY` listed, not `ANTHROPIC_API_KEY`). Please confirm this is correct before merging.\n- All Mermaid diagrams match the pipeline described in the existing README and code structure."

---
_Generated by [Claude Code](https://claude.ai/code/session_016jUJcCP2tSr4bqULuCmrPr)_