### PR TITLE
docs: restructure README for new readers, add Features section

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,19 @@
 ![Status: Alpha](https://img.shields.io/badge/status-alpha-orange)
 ![Version: 0.4.0--alpha.0](https://img.shields.io/badge/version-0.4.0--alpha.0-blue)
 
-AI-powered music recommendations for niche and lesser-known artists.
-Combines conversational AI with MusicBrainz metadata and preference memory.
+AI-powered music recommendations for niche and lesser-known artists. Describe bands you love, and Bandsearch surfaces similar but lesser-known picks — verified against MusicBrainz, ranked by Gemini.
 
-**Recommendation pipeline:** Gemini plans Brave web searches (FFO/Bandcamp-style discovery), extracts candidate band names from snippets, verifies them via MusicBrainz (`lookupArtist` with tags/genres/URL relations), optionally runs up to two reflection rounds (each processes only the new hits from that round and accumulates candidates across rounds), then ranks picks with evidence-grounded `why` text. `BRAVE_API_KEY` is required at startup — there is no fallback.
+## Features
+
+- **Niche artist discovery** — Gemini plans targeted Brave searches (FFO/Bandcamp-style) to find obscure artists that match your taste
+- **MusicBrainz verified** — every suggestion is checked against real artist records (mbid, genres, tags, URL relations)
+- **Preference memory** — save and rate bands; future recommendations adapt to your listening history
+- **Reflection loop** — if the first search pass is thin, the AI generates refined queries and searches again (up to 2 extra rounds)
+- **Native desktop app** — Tauri shell for Linux, macOS, and Windows; API keys stored in the OS config directory
+- **Flexible storage** — SQLite by default, Postgres or Turso for shared/cloud deployments
+- **Optional multi-user auth** — activates automatically once you register the first account; single-user setups need no config
+
+## How it works
 
 ```mermaid
 flowchart TD
@@ -194,7 +203,7 @@ Turso URL and auth token can also be saved through the **Settings** screen in th
 | `MUSICBRAINZ_TIMEOUT_MS` | `5000` | MusicBrainz request timeout |
 | `MUSICBRAINZ_RETRIES` | `1` | MusicBrainz retry attempts |
 | `LASTFM_API_KEY` | — | Optional — Last.fm fallback for artist images and obscurity scoring (listener counts) |
-| `MISTRAL_API_KEY` | — | Optional — activates the async LLM-as-judge eval worker (Mistral scores recommendations after the response is sent)
+| `MISTRAL_API_KEY` | — | Optional — activates the async LLM-as-judge eval worker (Mistral scores recommendations after the response is sent) |
 | `EVAL_DASHBOARD_ENABLED` | — | Set `true` to enable the developer eval dashboard at `/eval/dashboard` |
 | `LANGSMITH_API_KEY` | — | Optional LangSmith tracing |
 | `LANGSMITH_TRACING` | — | Set `true` to enable tracing |


### PR DESCRIPTION
## What changed

The README was comprehensive but jumped straight from a one-line description into a dense pipeline paragraph. This made it harder for someone landing on the repo for the first time to quickly understand what the app does before diving into implementation details.

### Changes

**README.md**
- Added a **Features** section after the description — a scannable bullet list of what the app actually gives you (discovery, MusicBrainz verification, preference memory, reflection loop, desktop app, storage options, auth)
- Added a `## How it works` heading over the existing Mermaid pipeline diagram so it's clearly labelled
- Removed the verbose inline "Recommendation pipeline:" paragraph (the diagram already communicates this visually)
- All other content (Quick Start, Desktop App, Auth, Storage, Env Vars, API Reference, Development, Monorepo Structure, Acknowledgements) is unchanged

## What was not changed

- `docs/README.md` — already a clean navigation guide, no changes needed
- `docs/architecture/ARCHITECTURE.md` — already has excellent Mermaid diagrams, no changes needed
- All other docs files — up to date

---
_Generated by [Claude Code](https://claude.ai/code/session_01561kHsmVHCjd5sZUqcrwHp)_