### PR TITLE
docs: weekly maintenance check 2026-06-17

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -4,6 +4,28 @@ Weekly dependency and health checks for the Bandsearch application.
 
 ---
 
+## 2026-06-17
+
+### Checks performed
+- Reviewed all CI workflows — all passing (last successful run: 2026-06-17T13:42:21Z, branch: chore/branch-protection-workflow)
+- Reviewed root `package.json`, `apps/desktop/package.json`, `services/api/package.json`
+- Reviewed `apps/desktop/src-tauri/Cargo.toml`
+- Compared versions against current ecosystem state
+
+### Fixes applied
+No fixes needed this cycle.
+
+### Dependency status
+No changes to any dependency constraints since 2026-06-10. All packages remain on current major versions.
+
+**Persistent note (dual lock files):**
+`package-lock.json` and `pnpm-lock.yaml` still coexist at the repo root. CI uses `npm ci` so resolved versions may drift if contributors use pnpm locally. Consider consolidating to a single package manager when convenient.
+
+### No major upgrades pending
+All packages are on current major versions this cycle.
+
+---
+
 ## 2026-06-10
 
 ### Checks performed


### PR DESCRIPTION
## Weekly health check — 2026-06-17

### What was checked
- All CI workflows (`.github/workflows/ci.yml`)
- Root `package.json`
- `apps/desktop/package.json` and `apps/desktop/src-tauri/Cargo.toml`
- `services/api/package.json`

### Result: everything healthy

| Check | Status |
|---|---|
| CI (last run 2026-06-17T13:42:21Z) | ✅ passing |
| Root workspace deps | ✅ all current |
| Desktop app deps (npm + Rust) | ✅ all current |
| API service deps | ✅ all current |

### Changes in this PR
- `docs/maintenance.md` — added 2026-06-17 weekly entry

### Persistent note (carried over, no action required this week)
The root directory still has both `package-lock.json` and `pnpm-lock.yaml`. CI uses `npm ci`, so this is not breaking anything, but it creates potential for version drift between local (pnpm) and CI (npm) environments. Consider removing one when convenient.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BeqgNgwLhCvPKsr2kJ1gA9)_