### PR TITLE
refactor(auth): extract shared user model helpers into userModel.ts

### DIFF
--- a/services/api/src/auth/tursoUserRepository.ts
+++ b/services/api/src/auth/tursoUserRepository.ts
@@ -1,28 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { Client as LibSQLClient } from "@libsql/client";
-import type { UserRepository, User, PublicUser } from "./userRepository";
-
-function normalizeEmail(email: string): string {
-  return email.trim().toLowerCase();
-}
-
-function rowToUser(row: Record<string, unknown>): User {
-  return {
-    id: row.id as string,
-    email: row.email as string,
-    displayName: row.display_name as string,
-    passwordHash: row.password_hash as string,
-    recoveryCodeHash: row.recovery_code_hash as string,
-    createdAt: row.created_at as string,
-  };
-}
-
-function publicUser(user: User): PublicUser {
-  const { passwordHash: _ph, recoveryCodeHash: _rc, ...pub } = user;
-  void _ph;
-  void _rc;
-  return pub;
-}
+import type { UserRepository } from "./userRepository";
+import { normalizeEmail, publicUser, rowToUser } from "./userModel.js";
 
 export function createTursoUserRepository({ client }: { client: LibSQLClient }): UserRepository {
   return {

--- a/services/api/src/auth/userModel.ts
+++ b/services/api/src/auth/userModel.ts
@@ -1,0 +1,23 @@
+import type { User, PublicUser } from "./userRepository.js";
+
+export function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+export function publicUser(user: User): PublicUser {
+  const { passwordHash: _ph, recoveryCodeHash: _rc, ...pub } = user;
+  void _ph;
+  void _rc;
+  return pub;
+}
+
+export function rowToUser(row: Record<string, unknown>): User {
+  return {
+    id: row.id as string,
+    email: row.email as string,
+    displayName: row.display_name as string,
+    passwordHash: row.password_hash as string,
+    recoveryCodeHash: row.recovery_code_hash as string,
+    createdAt: row.created_at as string,
+  };
+}

--- a/services/api/src/auth/userRepository.ts
+++ b/services/api/src/auth/userRepository.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "crypto";
+import { normalizeEmail, publicUser, rowToUser } from "./userModel.js";
 
 export type User = {
   id: string;
@@ -31,28 +32,6 @@ export type UserRepository = {
   updatePassword(id: string, input: UpdatePasswordInput): Promise<{ ok: true } | { ok: false; error: string }>;
   getFirstUser(): Promise<User | null>;
 };
-
-function normalizeEmail(email: string): string {
-  return email.trim().toLowerCase();
-}
-
-function publicUser(user: User): PublicUser {
-  const { passwordHash: _ph, recoveryCodeHash: _rc, ...pub } = user;
-  void _ph;
-  void _rc;
-  return pub;
-}
-
-function rowToUser(row: Record<string, unknown>): User {
-  return {
-    id: row.id as string,
-    email: row.email as string,
-    displayName: row.display_name as string,
-    passwordHash: row.password_hash as string,
-    recoveryCodeHash: row.recovery_code_hash as string,
-    createdAt: row.created_at as string,
-  };
-}
 
 export function createInMemoryUserRepository(): UserRepository {
   const users = new Map<string, User>();

--- a/services/api/test/user-model.test.js
+++ b/services/api/test/user-model.test.js
@@ -1,0 +1,59 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { normalizeEmail, publicUser, rowToUser } = require("../src/auth/userModel");
+
+test("normalizeEmail trims whitespace and lowercases", () => {
+  assert.equal(normalizeEmail("  Alice@Example.COM  "), "alice@example.com");
+});
+
+test("normalizeEmail handles already-lowercase email", () => {
+  assert.equal(normalizeEmail("alice@example.com"), "alice@example.com");
+});
+
+test("publicUser strips passwordHash and recoveryCodeHash fields", () => {
+  const user = {
+    id: "1",
+    email: "alice@example.com",
+    displayName: "Alice",
+    passwordHash: "secret",
+    recoveryCodeHash: "also-secret",
+    createdAt: "2024-01-01T00:00:00.000Z",
+  };
+  const pub = publicUser(user);
+  assert.equal("passwordHash" in pub, false);
+  assert.equal("recoveryCodeHash" in pub, false);
+});
+
+test("publicUser preserves id, email, displayName, createdAt", () => {
+  const user = {
+    id: "42",
+    email: "bob@example.com",
+    displayName: "Bob",
+    passwordHash: "hash",
+    recoveryCodeHash: "rchash",
+    createdAt: "2025-06-01T10:00:00.000Z",
+  };
+  const pub = publicUser(user);
+  assert.equal(pub.id, "42");
+  assert.equal(pub.email, "bob@example.com");
+  assert.equal(pub.displayName, "Bob");
+  assert.equal(pub.createdAt, "2025-06-01T10:00:00.000Z");
+});
+
+test("rowToUser maps snake_case DB row fields to camelCase User fields", () => {
+  const row = {
+    id: "abc",
+    email: "carol@example.com",
+    display_name: "Carol",
+    password_hash: "phash",
+    recovery_code_hash: "rchash",
+    created_at: "2026-01-01T00:00:00.000Z",
+  };
+  const user = rowToUser(row);
+  assert.equal(user.id, "abc");
+  assert.equal(user.email, "carol@example.com");
+  assert.equal(user.displayName, "Carol");
+  assert.equal(user.passwordHash, "phash");
+  assert.equal(user.recoveryCodeHash, "rchash");
+  assert.equal(user.createdAt, "2026-01-01T00:00:00.000Z");
+});


### PR DESCRIPTION
## Summary
- `normalizeEmail()`, `publicUser()`, and `rowToUser()` were copy-pasted verbatim in both `userRepository.ts` and `tursoUserRepository.ts`
- Extract to `services/api/src/auth/userModel.ts`; both adapters now import from it
- A bug fix or email normalisation change now touches one file instead of two

## Test plan
- [x] 5 new tests in `user-model.test.js` covering all three functions
- [x] Existing `user-repository.test.js` and `turso-user-repository.test.js` pass unchanged (401 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)