### PR TITLE
fix(ci): Node 20→22 (matches engines constraint) + weekly maintenance log

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Setup Python

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -1,0 +1,76 @@
+# Maintenance Log
+
+Weekly dependency and health checks for the Bandsearch application.
+
+---
+
+## 2026-06-10
+
+### Checks performed
+- Reviewed root `package.json`, `apps/desktop/package.json`, `services/api/package.json`
+- Reviewed `apps/desktop/src-tauri/Cargo.toml`
+- Reviewed CI workflow in `.github/workflows/ci.yml`
+- Compared versions across all workspaces
+
+### Fixes applied
+
+- **CI Node version (bug fix)** — Bumped Node from `20` to `22` in `.github/workflows/ci.yml`. The root `package.json` declares `"engines": { "node": ">=22" }` but CI was running Node 20, meaning every CI run executed on a Node version the project explicitly does not support. This is now consistent.
+
+### Dependency status
+
+**Root workspace (`package.json`):**
+
+| Package | Version | Status |
+|---|---|---|
+| `tsx` | `^4.22.3` | Current |
+| `typescript` | `^6.0.3` | Current |
+| `eslint` | `^10.4.0` | Current |
+| `@playwright/test` | `^1.59.1` | Current |
+| `husky` | `^9.1.7` | Current |
+| `globals` | `^17.6.0` | Current |
+| `typescript-eslint` | `^8.60.0` | Current |
+
+**`apps/desktop` (`apps/desktop/package.json`):**
+
+| Package | Version | Status |
+|---|---|---|
+| `@tauri-apps/api` | `^2.11.0` | Current |
+| `@tauri-apps/cli` | `^2.11.2` | Current |
+| `react` | `^19.2.6` | Current |
+| `react-dom` | `^19.2.6` | Current |
+| `esbuild` | `^0.28.0` | Current |
+
+**`apps/desktop` Rust (`apps/desktop/src-tauri/Cargo.toml`):**
+Uses broad `version = "2"` constraints for tauri — resolved by `Cargo.lock`.
+
+| Crate | Constraint | Status |
+|---|---|---|
+| `tauri` | `2` | Current |
+| `tauri-build` | `2` | Current |
+| `tauri-plugin-opener` | `2` | Current |
+| `serde` / `serde_json` | `1` | Current |
+| `dirs` | `5` | Current |
+
+**`services/api` (`services/api/package.json`):**
+
+| Package | Version | Status |
+|---|---|---|
+| `express` | `^5.2.1` | Current |
+| `zod` | `^4.4.3` | Current |
+| `@langchain/langgraph` | `^1.3.2` | Current |
+| `@langchain/google-genai` | `^2.1.31` | Current |
+| `better-sqlite3` | `^12.10.0` | Current |
+| `dotenv` | `^17.4.2` | Current |
+| `jsonwebtoken` | `^9.0.3` | Current |
+| `bcryptjs` | `^3.0.3` | Current |
+| `helmet` | `^8.2.0` | Current |
+| `express-rate-limit` | `^8.5.2` | Current |
+| `@libsql/client` | `^0.17.3` | Current |
+| `pg` | `^8.21.0` | Current |
+
+### Notes
+
+- **Dual lock files:** `package-lock.json` (root) and `pnpm-lock.yaml` both exist. CI uses `npm ci` (reads `package-lock.json`). If pnpm is used locally the resolved versions may differ from CI. Consider removing one set of lock files to avoid drift.
+
+### No major upgrades pending
+All packages are on current major versions this cycle.


### PR DESCRIPTION
## Weekly maintenance check — 2026-06-10

### What was checked
- Root `package.json` and workspace packages (`apps/desktop`, `services/api`)
- `apps/desktop/src-tauri/Cargo.toml` Rust dependencies
- CI workflow in `.github/workflows/ci.yml`
- Cross-repo consistency with job-tracker and radiationsafety

---

### Changes in this PR

#### `.github/workflows/ci.yml` — **bug fix**: Node 20 → 22

The root `package.json` declares:
```json
"engines": { "node": ">=22" }
```
But CI was running `node-version: 20`. This means **every CI run executed on a Node version the project explicitly does not support**. Fixed by bumping to Node 22.

#### `docs/maintenance.md` — new file
Introduces a weekly maintenance log. Records the CI fix, full dependency status across all workspaces (root, desktop, api, Rust), and a note about the dual lock-file situation.

---

### Dependency assessment

**All workspaces look healthy:**
- Root: TypeScript 6, ESLint 10, tsx 4, husky 9 — all current
- `apps/desktop`: Tauri 2.11, React 19, esbuild 0.28 — all current
- `services/api`: Express 5, Zod 4, LangGraph 1.3, better-sqlite3 12, dotenv 17 — all current
- Rust: uses broad `version = "2"` constraints resolved by Cargo.lock — no manual action needed

### Housekeeping note (not blocking)
Two lock files coexist: `package-lock.json` (used by CI via `npm ci`) and `pnpm-lock.yaml` (potentially used locally). If pnpm is the primary local package manager, the two files can drift. Documented in the maintenance log; no code change required now.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GSe7RhJyeybkvnu2Lpt18s)_