### PR TITLE
feat(desktop): configurable remote API endpoint with dynamic sidecar lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,19 @@
 ![Status: Alpha](https://img.shields.io/badge/status-alpha-orange)
 ![Version: 0.4.0--alpha.0](https://img.shields.io/badge/version-0.4.0--alpha.0-blue)
 
-AI-powered music recommendations for niche and lesser-known artists.
-Combines conversational AI with MusicBrainz metadata and preference memory.
+AI-powered music recommendations for niche and lesser-known artists. Describe bands you love, and Bandsearch surfaces similar but lesser-known picks — verified against MusicBrainz, ranked by Gemini.
 
-**Recommendation pipeline:** Gemini plans Brave web searches (FFO/Bandcamp-style discovery), extracts candidate band names from snippets, verifies them via MusicBrainz (`lookupArtist` with tags/genres/URL relations), optionally runs up to two reflection rounds (each processes only the new hits from that round and accumulates candidates across rounds), then ranks picks with evidence-grounded `why` text. `BRAVE_API_KEY` is required at startup — there is no fallback.
+## Features
+
+- **Niche artist discovery** — Gemini plans targeted Brave searches (FFO/Bandcamp-style) to find obscure artists that match your taste
+- **MusicBrainz verified** — every suggestion is checked against real artist records (mbid, genres, tags, URL relations)
+- **Preference memory** — save and rate bands; future recommendations adapt to your listening history
+- **Reflection loop** — if the first search pass is thin, the AI generates refined queries and searches again (up to 2 extra rounds)
+- **Native desktop app** — Tauri shell for Linux, macOS, and Windows; API keys stored in the OS config directory
+- **Flexible storage** — SQLite by default, Postgres or Turso for shared/cloud deployments
+- **Optional multi-user auth** — activates automatically once you register the first account; single-user setups need no config
+
+## How it works
 
 ```mermaid
 flowchart TD
@@ -194,7 +203,7 @@ Turso URL and auth token can also be saved through the **Settings** screen in th
 | `MUSICBRAINZ_TIMEOUT_MS` | `5000` | MusicBrainz request timeout |
 | `MUSICBRAINZ_RETRIES` | `1` | MusicBrainz retry attempts |
 | `LASTFM_API_KEY` | — | Optional — Last.fm fallback for artist images and obscurity scoring (listener counts) |
-| `MISTRAL_API_KEY` | — | Optional — activates the async LLM-as-judge eval worker (Mistral scores recommendations after the response is sent)
+| `MISTRAL_API_KEY` | — | Optional — activates the async LLM-as-judge eval worker (Mistral scores recommendations after the response is sent) |
 | `EVAL_DASHBOARD_ENABLED` | — | Set `true` to enable the developer eval dashboard at `/eval/dashboard` |
 | `LANGSMITH_API_KEY` | — | Optional LangSmith tracing |
 | `LANGSMITH_TRACING` | — | Set `true` to enable tracing |

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -28,6 +28,8 @@ struct BandsearchConfig {
     turso_auth_token: String,
     #[serde(default)]
     jwt_secret: String,
+    #[serde(default)]
+    api_endpoint_url: String,
 }
 
 #[derive(Serialize)]
@@ -40,6 +42,7 @@ struct GeminiConfigStatus {
     gemini_key_from_env: bool,
     brave_key_from_env: bool,
     turso_from_env: bool,
+    api_endpoint_url: String,
 }
 
 /// Returns true when the named environment variable is set to a non-blank value.
@@ -64,6 +67,27 @@ struct SaveBraveApiKeyRequest {
 struct SaveTursoConfigRequest {
     database_url: String,
     auth_token: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SaveApiEndpointUrlRequest {
+    url: String,
+}
+
+/// The local API sidecar runs only when no remote endpoint is configured.
+/// A blank (or whitespace-only) endpoint means "use the local sidecar".
+fn should_run_local_sidecar(api_endpoint_url: &str) -> bool {
+    api_endpoint_url.trim().is_empty()
+}
+
+/// Defensive http(s) URL check for the configured remote endpoint. The friendly,
+/// user-facing validation lives in the settings controller (`new URL(...)`); this
+/// is a last-resort guard so a malformed value never reaches the spawn logic.
+fn is_valid_http_url(value: &str) -> bool {
+    let v = value.trim();
+    (v.starts_with("http://") && v.len() > "http://".len())
+        || (v.starts_with("https://") && v.len() > "https://".len())
 }
 
 fn config_file_path() -> Result<PathBuf, String> {
@@ -346,6 +370,15 @@ fn start_api_sidecar(
     }
 }
 
+/// Kills the running API sidecar child, if any, and clears the slot.
+fn stop_api_sidecar(api: &ApiProcess) {
+    if let Ok(mut guard) = api.0.lock() {
+        if let Some(mut child) = guard.take() {
+            let _ = child.kill();
+        }
+    }
+}
+
 fn restart_api_sidecar(
     api: &ApiProcess,
     workspace_root: &Path,
@@ -355,12 +388,26 @@ fn restart_api_sidecar(
     turso_token: Option<&str>,
     jwt_secret: &str,
 ) {
-    if let Ok(mut guard) = api.0.lock() {
-        if let Some(mut child) = guard.take() {
-            let _ = child.kill();
-        }
-    }
+    stop_api_sidecar(api);
     start_api_sidecar(api, workspace_root, gemini_key, brave_key, turso_url, turso_token, jwt_secret);
+}
+
+/// Single source of truth for the local-sidecar lifecycle. Reads the current config
+/// and reconciles the running process with it: (re)start the sidecar when no remote
+/// endpoint is set, otherwise stop it. Every settings change funnels through here so
+/// the invariant "local sidecar runs iff no remote endpoint" holds in one place.
+fn reconcile_sidecar(api: &ApiProcess, workspace_root: &Path) {
+    let cfg = load_config();
+    if should_run_local_sidecar(&cfg.api_endpoint_url) {
+        let gemini = gemini_key_for_spawn();
+        let brave = brave_key_for_spawn();
+        let (turso_url, turso_tok) = turso_for_spawn();
+        let jwt = ensure_jwt_secret();
+        restart_api_sidecar(api, workspace_root, gemini.as_deref(), brave.as_deref(), turso_url.as_deref(), turso_tok.as_deref(), &jwt);
+    } else {
+        eprintln!("[bandsearch] remote API endpoint configured — stopping local sidecar");
+        stop_api_sidecar(api);
+    }
 }
 
 fn build_app_menu(app: &tauri::AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
@@ -390,6 +437,7 @@ fn gemini_config_status() -> Result<GeminiConfigStatus, String> {
         gemini_key_from_env,
         brave_key_from_env,
         turso_from_env,
+        api_endpoint_url: cfg.api_endpoint_url.trim().to_string(),
     })
 }
 
@@ -407,10 +455,7 @@ fn save_gemini_api_key(
     cfg.gemini_api_key = trimmed.to_string();
     cfg.onboarding_completed = true;
     persist_config(&cfg)?;
-    let brave = brave_key_for_spawn();
-    let (turso_url, turso_tok) = turso_for_spawn();
-    let jwt = ensure_jwt_secret();
-    restart_api_sidecar(api.inner(), &workspace.0, Some(trimmed), brave.as_deref(), turso_url.as_deref(), turso_tok.as_deref(), &jwt);
+    reconcile_sidecar(api.inner(), &workspace.0);
     Ok(())
 }
 
@@ -427,10 +472,7 @@ fn save_brave_api_key(
     let mut cfg = load_config();
     cfg.brave_api_key = trimmed.to_string();
     persist_config(&cfg)?;
-    let gemini = gemini_key_for_spawn();
-    let (turso_url, turso_tok) = turso_for_spawn();
-    let jwt = ensure_jwt_secret();
-    restart_api_sidecar(api.inner(), &workspace.0, gemini.as_deref(), Some(trimmed), turso_url.as_deref(), turso_tok.as_deref(), &jwt);
+    reconcile_sidecar(api.inner(), &workspace.0);
     Ok(())
 }
 
@@ -448,10 +490,7 @@ fn save_turso_config(
     cfg.turso_database_url = url.to_string();
     cfg.turso_auth_token = req.auth_token.trim().to_string();
     persist_config(&cfg)?;
-    let gemini = gemini_key_for_spawn();
-    let brave = brave_key_for_spawn();
-    let jwt = ensure_jwt_secret();
-    restart_api_sidecar(api.inner(), &workspace.0, gemini.as_deref(), brave.as_deref(), Some(url), Some(cfg.turso_auth_token.as_str()), &jwt);
+    reconcile_sidecar(api.inner(), &workspace.0);
     Ok(())
 }
 
@@ -464,10 +503,26 @@ fn clear_turso_config(
     cfg.turso_database_url = String::new();
     cfg.turso_auth_token = String::new();
     persist_config(&cfg)?;
-    let gemini = gemini_key_for_spawn();
-    let brave = brave_key_for_spawn();
-    let jwt = ensure_jwt_secret();
-    restart_api_sidecar(api.inner(), &workspace.0, gemini.as_deref(), brave.as_deref(), None, None, &jwt);
+    reconcile_sidecar(api.inner(), &workspace.0);
+    Ok(())
+}
+
+#[tauri::command]
+fn save_api_endpoint_url(
+    workspace: State<'_, WorkspaceRoot>,
+    api: State<'_, ApiProcess>,
+    req: SaveApiEndpointUrlRequest,
+) -> Result<(), String> {
+    let trimmed = req.url.trim();
+    if !trimmed.is_empty() && !is_valid_http_url(trimmed) {
+        return Err("API endpoint must be an http(s) URL".into());
+    }
+    let mut cfg = load_config();
+    cfg.api_endpoint_url = trimmed.to_string();
+    persist_config(&cfg)?;
+    // Reconcile the sidecar: a remote endpoint stops the local one; clearing it
+    // (blank URL) restarts the local sidecar with the stored keys.
+    reconcile_sidecar(api.inner(), &workspace.0);
     Ok(())
 }
 
@@ -481,7 +536,7 @@ fn complete_onboarding() -> Result<(), String> {
 fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
-        .invoke_handler(tauri::generate_handler![gemini_config_status, save_gemini_api_key, save_brave_api_key, save_turso_config, clear_turso_config, complete_onboarding])
+        .invoke_handler(tauri::generate_handler![gemini_config_status, save_gemini_api_key, save_brave_api_key, save_turso_config, clear_turso_config, save_api_endpoint_url, complete_onboarding])
         .setup(|app| {
             let menu = build_app_menu(&app.handle())?;
             app.set_menu(menu)?;
@@ -495,11 +550,8 @@ fn main() {
             );
 
             let api = ApiProcess(Mutex::new(None));
-            let gemini = gemini_key_for_spawn();
-            let brave = brave_key_for_spawn();
-            let (turso_url, turso_tok) = turso_for_spawn();
-            let jwt = ensure_jwt_secret();
-            start_api_sidecar(&api, &workspace_root, gemini.as_deref(), brave.as_deref(), turso_url.as_deref(), turso_tok.as_deref(), &jwt);
+            // Start the local sidecar only when no remote endpoint is configured.
+            reconcile_sidecar(&api, &workspace_root);
 
             app.manage(api);
             app.manage(WorkspaceRoot(workspace_root));
@@ -510,11 +562,7 @@ fn main() {
             if let WindowEvent::Destroyed = event {
                 if window.label() == "main" {
                     if let Some(state) = window.try_state::<ApiProcess>() {
-                        if let Ok(mut guard) = state.0.lock() {
-                            if let Some(mut child) = guard.take() {
-                                let _ = child.kill();
-                            }
-                        }
+                        stop_api_sidecar(&state);
                     }
                 }
             }
@@ -653,5 +701,72 @@ mod tests {
         std::env::set_var(key, "   ");
         assert!(!env_non_empty(key));
         std::env::remove_var(key);
+    }
+
+    #[test]
+    fn should_run_local_sidecar_true_when_endpoint_blank() {
+        assert!(should_run_local_sidecar(""));
+    }
+
+    #[test]
+    fn should_run_local_sidecar_true_when_endpoint_whitespace() {
+        assert!(should_run_local_sidecar("   "));
+    }
+
+    #[test]
+    fn should_run_local_sidecar_false_when_endpoint_set() {
+        assert!(!should_run_local_sidecar("https://bandsearch.onrender.com"));
+    }
+
+    #[test]
+    fn is_valid_http_url_accepts_http_and_https() {
+        assert!(is_valid_http_url("http://localhost:3001"));
+        assert!(is_valid_http_url("https://bandsearch.onrender.com"));
+        assert!(is_valid_http_url("  https://example.com  "));
+    }
+
+    #[test]
+    fn is_valid_http_url_rejects_non_http_and_empty() {
+        assert!(!is_valid_http_url(""));
+        assert!(!is_valid_http_url("   "));
+        assert!(!is_valid_http_url("ftp://example.com"));
+        assert!(!is_valid_http_url("javascript:alert(1)"));
+        assert!(!is_valid_http_url("http://"));
+        assert!(!is_valid_http_url("https://"));
+        assert!(!is_valid_http_url("bandsearch.onrender.com"));
+    }
+
+    #[test]
+    fn config_defaults_api_endpoint_url_to_empty_when_absent() {
+        // Older config.json files predate the field; serde(default) must keep them valid.
+        let cfg: BandsearchConfig = serde_json::from_str(r#"{"gemini_api_key":"k"}"#)
+            .expect("config without api_endpoint_url must still parse");
+        assert_eq!(cfg.api_endpoint_url, "");
+        assert!(should_run_local_sidecar(&cfg.api_endpoint_url));
+    }
+
+    #[test]
+    fn config_round_trips_api_endpoint_url() {
+        let cfg: BandsearchConfig =
+            serde_json::from_str(r#"{"api_endpoint_url":"https://remote.example"}"#)
+                .expect("config with api_endpoint_url must parse");
+        assert_eq!(cfg.api_endpoint_url, "https://remote.example");
+        assert!(!should_run_local_sidecar(&cfg.api_endpoint_url));
+    }
+
+    #[test]
+    fn gemini_config_status_serializes_api_endpoint_url_camel_case() {
+        let status = GeminiConfigStatus {
+            has_stored_key: false,
+            has_brave_key: false,
+            onboarding_complete: false,
+            has_turso_config: false,
+            gemini_key_from_env: false,
+            brave_key_from_env: false,
+            turso_from_env: false,
+            api_endpoint_url: "https://remote.example".to_string(),
+        };
+        let value = serde_json::to_value(&status).expect("status must serialize");
+        assert_eq!(value["apiEndpointUrl"], "https://remote.example");
     }
 }

--- a/apps/desktop/src/geminiDesktopSettings.ts
+++ b/apps/desktop/src/geminiDesktopSettings.ts
@@ -1,7 +1,19 @@
 import { FIRST_RUN_ONBOARDING_STORAGE_KEY } from "./firstRunOnboarding.js";
 
+export const API_ENDPOINT_STORAGE_KEY = "bandsearch_api_endpoint_url";
+
 type StatusMessage = { type: "success" | "error"; text: string };
 type ProbeResult = { ok: boolean; error?: string };
+
+/** True for a non-empty http(s) URL. Empty is handled separately (= reset to local). */
+function isHttpUrl(value: string): boolean {
+  try {
+    const u = new URL(value);
+    return u.protocol === "http:" || u.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
 
 async function defaultProbeTursoConnection(url: string, token: string): Promise<ProbeResult> {
   try {
@@ -27,6 +39,7 @@ export function createGeminiSettingsController(options: GeminiSettingsController
   let geminiStatus: StatusMessage | null = null;
   let braveStatus: StatusMessage | null = null;
   let tursoStatus: StatusMessage | null = null;
+  let apiEndpointStatus: StatusMessage | null = null;
 
   async function getBootstrapGate() {
     if (typeof invokeTauri === "function") {
@@ -34,24 +47,27 @@ export function createGeminiSettingsController(options: GeminiSettingsController
         const r = (await invokeTauri("gemini_config_status")) as {
           hasStoredKey?: boolean;
           onboardingComplete?: boolean;
+          apiEndpointUrl?: string;
         };
         return {
           hasStoredKey: Boolean(r?.hasStoredKey),
           onboardingComplete: Boolean(r?.onboardingComplete),
+          apiEndpointUrl: String(r?.apiEndpointUrl ?? "").trim(),
         };
       } catch {
-        return { hasStoredKey: false, onboardingComplete: false };
+        return { hasStoredKey: false, onboardingComplete: false, apiEndpointUrl: "" };
       }
     }
     try {
       const ls = globalThis.localStorage;
-      if (!ls) return { hasStoredKey: false, onboardingComplete: false };
+      if (!ls) return { hasStoredKey: false, onboardingComplete: false, apiEndpointUrl: "" };
       return {
         hasStoredKey: Boolean(ls.getItem("bandsearch_gemini_api_key")?.trim()),
         onboardingComplete: ls.getItem(FIRST_RUN_ONBOARDING_STORAGE_KEY) === "1",
+        apiEndpointUrl: String(ls.getItem(API_ENDPOINT_STORAGE_KEY) ?? "").trim(),
       };
     } catch {
-      return { hasStoredKey: false, onboardingComplete: false };
+      return { hasStoredKey: false, onboardingComplete: false, apiEndpointUrl: "" };
     }
   }
 
@@ -78,6 +94,7 @@ export function createGeminiSettingsController(options: GeminiSettingsController
     let geminiKeyFromEnv = false;
     let braveKeyFromEnv = false;
     let tursoFromEnv = false;
+    let apiEndpointUrl = "";
 
     if (typeof invokeTauri === "function") {
       try {
@@ -88,6 +105,7 @@ export function createGeminiSettingsController(options: GeminiSettingsController
           geminiKeyFromEnv?: boolean;
           braveKeyFromEnv?: boolean;
           tursoFromEnv?: boolean;
+          apiEndpointUrl?: string;
         };
         hasStoredKey = Boolean(r?.hasStoredKey);
         hasBraveKey = Boolean(r?.hasBraveKey);
@@ -95,6 +113,7 @@ export function createGeminiSettingsController(options: GeminiSettingsController
         geminiKeyFromEnv = Boolean(r?.geminiKeyFromEnv);
         braveKeyFromEnv = Boolean(r?.braveKeyFromEnv);
         tursoFromEnv = Boolean(r?.tursoFromEnv);
+        apiEndpointUrl = String(r?.apiEndpointUrl ?? "").trim();
       } catch {
         /* defaults */
       }
@@ -105,6 +124,7 @@ export function createGeminiSettingsController(options: GeminiSettingsController
           hasStoredKey = Boolean(ls.getItem("bandsearch_gemini_api_key")?.trim());
           hasBraveKey = Boolean(ls.getItem("bandsearch_brave_api_key")?.trim());
           hasTursoConfig = Boolean(ls.getItem("bandsearch_turso_database_url")?.trim());
+          apiEndpointUrl = String(ls.getItem(API_ENDPOINT_STORAGE_KEY) ?? "").trim();
         }
       } catch {
         /* defaults */
@@ -120,10 +140,12 @@ export function createGeminiSettingsController(options: GeminiSettingsController
       geminiKeyFromEnv,
       braveKeyFromEnv,
       tursoFromEnv,
+      apiEndpointUrl,
       statusMessage: geminiStatus ?? braveStatus,
       geminiStatusMessage: geminiStatus,
       braveStatusMessage: braveStatus,
       tursoStatusMessage: tursoStatus,
+      apiEndpointStatusMessage: apiEndpointStatus,
     };
   }
 
@@ -236,6 +258,43 @@ export function createGeminiSettingsController(options: GeminiSettingsController
     }
   }
 
+  async function saveApiEndpointUrl(endpointUrl: string) {
+    const trimmed = String(endpointUrl || "").trim();
+    // A blank value resets to the local sidecar; any non-blank value must be a URL.
+    if (trimmed && !isHttpUrl(trimmed)) {
+      apiEndpointStatus = {
+        type: "error",
+        text: "Enter a valid http(s) URL, or leave blank to use the built-in local app.",
+      };
+      return;
+    }
+
+    const successText = trimmed
+      ? "Saved. The app will use the remote API from the next restart."
+      : "Reset. The app will use the built-in local API from the next restart.";
+
+    if (typeof invokeTauri === "function") {
+      try {
+        await invokeTauri("save_api_endpoint_url", { url: trimmed });
+        apiEndpointStatus = { type: "success", text: successText };
+      } catch (e) {
+        const err = e as { message?: string };
+        apiEndpointStatus = { type: "error", text: String(err?.message || e || "Could not save endpoint.") };
+      }
+      return;
+    }
+
+    try {
+      const ls = globalThis.localStorage;
+      if (trimmed) ls?.setItem(API_ENDPOINT_STORAGE_KEY, trimmed);
+      else ls?.removeItem(API_ENDPOINT_STORAGE_KEY);
+      apiEndpointStatus = { type: "success", text: successText };
+    } catch (e) {
+      const err = e as { message?: string };
+      apiEndpointStatus = { type: "error", text: String(err?.message || e || "Could not save endpoint.") };
+    }
+  }
+
   async function clearTursoConfig() {
     if (typeof invokeTauri === "function") {
       try {
@@ -254,6 +313,7 @@ export function createGeminiSettingsController(options: GeminiSettingsController
     saveBraveApiKey,
     saveTursoConfig,
     clearTursoConfig,
+    saveApiEndpointUrl,
     getBootstrapGate,
     completeOnboarding,
   };

--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -64,6 +64,7 @@ export type BootstrapDesktopReactAppOptions = {
   saveBraveApiKey?: (apiKey: string) => Promise<void>;
   saveTursoConfig?: (url: string, token: string) => Promise<void>;
   clearTursoConfig?: () => Promise<void>;
+  saveApiEndpointUrl?: (url: string) => Promise<void>;
   completeOnboarding?: () => Promise<void>;
   onLogin?: (email: string, password: string) => Promise<void>;
   onRegister?: (email: string, displayName: string, password: string) => Promise<{ recoveryCode: string }>;
@@ -82,6 +83,7 @@ function bootstrapDesktopReactApp(options: BootstrapDesktopReactAppOptions = {})
     saveBraveApiKey,
     saveTursoConfig,
     clearTursoConfig,
+    saveApiEndpointUrl,
     completeOnboarding,
     onLogin,
     onRegister,
@@ -97,6 +99,7 @@ function bootstrapDesktopReactApp(options: BootstrapDesktopReactAppOptions = {})
     saveBraveApiKey,
     saveTursoConfig,
     clearTursoConfig,
+    saveApiEndpointUrl,
     completeOnboarding,
     onLogin,
     onRegister,

--- a/apps/desktop/src/startDesktopBrowserApp.ts
+++ b/apps/desktop/src/startDesktopBrowserApp.ts
@@ -77,12 +77,16 @@ export async function startDesktopBrowserApp({
     router.navigate("login");
   });
 
+  const normalizeBase = (url: string): string => (url.endsWith("/") ? url.slice(0, -1) : url);
+  // Resolved later from the stored config; the Turso probe reads it lazily so it
+  // always targets the same API the rest of the app talks to.
+  let resolvedBaseUrl = normalizeBase(apiBaseUrl);
+
   const gemini = createGeminiSettingsController({
     invokeTauri: typeof resolvedInvoke === "function" ? resolvedInvoke : undefined,
     probeTursoConnection: async (url: string, token: string) => {
-      const base = apiBaseUrl.endsWith("/") ? apiBaseUrl.slice(0, -1) : apiBaseUrl;
       try {
-        const response = await authAwareFetch(`${base}/preferences/turso/test`, {
+        const response = await authAwareFetch(`${resolvedBaseUrl}/preferences/turso/test`, {
           method: "POST",
           headers: { "content-type": "application/json" },
           body: JSON.stringify({ databaseUrl: url, authToken: token }),
@@ -94,8 +98,13 @@ export async function startDesktopBrowserApp({
     },
   });
 
-  const authClient = createAuthApiClient({ apiBaseUrl, fetchImpl: authAwareFetch });
-  const app = bootstrapDesktopApp({ apiBaseUrl, fetchImpl: authAwareFetch, getToken: () => getAuthToken() });
+  // Read the persisted config before building API clients so a configured remote
+  // endpoint becomes the base URL for every caller (chat, auth, preferences).
+  const gate = await gemini.getBootstrapGate();
+  if (gate.apiEndpointUrl) resolvedBaseUrl = normalizeBase(gate.apiEndpointUrl);
+
+  const authClient = createAuthApiClient({ apiBaseUrl: resolvedBaseUrl, fetchImpl: authAwareFetch });
+  const app = bootstrapDesktopApp({ apiBaseUrl: resolvedBaseUrl, fetchImpl: authAwareFetch, getToken: () => getAuthToken() });
   const savedArtistsShell = createSavedArtistsShell({ app });
   const initialViewport = resolveInitialViewport(viewport);
 
@@ -112,7 +121,6 @@ export async function startDesktopBrowserApp({
     }
   }
 
-  const gate = await gemini.getBootstrapGate();
   if (shouldOfferWelcomeScreen({ hasStoredKey: gate.hasStoredKey, onboardingComplete: gate.onboardingComplete, locationHash: initialHash })) {
     router.navigate("welcome");
   } else {
@@ -150,6 +158,7 @@ export async function startDesktopBrowserApp({
     saveBraveApiKey: (key: string) => gemini.saveBraveApiKey(key),
     saveTursoConfig: (url: string, token: string) => gemini.saveTursoConfig(url, token),
     clearTursoConfig: () => gemini.clearTursoConfig(),
+    saveApiEndpointUrl: (url: string) => gemini.saveApiEndpointUrl(url),
     completeOnboarding: async () => { await gemini.completeOnboarding(); await runAuthGate(); },
     onLogin,
     onRegister,

--- a/apps/desktop/src/ui/SettingsView.ts
+++ b/apps/desktop/src/ui/SettingsView.ts
@@ -310,7 +310,10 @@ interface ApiEndpointCardProps {
 
 function ApiEndpointCard({ apiEndpointUrl, statusMessage, onSave }: ApiEndpointCardProps) {
   const isRemote = Boolean(apiEndpointUrl);
-  const [draft, setDraft] = React.useState(apiEndpointUrl);
+  // Like TursoConfigCard, the input starts empty: the current endpoint is shown in
+  // the description, the field is only for entering a new value. This keeps the two
+  // cards consistent and avoids a stale value lingering after "Reset to local".
+  const [draft, setDraft] = React.useState("");
 
   return React.createElement(
     "section",
@@ -350,7 +353,7 @@ function ApiEndpointCard({ apiEndpointUrl, statusMessage, onSave }: ApiEndpointC
       autoComplete: "off",
       value: draft,
       onChange: (e: React.ChangeEvent<HTMLInputElement>) => setDraft(e.target.value),
-      placeholder: "https://bandsearch.onrender.com",
+      placeholder: isRemote ? "Enter a new URL to replace the saved endpoint" : "https://bandsearch.onrender.com",
       style: {
         width: "100%",
         boxSizing: "border-box",

--- a/apps/desktop/src/ui/SettingsView.ts
+++ b/apps/desktop/src/ui/SettingsView.ts
@@ -302,6 +302,123 @@ function TursoConfigCard({ hasTursoConfig, statusMessage, onSave, onClear, fromE
   );
 }
 
+interface ApiEndpointCardProps {
+  apiEndpointUrl: string;
+  statusMessage: StatusMessage;
+  onSave?: (url: string) => void;
+}
+
+function ApiEndpointCard({ apiEndpointUrl, statusMessage, onSave }: ApiEndpointCardProps) {
+  const isRemote = Boolean(apiEndpointUrl);
+  const [draft, setDraft] = React.useState(apiEndpointUrl);
+
+  return React.createElement(
+    "section",
+    {
+      style: {
+        marginTop: "12px",
+        padding: "16px",
+        borderRadius: "10px",
+        border: `1px solid ${palette.border}`,
+        backgroundColor: palette.cardBg,
+      },
+    },
+    React.createElement(
+      "p",
+      { style: { fontSize: "12px", fontWeight: "600", color: palette.textSecondary, marginBottom: "4px" } },
+      "API endpoint",
+    ),
+    React.createElement(
+      "p",
+      { style: { fontSize: "12px", color: palette.textTertiary, marginBottom: "12px" } },
+      isRemote
+        ? `Connected to a remote API at ${apiEndpointUrl}. The built-in local app is not started while a remote endpoint is set.`
+        : "Using the built-in local app. Enter a remote URL to connect to a hosted Bandsearch API instead.",
+    ),
+    React.createElement(
+      "label",
+      {
+        htmlFor: "api-endpoint-url",
+        style: { display: "block", fontSize: "12px", color: palette.textSecondary, marginBottom: "6px" },
+      },
+      "Remote API URL",
+    ),
+    React.createElement("input", {
+      id: "api-endpoint-url",
+      name: "api-endpoint-url",
+      type: "text",
+      autoComplete: "off",
+      value: draft,
+      onChange: (e: React.ChangeEvent<HTMLInputElement>) => setDraft(e.target.value),
+      placeholder: "https://bandsearch.onrender.com",
+      style: {
+        width: "100%",
+        boxSizing: "border-box",
+        backgroundColor: palette.inputBg,
+        color: palette.textPrimary,
+        border: `1px solid ${palette.border}`,
+        borderRadius: "8px",
+        padding: "10px 12px",
+        fontSize: "14px",
+        marginBottom: "12px",
+      },
+    }),
+    statusMessage
+      ? React.createElement(
+          "p",
+          {
+            role: "status",
+            style: {
+              fontSize: "13px",
+              color: statusMessage.type === "error" ? "#e57373" : palette.accent,
+              marginBottom: "12px",
+            },
+          },
+          statusMessage.text,
+        )
+      : null,
+    React.createElement(
+      "button",
+      {
+        type: "button",
+        onClick: () => onSave?.(draft.trim()),
+        style: {
+          backgroundColor: palette.accent,
+          color: "#0a0d14",
+          border: "none",
+          borderRadius: "8px",
+          padding: "10px 18px",
+          fontWeight: "600",
+          fontSize: "13px",
+          cursor: "pointer",
+        },
+      },
+      "Save endpoint",
+    ),
+    isRemote
+      ? React.createElement(
+          "button",
+          {
+            type: "button",
+            onClick: () => onSave?.(""),
+            style: {
+              backgroundColor: "transparent",
+              color: palette.textSecondary,
+              border: `1px solid ${palette.border}`,
+              borderRadius: "8px",
+              padding: "10px 18px",
+              fontWeight: "600",
+              fontSize: "13px",
+              cursor: "pointer",
+              marginTop: "8px",
+            },
+          },
+          "Reset to local",
+        )
+      : null,
+  );
+}
+
 interface SettingsViewProps {
   viewProps: {
     headerTitle?: string;
@@ -312,9 +429,11 @@ interface SettingsViewProps {
     geminiKeyFromEnv?: boolean;
     braveKeyFromEnv?: boolean;
     tursoFromEnv?: boolean;
+    apiEndpointUrl?: string;
     geminiStatusMessage?: StatusMessage;
     braveStatusMessage?: StatusMessage;
     tursoStatusMessage?: StatusMessage;
+    apiEndpointStatusMessage?: StatusMessage;
   };
   handlers: {
     onNavigateChat?: () => void;
@@ -322,6 +441,7 @@ interface SettingsViewProps {
     onSaveBraveApiKey?: (key: string) => void;
     onSaveTursoConfig?: (url: string, token: string) => void;
     onClearTursoConfig?: () => void;
+    onSaveApiEndpointUrl?: (url: string) => void;
   };
 }
 
@@ -354,6 +474,23 @@ export function SettingsView({ viewProps, handlers }: SettingsViewProps) {
           `${missingKeys.join(" and ")} API ${missingKeys.length === 1 ? "key is" : "keys are"} not configured yet. Add ${missingKeys.length === 1 ? "it" : "them"} below so recommendations can run.`,
         )
       : null;
+
+  const isRemote = Boolean(viewProps.apiEndpointUrl);
+  const serverManagedNote = isRemote
+    ? React.createElement(
+        "p",
+        {
+          role: "note",
+          style: {
+            marginTop: "12px",
+            fontSize: "12px",
+            color: palette.textTertiary,
+            lineHeight: 1.45,
+          },
+        },
+        "A remote endpoint is active — the keys below configure the built-in local app and apply only if you reset to local.",
+      )
+    : null;
 
   return React.createElement(
     "main",
@@ -413,6 +550,12 @@ export function SettingsView({ viewProps, handlers }: SettingsViewProps) {
       React.createElement("hr", { style: { border: "none", borderTop: `1px solid ${palette.border}`, margin: "0" } }),
     ),
     banner,
+    React.createElement(ApiEndpointCard, {
+      apiEndpointUrl: viewProps.apiEndpointUrl ?? "",
+      statusMessage: viewProps.apiEndpointStatusMessage ?? null,
+      onSave: (url) => handlers.onSaveApiEndpointUrl?.(url),
+    }),
+    serverManagedNote,
     React.createElement(ApiKeyCard, {
       id: "gemini-api-key",
       label: "Gemini API key",

--- a/apps/desktop/src/ui/mountDesktopReactApp.ts
+++ b/apps/desktop/src/ui/mountDesktopReactApp.ts
@@ -34,6 +34,7 @@ export interface DesktopReactMountOptions {
   saveBraveApiKey?: (apiKey: string) => Promise<void>;
   saveTursoConfig?: (url: string, token: string) => Promise<void>;
   clearTursoConfig?: () => Promise<void>;
+  saveApiEndpointUrl?: (url: string) => Promise<void>;
   completeOnboarding?: () => Promise<void>;
   onLogin?: (email: string, password: string) => Promise<void>;
   onRegister?: (email: string, displayName: string, password: string) => Promise<{ recoveryCode: string }>;
@@ -57,6 +58,7 @@ export function createDesktopReactMount({
   saveBraveApiKey = async (apiKey) => { void apiKey; },
   saveTursoConfig = async (url, token) => { void url; void token; },
   clearTursoConfig = async () => {},
+  saveApiEndpointUrl = async (url) => { void url; },
   completeOnboarding = async () => {},
   onLogin,
   onRegister,
@@ -228,6 +230,10 @@ export function createDesktopReactMount({
     onSaveTursoConfig: handlers.onSaveTursoConfig,
     onClearTursoConfig: async () => {
       await clearTursoConfig();
+      return renderCurrent();
+    },
+    onSaveApiEndpointUrl: async (url: string) => {
+      await saveApiEndpointUrl(url);
       return renderCurrent();
     },
   };

--- a/apps/desktop/test/gemini-desktop-settings.test.js
+++ b/apps/desktop/test/gemini-desktop-settings.test.js
@@ -123,7 +123,7 @@ test("createGeminiSettingsController getBootstrapGate reads onboarding flag from
     invokeTauri: async () => ({ hasStoredKey: false, onboardingComplete: true }),
   });
   const gate = await ctrl.getBootstrapGate();
-  assert.deepEqual(gate, { hasStoredKey: false, onboardingComplete: true });
+  assert.deepEqual(gate, { hasStoredKey: false, onboardingComplete: true, apiEndpointUrl: "" });
 });
 
 test("createGeminiSettingsController completeOnboarding invokes Tauri command", async () => {
@@ -237,4 +237,89 @@ test("createGeminiSettingsController saveTursoConfig rejects empty databaseUrl",
   const props = await ctrl.getSettingsViewProps();
   assert.equal(props.tursoStatusMessage?.type, "error");
   assert.equal(tauriCalls.includes("save_turso_config"), false);
+});
+
+// ── API endpoint (remote vs local sidecar) ───────────────────────────────────
+
+test("getSettingsViewProps passes apiEndpointUrl from invoke", async () => {
+  const ctrl = createGeminiSettingsController({
+    invokeTauri: async () => ({ hasStoredKey: true, apiEndpointUrl: "https://bandsearch.onrender.com" }),
+  });
+  const props = await ctrl.getSettingsViewProps();
+  assert.equal(props.apiEndpointUrl, "https://bandsearch.onrender.com");
+});
+
+test("getSettingsViewProps apiEndpointUrl defaults to empty string when invoke omits it", async () => {
+  const ctrl = createGeminiSettingsController({
+    invokeTauri: async () => ({ hasStoredKey: true }),
+  });
+  const props = await ctrl.getSettingsViewProps();
+  assert.equal(props.apiEndpointUrl, "");
+});
+
+test("getBootstrapGate includes apiEndpointUrl from invoke", async () => {
+  const ctrl = createGeminiSettingsController({
+    invokeTauri: async () => ({ hasStoredKey: true, onboardingComplete: true, apiEndpointUrl: "https://remote.example" }),
+  });
+  const gate = await ctrl.getBootstrapGate();
+  assert.equal(gate.apiEndpointUrl, "https://remote.example");
+});
+
+test("saveApiEndpointUrl calls save_api_endpoint_url with trimmed url", async () => {
+  const calls = [];
+  const ctrl = createGeminiSettingsController({
+    invokeTauri: async (cmd, args) => { calls.push({ cmd, args }); return {}; },
+  });
+  await ctrl.saveApiEndpointUrl("  https://bandsearch.onrender.com  ");
+  const saveCall = calls.find((c) => c.cmd === "save_api_endpoint_url");
+  assert.ok(saveCall, "should call save_api_endpoint_url");
+  assert.equal(saveCall.args.url, "https://bandsearch.onrender.com");
+});
+
+test("saveApiEndpointUrl accepts empty string to reset to local and reports success", async () => {
+  const calls = [];
+  const ctrl = createGeminiSettingsController({
+    invokeTauri: async (cmd, args) => { calls.push({ cmd, args }); return {}; },
+  });
+  await ctrl.saveApiEndpointUrl("   ");
+  const saveCall = calls.find((c) => c.cmd === "save_api_endpoint_url");
+  assert.ok(saveCall, "should call save_api_endpoint_url with empty url");
+  assert.equal(saveCall.args.url, "");
+  const props = await ctrl.getSettingsViewProps();
+  assert.equal(props.apiEndpointStatusMessage?.type, "success");
+});
+
+test("saveApiEndpointUrl rejects a non-URL value without invoking", async () => {
+  const calls = [];
+  const ctrl = createGeminiSettingsController({
+    invokeTauri: async (cmd) => { calls.push(cmd); return {}; },
+  });
+  await ctrl.saveApiEndpointUrl("bandsearch.onrender.com");
+  assert.equal(calls.includes("save_api_endpoint_url"), false, "should not invoke for a malformed URL");
+  const props = await ctrl.getSettingsViewProps();
+  assert.equal(props.apiEndpointStatusMessage?.type, "error");
+});
+
+test("saveApiEndpointUrl rejects a non-http protocol without invoking", async () => {
+  const calls = [];
+  const ctrl = createGeminiSettingsController({
+    invokeTauri: async (cmd) => { calls.push(cmd); return {}; },
+  });
+  await ctrl.saveApiEndpointUrl("javascript:alert(1)");
+  assert.equal(calls.includes("save_api_endpoint_url"), false, "should not invoke for a non-http protocol");
+  const props = await ctrl.getSettingsViewProps();
+  assert.equal(props.apiEndpointStatusMessage?.type, "error");
+});
+
+test("saveApiEndpointUrl records error when invoke fails", async () => {
+  const ctrl = createGeminiSettingsController({
+    invokeTauri: async (cmd) => {
+      if (cmd === "save_api_endpoint_url") throw new Error("disk full");
+      return { hasStoredKey: false };
+    },
+  });
+  await ctrl.saveApiEndpointUrl("https://remote.example");
+  const props = await ctrl.getSettingsViewProps();
+  assert.equal(props.apiEndpointStatusMessage?.type, "error");
+  assert.match(props.apiEndpointStatusMessage?.text || "", /disk full/);
 });

--- a/apps/desktop/test/settings-view.test.js
+++ b/apps/desktop/test/settings-view.test.js
@@ -22,6 +22,7 @@ const baseHandlers = {
   onSaveApiKey: () => {},
   onSaveBraveApiKey: () => {},
   onSaveTursoConfig: () => {},
+  onSaveApiEndpointUrl: () => {},
 };
 
 test("SettingsView renders Turso section heading", () => {
@@ -162,4 +163,80 @@ test("SettingsView shows Switch back to SQLite button when Turso is configured a
     }),
   );
   assert.equal(html.includes("Switch back"), true, "should show switch-back button when Turso is configured");
+});
+
+// ── API endpoint card ────────────────────────────────────────────────────────
+
+test("SettingsView renders API endpoint heading", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(SettingsView, { viewProps: baseViewProps, handlers: baseHandlers }),
+  );
+  assert.equal(html.includes("API endpoint"), true, "should render API endpoint heading");
+});
+
+test("SettingsView renders API endpoint URL input", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(SettingsView, { viewProps: baseViewProps, handlers: baseHandlers }),
+  );
+  assert.equal(html.includes("api-endpoint-url"), true, "should render API endpoint input id");
+});
+
+test("SettingsView shows the configured remote URL when set", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(SettingsView, {
+      viewProps: { ...baseViewProps, apiEndpointUrl: "https://bandsearch.onrender.com" },
+      handlers: baseHandlers,
+    }),
+  );
+  assert.equal(html.includes("https://bandsearch.onrender.com"), true, "should display the configured endpoint");
+});
+
+test("SettingsView shows Reset to local button when a remote endpoint is configured", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(SettingsView, {
+      viewProps: { ...baseViewProps, apiEndpointUrl: "https://remote.example" },
+      handlers: baseHandlers,
+    }),
+  );
+  assert.equal(html.includes("Reset to local"), true, "should offer a reset button in remote mode");
+});
+
+test("SettingsView does not show Reset to local button when using the local app", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(SettingsView, {
+      viewProps: { ...baseViewProps, apiEndpointUrl: "" },
+      handlers: baseHandlers,
+    }),
+  );
+  assert.equal(html.includes("Reset to local"), false, "should not show reset button in local mode");
+});
+
+test("SettingsView renders API endpoint status message when present", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(SettingsView, {
+      viewProps: { ...baseViewProps, apiEndpointStatusMessage: { type: "success", text: "Endpoint saved!" } },
+      handlers: baseHandlers,
+    }),
+  );
+  assert.equal(html.includes("Endpoint saved!"), true, "should show endpoint status message");
+});
+
+test("SettingsView notes that keys are server-managed when a remote endpoint is active", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(SettingsView, {
+      viewProps: { ...baseViewProps, apiEndpointUrl: "https://remote.example" },
+      handlers: baseHandlers,
+    }),
+  );
+  assert.equal(html.includes("remote endpoint is active"), true, "should hint keys apply to the local API only");
+});
+
+test("SettingsView does not show the server-managed note in local mode", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(SettingsView, {
+      viewProps: { ...baseViewProps, apiEndpointUrl: "" },
+      handlers: baseHandlers,
+    }),
+  );
+  assert.equal(html.includes("remote endpoint is active"), false, "no server-managed note when local");
 });

--- a/apps/desktop/test/start-desktop-browser-app.test.js
+++ b/apps/desktop/test/start-desktop-browser-app.test.js
@@ -39,6 +39,53 @@ test("startDesktopBrowserApp mounts bootstrapped react app", async () => {
   assert.equal(calls[2].type, "mount");
 });
 
+test("startDesktopBrowserApp uses the configured remote endpoint as the API base URL", async () => {
+  const modulePath = require.resolve("../src/index");
+  const original = require(modulePath);
+  const calls = [];
+
+  require.cache[modulePath].exports = {
+    ...original,
+    bootstrapDesktopApp: (options) => {
+      calls.push({ type: "bootstrapApp", options });
+      return { mocked: true };
+    },
+    bootstrapDesktopReactApp: (opts) => {
+      calls.push({ type: "bootstrapReact", saveApiEndpointUrl: opts.saveApiEndpointUrl });
+      return { mount: async () => { calls.push({ type: "mount" }); } };
+    },
+  };
+
+  const fakeFetch = async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ enabled: false, userCount: 0 }),
+    clone() { return this; },
+    text: async () => "",
+  });
+
+  delete require.cache[require.resolve("../src/startDesktopBrowserApp")];
+  const { startDesktopBrowserApp } = require("../src/startDesktopBrowserApp");
+  await startDesktopBrowserApp({
+    apiBaseUrl: "http://localhost:3001",
+    fetchImpl: fakeFetch,
+    invokeTauri: async (cmd) => {
+      if (cmd === "gemini_config_status") {
+        return { hasStoredKey: true, onboardingComplete: true, apiEndpointUrl: "https://bandsearch.onrender.com" };
+      }
+      return {};
+    },
+  });
+
+  require.cache[modulePath].exports = original;
+
+  const appCall = calls.find((c) => c.type === "bootstrapApp");
+  assert.ok(appCall, "bootstrapDesktopApp should be called");
+  assert.equal(appCall.options.apiBaseUrl, "https://bandsearch.onrender.com");
+  const reactCall = calls.find((c) => c.type === "bootstrapReact");
+  assert.equal(typeof reactCall.saveApiEndpointUrl, "function", "should wire saveApiEndpointUrl through");
+});
+
 test("startDesktopBrowserApp picks mobile viewport when matchMedia matches narrow width", async () => {
   const modulePath = require.resolve("../src/index");
   const original = require(modulePath);

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -252,3 +252,23 @@ All four implementations carry 13 methods covering three distinct concerns: band
 `normalizeEmail()`, `publicUser()`, and `rowToUser()` are copied verbatim in both user repository adapters.
 
 **Action:** Move the three functions into a shared `services/api/src/auth/userModel.ts` module. Both adapters import from it. The factory in `userRepository.ts` is unchanged. Test `normalizeEmail` once in `userModel.test.ts`.
+
+---
+
+### 5. Consolidate duplicate `gemini_config_status` reads in the desktop settings controller
+
+**Files:** `apps/desktop/src/geminiDesktopSettings.ts`
+
+`getBootstrapGate()` and `getSettingsViewProps()` both call `invokeTauri("gemini_config_status")` and parse the response independently. Any change to the response shape must be applied in two places, and a concurrent render after save could read two different snapshots.
+
+**Action:** Extract a private `readStatus()` async helper that invokes `gemini_config_status` once and returns the typed result. Both `getBootstrapGate` and `getSettingsViewProps` call it. Add a test that stubs `invokeTauri` and asserts it is called exactly once per `getSettingsViewProps` call.
+
+---
+
+### 6. Bearer token forwarded to user-configured remote endpoints
+
+**Files:** `apps/desktop/src/startDesktopBrowserApp.ts`, `apps/desktop/src/authAwareFetch.ts`
+
+`authAwareFetch` injects `Authorization: Bearer <token>` on every request. Once a user overrides the API endpoint in Settings, all requests — including auth API calls — go to the user-supplied URL carrying the JWT. In a self-hosted scenario with a trusted operator-supplied URL this is correct behaviour; if the URL were somehow corrupted (e.g. a stored config tampered on disk) the token could be sent to an unintended host.
+
+**Note (low priority, no immediate action):** The desktop is a local trust boundary, so this risk is low. Document the invariant in `authAwareFetch.ts`: tokens are sent to `apiBaseUrl` only, and `apiBaseUrl` originates from either the default localhost or the URL the user explicitly saved in Settings. Revisit if the app ever accepts the endpoint from a non-user source (e.g. a deep-link or QR code).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -149,17 +149,19 @@ Deploy the Express API as a Render Web Service.
 
 ---
 
-### 9.4 — Desktop app: configurable API endpoint
+### 9.4 — Desktop app: configurable API endpoint ✓ Done
 
 **Files:** `apps/desktop/src/`, `apps/desktop/src-tauri/`
 
 The desktop app currently assumes the API runs as a local Tauri sidecar on `localhost`. For a cloud deployment, users need to be able to point the app at a remote API URL.
 
 **Action:**
-1. Add an API endpoint field to the Settings screen (`#/settings`) — default to local sidecar, allow overriding with a remote URL (e.g. `https://bandsearch.onrender.com`).
-2. Persist the setting in the OS config directory alongside the existing Gemini/Turso credentials.
-3. When a remote endpoint is configured, skip launching the local API sidecar in the Tauri backend.
-4. Update `chatClient.ts` and all API callers to use the configured endpoint.
+1. Add an API endpoint field to the Settings screen (`#/settings`) — default to local sidecar, allow overriding with a remote URL (e.g. `https://bandsearch.onrender.com`). ✓ Done (`ApiEndpointCard` in `SettingsView.ts`)
+2. Persist the setting in the OS config directory alongside the existing Gemini/Turso credentials. ✓ Done (`api_endpoint_url` in `bandsearch/config.json`; localStorage fallback for browser dev)
+3. When a remote endpoint is configured, skip launching the local API sidecar in the Tauri backend. ✓ Done (single `reconcile_sidecar()` invariant: local sidecar runs iff no remote endpoint)
+4. Update `chatClient.ts` and all API callers to use the configured endpoint. ✓ Done (`startDesktopBrowserApp` resolves the endpoint before building the auth/chat clients; `chatClient` already took `apiBaseUrl`, so no change needed there)
+
+Implemented: `save_api_endpoint_url` Tauri command + `apiEndpointUrl` on `gemini_config_status`; controller `saveApiEndpointUrl` with http(s) format validation (no reachability probe — Render cold starts would make one falsely fail); settings card with "Reset to local"; Gemini/Brave/Turso cards stay visible in remote mode with a "managed locally" note. Note: applies on next app restart (the frontend resolves the base URL at startup).
 
 ---
 


### PR DESCRIPTION
## Summary

Complete implementation of configurable remote API endpoint for the desktop app. Users can now:
- Switch between local sidecar and remote API endpoints via Settings
- Save and persist endpoint configuration in OS config directory
- Automatic sidecar lifecycle: runs locally when no remote endpoint set, stops when remote endpoint configured
- Full validation and error handling on both frontend and backend

## Changes

### Backend (Tauri)
- **API endpoint configuration** — new `api_endpoint_url` field in `BandsearchConfig` stored in OS config dir
- **Sidecar lifecycle management** — `reconcile_sidecar()` ensures invariant: "local sidecar runs iff no remote endpoint"
- **New IPC commands:**
  - `save_api_endpoint_url()` — saves endpoint and reconciles sidecar state
  - Existing commands trigger reconciliation on config change
- **URL validation** — `is_valid_http_url()` defensive check prevents malformed URLs
- **Status reporting** — `gemini_config_status()` includes `apiEndpointUrl` field

### Frontend (TypeScript/React)
- **Settings UI** — new `SettingsView.ts` component with API endpoint card
- **Settings controller** — `geminiDesktopSettings.ts` handles fetch/persist/validate via Tauri IPC
- **Bootstrap gate** — includes `apiEndpointUrl`

### Documentation & Tests
- **README** — expanded Features section
- **ROADMAP** — Phase 9.4 marked complete
- **Test suite** — desktop settings, settings view, browser app initialization

## Test plan

- [ ] Settings UI renders API endpoint card
- [ ] Can enter and save remote endpoint URL
- [ ] Invalid URLs are rejected
- [ ] Clearing endpoint restarts local sidecar
- [ ] Config persists across app restarts

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)