### PR TITLE
docs: streamline README for external readers, add tech stack table

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![CI](https://github.com/eikrad/bandsearch-app/actions/workflows/ci.yml/badge.svg)](https://github.com/eikrad/bandsearch-app/actions/workflows/ci.yml)
 ![Status: Alpha](https://img.shields.io/badge/status-alpha-orange)
-![Version: 0.4.0--alpha.0](https://img.shields.io/badge/version-0.4.0--alpha.0-blue)
+![Version: 0.4.0-alpha.0](https://img.shields.io/badge/version-0.4.0--alpha.0-blue)
 
-AI-powered music recommendations for niche and lesser-known artists. Describe bands you love, and Bandsearch surfaces similar but lesser-known picks — verified against MusicBrainz, ranked by Gemini.
+AI-powered music recommendations for niche and lesser-known artists. Describe bands you love, and Bandsearch surfaces similar but lesser-known picks — verified against MusicBrainz and ranked by Gemini.
 
 ## Features
 
@@ -13,7 +13,7 @@ AI-powered music recommendations for niche and lesser-known artists. Describe ba
 - **Preference memory** — save and rate bands; future recommendations adapt to your listening history
 - **Reflection loop** — if the first search pass is thin, the AI generates refined queries and searches again (up to 2 extra rounds)
 - **Native desktop app** — Tauri shell for Linux, macOS, and Windows; API keys stored in the OS config directory
-- **Flexible storage** — SQLite by default, Postgres or Turso for shared/cloud deployments
+- **Flexible storage** — SQLite by default, PostgreSQL or Turso for shared/cloud deployments
 - **Optional multi-user auth** — activates automatically once you register the first account; single-user setups need no config
 
 ## How it works
@@ -42,6 +42,20 @@ flowchart TD
 ```
 
 See [`docs/architecture/ARCHITECTURE.md`](docs/architecture/ARCHITECTURE.md) for a full description of all nodes, state fields, and design decisions.
+
+---
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|------------|
+| API server | Express.js + TypeScript (Node.js 22+) |
+| AI pipeline | LangGraph + Google Gemini |
+| Web search | Brave Search API |
+| Artist verification | MusicBrainz |
+| Desktop shell | Tauri v2 (Rust) + React + TypeScript |
+| Database | SQLite / PostgreSQL / Turso (pluggable) |
+| Auth | bcrypt + JWT (30-day sessions) |
 
 ---
 
@@ -91,17 +105,11 @@ sudo apt install libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchel
 
 **macOS:** Xcode Command Line Tools (`xcode-select --install`). No additional packages needed.
 
-**Windows:** [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) with the **Desktop development with C++** workload. WebView2 is built into Windows 10 1803+ and Windows 11 — no manual install needed.
-
-### How the API server is launched
-
-The desktop app spawns a Node.js API server as a child process. In development it uses the system `node` on your `PATH`. In a production bundle (`tauri build`), it looks for a Tauri-bundled Node sidecar placed next to the executable — named `node-<target-triple>[.exe]` — and prefers that over the system node. If no sidecar is present, it falls back to system `node` automatically.
-
-To produce a production build you must place the correct Node binary in `apps/desktop/src-tauri/binaries/` before running `tauri build`. See `apps/desktop/src-tauri/binaries/README` for the naming convention and download instructions.
+**Windows:** [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) with the **Desktop development with C++** workload. WebView2 is built into Windows 10 1803+ and Windows 11.
 
 ### API key storage
 
-Keys are written to the OS config directory as `bandsearch/config.json`:
+Keys are written to the OS config directory as `bandsearch/config.json`. Use **Settings** in the app header to save your Gemini and Brave keys.
 
 | OS | Path |
 |----|------|
@@ -109,17 +117,13 @@ Keys are written to the OS config directory as `bandsearch/config.json`:
 | macOS | `~/Library/Application Support/bandsearch/config.json` |
 | Windows | `%APPDATA%\bandsearch\config.json` |
 
-**First launch:** A welcome screen (`#/welcome`) explains that a Gemini key is needed and links to Settings. Use **Settings** in the app header (or `#/settings`) to save your Gemini and Brave keys. The Tauri shell passes both keys to the Node API process and restarts it after you save.
-
-If a recommendation call fails (rate limit, unreachable API, or Gemini errors), the chat view shows a banner with a short, human-readable hint instead of failing silently.
+If a recommendation call fails, the chat view shows a banner with a short, human-readable hint.
 
 ---
 
 ## Authentication
 
-Bandsearch uses optional local multi-user auth (bcrypt + 30-day JWT).
-
-**Single-user bypass (default):** When no users are registered the API runs open with no auth checks — ideal for local single-user setups. Auth is enforced only once you register the first account.
+Optional local multi-user auth (bcrypt + 30-day JWT). Auth behaviour is determined by how many users are registered:
 
 | Users registered | Behaviour |
 |-----------------|----------|
@@ -127,13 +131,9 @@ Bandsearch uses optional local multi-user auth (bcrypt + 30-day JWT).
 | 1 | Auto-attach — requests are automatically associated with the single user |
 | ≥ 2 | Enforced — `Authorization: Bearer <token>` required for preference endpoints |
 
-**Registration:** `POST /auth/register` returns a JWT token and a **recovery code**. Store the recovery code safely — it is the only way to reset your password. Tokens expire after 30 days.
+Register with `POST /auth/register`, which returns a JWT token and a **recovery code**. Store the recovery code safely — it is the only way to reset your password. Tokens expire after 30 days.
 
-**Recovery:** `POST /auth/reset-password` accepts the recovery code and issues a new code. The old code is invalidated immediately.
-
-**JWT secret:** Set `JWT_SECRET` in your environment for persistent sessions. Without it, a random secret is generated on startup and all tokens are invalidated on restart.
-
-The desktop client persists the token in browser storage and injects it as `Authorization: Bearer` on every API call. The login/register/reset-password screens are shown automatically on startup when the API requires authentication.
+Set `JWT_SECRET` in your environment for persistent sessions across restarts.
 
 ---
 
@@ -142,169 +142,40 @@ The desktop client persists the token in browser storage and injects it as `Auth
 Bandsearch uses two persistence domains:
 
 - **Preferences store** (`saved_bands`, groups) — configurable via `PREFERENCE_STORE`.
-- **Session store** (`chat_sessions`, `chat_messages`) — local SQLite in `DATABASE_PATH` (default `bandsearch.db`), with in-memory fallback if SQLite is unavailable.
+- **Session store** (`chat_sessions`, `chat_messages`) — local SQLite in `DATABASE_PATH` (default `bandsearch.db`).
 
 | `PREFERENCE_STORE` | Description |
 |--------------------|-------------|
 | `sqlite` (default) | Local file, zero-config, data survives restarts |
 | `memory` | In-process only, data lost on restart |
-| `postgres` | Postgres/Supabase, requires `DATABASE_URL` |
-| `turso` | Turso/libSQL cloud SQLite, requires `TURSO_DATABASE_URL` — enables cross-device sync |
+| `postgres` | PostgreSQL / Supabase; run `npm run migrate` after setup |
+| `turso` | Turso cloud SQLite — enables cross-device sync |
 
-**Postgres setup:**
-
-```bash
-# in .env:
-PREFERENCE_STORE=postgres
-DATABASE_URL=postgres://user:pass@host/dbname
-
-npm run migrate
-npm run dev
-```
-
-**Turso setup:**
-
-```bash
-# Install the Turso CLI and create a database:
-#   turso db create bandsearch
-#   turso db show bandsearch --url
-#   turso db tokens create bandsearch
-
-# in .env:
-PREFERENCE_STORE=turso
-TURSO_DATABASE_URL=libsql://your-db.turso.io
-TURSO_AUTH_TOKEN=your_turso_auth_token_here
-
-TURSO_DATABASE_URL=libsql://your-db.turso.io TURSO_AUTH_TOKEN=your_token npm run migrate:turso
-npm run dev
-```
-
-Turso URL and auth token can also be saved through the **Settings** screen in the desktop app; the API restarts automatically with the new credentials.
+See `.env.example` for the connection variables needed for each backend (`DATABASE_URL`, `TURSO_DATABASE_URL`, `TURSO_AUTH_TOKEN`).
 
 ---
 
-## Environment Variables
+## Configuration
+
+Required variables:
+
+| Variable | Description |
+|----------|-------------|
+| `GEMINI_API_KEY` | Google Gemini — required, API will not start without it |
+| `BRAVE_API_KEY` | Brave Search token for niche artist discovery |
+
+Common optional variables:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `PORT` | `3001` | API port |
-| `GEMINI_API_KEY` | — | **Required** — API will not start without it |
-| `BRAVE_API_KEY` | — | **Required** — Brave Search token (`X-Subscription-Token`) |
-| `JWT_SECRET` | *(auto-generated)* | Signing secret for JWT tokens; set for persistent sessions across restarts |
+| `JWT_SECRET` | *(auto-generated)* | Set for persistent sessions across restarts |
 | `PREFERENCE_STORE` | `sqlite` | `sqlite`, `memory`, `postgres`, or `turso` |
-| `DATABASE_PATH` | `bandsearch.db` | SQLite file path |
-| `DATABASE_URL` | — | Required when `PREFERENCE_STORE=postgres` |
-| `DATABASE_SSL` | `true` | TLS for Postgres connection |
-| `TURSO_DATABASE_URL` | — | Required when `PREFERENCE_STORE=turso` |
-| `TURSO_AUTH_TOKEN` | — | Turso auth token (omit for local libSQL) |
-| `CORS_ORIGIN` | `*` | Allowed browser origin |
-| `RECOMMENDATION_TIMEOUT_MS` | `8000` | Gemini request timeout |
-| `RECOMMENDATION_PIPELINE_READY_TIMEOUT_MS` | `45000` | Max wait before HTTP listen while the pipeline initializes |
-| `MUSICBRAINZ_TIMEOUT_MS` | `5000` | MusicBrainz request timeout |
-| `MUSICBRAINZ_RETRIES` | `1` | MusicBrainz retry attempts |
-| `LASTFM_API_KEY` | — | Optional — Last.fm fallback for artist images and obscurity scoring (listener counts) |
-| `MISTRAL_API_KEY` | — | Optional — activates the async LLM-as-judge eval worker (Mistral scores recommendations after the response is sent) |
-| `EVAL_DASHBOARD_ENABLED` | — | Set `true` to enable the developer eval dashboard at `/eval/dashboard` |
-| `LANGSMITH_API_KEY` | — | Optional LangSmith tracing |
-| `LANGSMITH_TRACING` | — | Set `true` to enable tracing |
-| `LANGSMITH_PROJECT` | — | LangSmith project name |
-| `RESEARCH_MAX_INITIAL_SEARCHES` | `6` | Max Brave queries on first pass |
-| `RESEARCH_MAX_REFLECTION_SEARCHES` | `4` | Cap on extra queries after reflection |
-| `RESEARCH_TOTAL_SEARCH_BUDGET` | `10` | Max Brave calls per recommendation request |
-| `RESEARCH_TIMEOUT_MS` | `25000` | Upper bound for the multi-step research workflow |
-| `RESEARCH_TARGET_VERIFIED_CANDIDATES` | `8` | Verified MusicBrainz hits before skipping reflection |
+| `LASTFM_API_KEY` | — | Last.fm fallback for artist images and obscurity scoring |
+| `MISTRAL_API_KEY` | — | Activates async LLM-as-judge eval scoring |
+| `LANGSMITH_API_KEY` | — | LangSmith distributed tracing |
 
----
-
-## API Reference
-
-### Core
-
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/health` | Service health probe |
-| `GET` | `/version` | Returns app version |
-
-### Auth
-
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/auth/status` | Returns `{ enabled, userCount }` — always public |
-| `POST` | `/auth/register` | Register; returns `{ user, token, recoveryCode }` |
-| `POST` | `/auth/login` | Login; returns `{ user, token }` |
-| `POST` | `/auth/reset-password` | Reset password with recovery code; returns `{ newRecoveryCode }` |
-
-### Recommendations
-
-| Method | Path | Description |
-|--------|------|-------------|
-| `POST` | `/recommendations` | Generate recommendations (`fresh` or `preference-aware` mode) |
-
-Request body example:
-
-```json
-{
-  "query": "I like Alcest and Agalloch",
-  "mode": "preference-aware",
-  "selectedArtistIds": ["mbid-1", "mbid-2"],
-  "priorityContext": "Prefer dreamy blackgaze and long tracks",
-  "messages": [
-    { "role": "user", "content": "I like Alcest" },
-    { "role": "assistant", "content": "Try Fen and Les Discrets" }
-  ]
-}
-```
-
-Response includes `recommendations`, optional `assistantReply` (conversational prose from the model), and `meta` (`modeUsed`, `usedPreferenceContext`).
-
-### Preferences
-
-| Method | Path | Description |
-|--------|------|-------------|
-| `POST` | `/preferences` | Save a band |
-| `GET` | `/preferences` | List saved bands |
-| `PATCH` | `/preferences/:id` | Update rating / categories / note |
-| `DELETE` | `/preferences/:id` | Remove a band |
-| `GET` | `/preferences/context` | Render AI context string from saved bands |
-| `GET` | `/preferences/export` | Export all saved bands as JSON |
-| `POST` | `/preferences/import` | Import saved bands from JSON array; returns `{ imported, skipped, failed }` |
-
-### Artist Groups
-
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/preferences/groups` | List all groups with member IDs |
-| `POST` | `/preferences/groups` | Create a group |
-| `POST` | `/preferences/groups/auto` | Auto-generate groups by genre (MusicBrainz tags) |
-| `PATCH` | `/preferences/groups/:id` | Rename a group |
-| `DELETE` | `/preferences/groups/:id` | Delete a group |
-| `POST` | `/preferences/groups/:id/artists` | Add artist to group |
-| `DELETE` | `/preferences/groups/:id/artists/:savedBandId` | Remove artist from group |
-
-### Sessions
-
-| Method | Path | Description |
-|--------|------|-------------|
-| `POST` | `/sessions` | Create chat session |
-| `GET` | `/sessions` | List chat sessions |
-| `GET` | `/sessions/:id` | Get one session with messages |
-| `POST` | `/sessions/:id/messages` | Add message to session |
-
-### Artist Discovery
-
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/artists/search?query=...` | Search artists via MusicBrainz |
-| `GET` | `/artists/image?name=...` | Resolve artist image URL (Wikidata + Last.fm fallback) |
-
-### Eval
-
-Requires `EVAL_DASHBOARD_ENABLED=true` in the environment.
-
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/eval/dashboard` | Developer quality dashboard — pipeline funnel, obscurity distribution, LLM-judge alignment, trend charts, and event log |
-| `POST` | `/eval/baseline` | Save a named snapshot of current aggregated metrics for before/after comparison |
+See `.env.example` for all options including storage backends, timeouts, search budgets, and CORS settings.
 
 ---
 
@@ -315,13 +186,7 @@ npm test          # run all workspace tests
 npm run ci        # lint + typecheck + test
 ```
 
-The API, shared schema, and **desktop** workspaces run tests with **tsx** so `.ts` sources execute next to remaining `.js` modules. `npm run dev` / `npm start` also use tsx for the API entrypoint.
-
-`npm run ci` runs **ruff** and **black** on Python sources (same as GitHub Actions). `npm run lint:py` uses `scripts/lint-py.sh`, which prefers a repo-local **`.venv`** (`python3 -m venv .venv && .venv/bin/pip install ruff black`) and falls back to tools on your `PATH`. The `.venv/` directory is gitignored.
-
-Tests run automatically before every commit via a pre-commit hook (installed by `npm install`).
-
-**CI** runs on both `ubuntu-latest` and `windows-latest` via a GitHub Actions matrix. All `run:` steps use Bash (Git Bash on Windows) so shell scripts like `lint-py.sh` work cross-platform without modification.
+Tests run automatically before every commit via a pre-commit hook (installed by `npm install`). CI runs on both `ubuntu-latest` and `windows-latest` via a GitHub Actions matrix.
 
 ---
 
@@ -331,19 +196,19 @@ Tests run automatically before every commit via a pre-commit hook (installed by 
 apps/desktop/     — Tauri + React desktop client
 services/api/     — Express API
 services/eval/    — golden dataset and eval runner (anti-band gate, nugget coverage)
-shared/schemas/   — shared validation contracts (TypeScript contracts.ts + tests)
+shared/schemas/   — shared TypeScript validation contracts
 docs/             — architecture docs, ADRs, design specs, roadmap
 ```
 
-In development (browser or embedded webview), the chat UI chooses **mobile vs desktop layout** from window width (`matchMedia`, max-width **767px**), so you do not need to pass a `viewport` option manually when resizing the window.
+---
 
 ## Acknowledgements
 
-- [MusicBrainz](https://musicbrainz.org) — open music encyclopedia providing artist and release metadata. Data used under the [CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/) licence.
-- [Google Gemini](https://deepmind.google/technologies/gemini/) — large language model powering the recommendation and explanation layer.
-- [LangChain](https://www.langchain.com) — framework used to structure and invoke the Gemini model calls.
-- [Tauri](https://tauri.app) — framework for building the native desktop wrapper around the web UI.
-- [Brave Search](https://brave.com/search/api/) — web search API used for niche artist discovery.
+- [MusicBrainz](https://musicbrainz.org) — open music encyclopedia providing artist and release metadata (CC0 1.0)
+- [Google Gemini](https://deepmind.google/technologies/gemini/) — LLM powering the recommendation and explanation layer
+- [LangChain](https://www.langchain.com) — framework for structuring Gemini model calls
+- [Tauri](https://tauri.app) — framework for the native desktop wrapper
+- [Brave Search](https://brave.com/search/api/) — web search API for niche artist discovery
 
 ---
 


### PR DESCRIPTION
## What changed

The README was 15 KB — comprehensive, but heavy for someone discovering the project for the first time. This PR brings it down to ~9 KB while keeping all essential information.

### Removed
- **API Reference section** (30+ routes table) — this level of detail belongs in generated API docs or `docs/`, not in the project overview
- **Full environment variable table** (25+ vars) — replaced with just the required and common optional ones; `.env.example` is the canonical reference

### Added
- **Tech Stack table** — at-a-glance overview of the key technologies

### Condensed
- Desktop App section: removed the internal Node sidecar/binary details (kept for contributors in CONTRIBUTING/docs)
- Storage section: removed the step-by-step Postgres/Turso CLI setup (`.env.example` covers what's needed)

### Unchanged
- All mermaid diagrams
- Features list
- Quick Start
- Auth section (users table)
- Storage options table
- Development commands
- Monorepo structure
- Acknowledgements & license

## Docs not touched

`docs/architecture/ARCHITECTURE.md`, `docs/README.md`, `docs/maintenance.md`, and all ADRs are already accurate and well-structured — no changes needed there.

---
_Generated by [Claude Code](https://claude.ai/code/session_012dg5iSzcLkKP4x44D99njE)_