### PR TITLE
ci: enforce staging→main workflow and document branching

### DIFF
--- a/.github/workflows/protect-main.yml
+++ b/.github/workflows/protect-main.yml
@@ -1,0 +1,19 @@
+name: Protect main
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  require-staging:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check source branch is staging
+        run: |
+          if [ "${{ github.head_ref }}" != "staging" ]; then
+            echo "❌ PRs into main must come from 'staging', not '${{ github.head_ref }}'."
+            echo "   Workflow: feature branch → staging → main"
+            exit 1
+          fi
+          echo "✅ Source branch is staging — allowed to merge into main."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,17 @@ Implement TypeScript as a parallel, non-blocking track: migrate incrementally in
 
 **Sequentiell arbeiten, nicht parallel.**
 
+### Branching workflow
+
+```
+feature branch  →  staging  →  main
+```
+
+- All PRs target `staging`, never `main` directly
+- `main` is only updated by merging `staging` → `main` after validation
+- When creating a feature branch or fixing a bug, set `base = staging` in the PR
+- `staging` acts as the integration/QA gate before production (`main`)
+
 ## Testing
 
 TDD-Ansatz: erst Tests schreiben (rot), dann implementieren (grün), dann refactoren.


### PR DESCRIPTION
## What

Sets up the `feature → staging → main` branch workflow (adapted from the Radiationsafety repo, using `main` since this repo has no `master`).

- **`.github/workflows/protect-main.yml`** — fails any PR into `main` whose source branch is not `staging`.
- **`AGENTS.md`** — documents the branching workflow under *Git & PR Workflow*.

## Notes

- `staging` already existed and is in sync with `main` (0 ahead / 0 behind), so no sync PR was needed.
- Manual GitHub branch-protection settings still need to be configured (see chat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)