### PR TITLE
docs: add missing auto-update plan to docs index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ Navigation guide for the `docs/` folder.
 | [architecture/ARCHITECTURE.md](architecture/ARCHITECTURE.md) | System architecture — graph pipeline, state fields, integrations, storage, auth |
 | [architecture/2026-05-29-eval-architecture.md](architecture/2026-05-29-eval-architecture.md) | Evaluation layer design — three-tier scoring, LLM-as-judge, feedback loop |
 | [architecture/2026-05-30-phase8-implementation-plan.md](architecture/2026-05-30-phase8-implementation-plan.md) | Phase 8 step-by-step implementation plan (eval & quality observability) |
+| [architecture/2026-06-03-auto-update-plan.md](architecture/2026-06-03-auto-update-plan.md) | Auto-update design for the Tauri desktop client |
 | [adr/0001-prompt-injection-guardrails.md](adr/0001-prompt-injection-guardrails.md) | ADR: prompt injection defence — bracket-marker envelope and length caps |
 | [design/UI_GUIDELINES.md](design/UI_GUIDELINES.md) | UI design guidelines — layout, components, responsive behaviour |
 | [design/UI_EXAMPLES.md](design/UI_EXAMPLES.md) | UI copy examples and interaction patterns |


### PR DESCRIPTION
## What changed

`docs/README.md` was missing a reference to `architecture/2026-06-03-auto-update-plan.md`, which exists in the folder but wasn't listed in the index.

## Why

The docs index is the navigation entry point — unlisted files are effectively invisible to readers and AI agents consulting the docs. Everything else in `docs/` was already up to date: the README already has the mermaid pipeline diagram, and `docs/architecture/ARCHITECTURE.md` is comprehensive.

## Changes

- `docs/README.md` — added row for `architecture/2026-06-03-auto-update-plan.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01B14vrShxZsDCX57VcT5VeE)_