### PR TITLE
refactor(preferences): introduce BandRepository and BandGroupRepository interfaces

### DIFF
--- a/services/api/src/preferences/postgresPreferenceRepository.ts
+++ b/services/api/src/preferences/postgresPreferenceRepository.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { Pool } from "pg";
 import { validateSavedBand as validateSavedBandInput } from "../../../../shared/schemas/src/contracts.js";
 import { formatSavedBandContextLine } from "./savedBandContextFormat.js";
+import type { PreferenceRepository } from "./preferenceRepository.js";
 
 type SavedBandRow = {
   id: string;
@@ -41,7 +42,7 @@ function mapRowToSavedBand(row: SavedBandRow) {
   };
 }
 
-export function createPostgresPreferenceRepository({ pool }: { pool: Pool }) {
+export function createPostgresPreferenceRepository({ pool }: { pool: Pool }): PreferenceRepository {
   return {
     async addSavedBand(input: unknown) {
       const validation = validateSavedBandInput(input);

--- a/services/api/src/preferences/preferenceMemory.ts
+++ b/services/api/src/preferences/preferenceMemory.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { validateSavedBand as validateSavedBandInput } from "../../../../shared/schemas/src/contracts.js";
 import { formatSavedBandContextLine } from "./savedBandContextFormat.js";
+import type { PreferenceRepository } from "./preferenceRepository.js";
 
 export { validateSavedBandInput };
 
@@ -212,6 +213,6 @@ export function createPreferenceMemory() {
   };
 }
 
-export function createInMemoryPreferenceRepository() {
+export function createInMemoryPreferenceRepository(): PreferenceRepository {
   return createPreferenceMemory();
 }

--- a/services/api/src/preferences/preferenceRepository.ts
+++ b/services/api/src/preferences/preferenceRepository.ts
@@ -17,13 +17,16 @@ function addColumnIfMissing(db: import("better-sqlite3").Database, table: string
 
 type Group = { id: string; name: string; memberIds: string[] };
 
-export type PreferenceRepository = {
+export type BandRepository = {
   addSavedBand: (input: unknown, userId?: string) => Promise<{ ok: boolean; error?: string; savedBand?: unknown }>;
   listSavedBands: (userId?: string) => Promise<unknown[]>;
   updateSavedBand: (id: string, updates: { rating?: number; categories?: string[]; note?: string }, userId?: string) => Promise<{ ok: boolean; error?: string; status?: number; savedBand?: unknown }>;
   deleteSavedBand: (id: string, userId?: string) => Promise<{ ok: boolean; error?: string; status?: number; deletedId?: string }>;
   buildContext: (userId?: string) => Promise<string>;
   buildContextForIds: (ids: string[], userId?: string) => Promise<string>;
+};
+
+export type BandGroupRepository = {
   importSavedBands: (bands: unknown[], userId?: string) => Promise<{ imported: number; skipped: number; failed: number }>;
   listGroups: (userId?: string) => Promise<Group[]>;
   createGroup: (name: string, userId?: string) => Promise<{ ok: boolean; error?: string; status?: number; group?: Group }>;
@@ -33,29 +36,48 @@ export type PreferenceRepository = {
   removeArtistFromGroup: (groupId: string, savedBandId: string, userId?: string) => Promise<{ ok: boolean; error?: string; status?: number }>;
 };
 
-export function assertPreferenceRepository(repository: unknown): PreferenceRepository {
-  const requiredMethods = [
-    "addSavedBand",
-    "listSavedBands",
-    "updateSavedBand",
-    "deleteSavedBand",
-    "buildContext",
-    "buildContextForIds",
-    "importSavedBands",
-    "listGroups",
-    "createGroup",
-    "renameGroup",
-    "deleteGroup",
-    "addArtistToGroup",
-    "removeArtistFromGroup",
-  ];
+// Keep for backwards compatibility during transition — all existing adapters implement both
+export type PreferenceRepository = BandRepository & BandGroupRepository;
 
-  for (const methodName of requiredMethods) {
+const BAND_REPOSITORY_METHODS = [
+  "addSavedBand",
+  "listSavedBands",
+  "updateSavedBand",
+  "deleteSavedBand",
+  "buildContext",
+  "buildContextForIds",
+] as const;
+
+const BAND_GROUP_REPOSITORY_METHODS = [
+  "importSavedBands",
+  "listGroups",
+  "createGroup",
+  "renameGroup",
+  "deleteGroup",
+  "addArtistToGroup",
+  "removeArtistFromGroup",
+] as const;
+
+function assertMethods(repository: unknown, methodNames: readonly string[]) {
+  for (const methodName of methodNames) {
     if (typeof (repository as Record<string, unknown>)?.[methodName] !== "function") {
       throw new Error(`invalid preference repository: missing method ${methodName}`);
     }
   }
+}
 
+export function assertBandRepository(repository: unknown): BandRepository {
+  assertMethods(repository, BAND_REPOSITORY_METHODS);
+  return repository as BandRepository;
+}
+
+export function assertBandGroupRepository(repository: unknown): BandGroupRepository {
+  assertMethods(repository, BAND_GROUP_REPOSITORY_METHODS);
+  return repository as BandGroupRepository;
+}
+
+export function assertPreferenceRepository(repository: unknown): PreferenceRepository {
+  assertMethods(repository, [...BAND_REPOSITORY_METHODS, ...BAND_GROUP_REPOSITORY_METHODS]);
   return repository as PreferenceRepository;
 }
 
@@ -68,7 +90,7 @@ type PreferenceConfig = {
   tursoAuthToken?: string;
 };
 
-export function createPreferenceRepository(runtimeConfig: PreferenceConfig = {}) {
+export function createPreferenceRepository(runtimeConfig: PreferenceConfig = {}): PreferenceRepository {
   if (runtimeConfig.preferenceStore === "postgres") {
     const pool = new Pool({
       connectionString: runtimeConfig.databaseUrl,

--- a/services/api/src/preferences/sqlitePreferenceRepository.ts
+++ b/services/api/src/preferences/sqlitePreferenceRepository.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { Database } from "better-sqlite3";
 import { validateSavedBand as validateSavedBandInput } from "../../../../shared/schemas/src/contracts.js";
 import { formatSavedBandContextLine } from "./savedBandContextFormat.js";
+import type { PreferenceRepository } from "./preferenceRepository.js";
 
 const DEFAULT_USER = "anonymous";
 
@@ -44,7 +45,7 @@ function mapRowToSavedBand(row: SavedBandRow) {
   };
 }
 
-export function createSqlitePreferenceRepository({ db }: { db: Database }) {
+export function createSqlitePreferenceRepository({ db }: { db: Database }): PreferenceRepository {
   return {
     async addSavedBand(input: unknown, userId = DEFAULT_USER) {
       const validation = validateSavedBandInput(input);

--- a/services/api/src/preferences/tursoPreferenceRepository.ts
+++ b/services/api/src/preferences/tursoPreferenceRepository.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { Client as LibSQLClient, Row } from "@libsql/client";
 import { validateSavedBand as validateSavedBandInput } from "../../../../shared/schemas/src/contracts.js";
 import { formatSavedBandContextLine } from "./savedBandContextFormat.js";
+import type { PreferenceRepository } from "./preferenceRepository.js";
 
 const DEFAULT_USER = "anonymous";
 
@@ -28,7 +29,7 @@ function mapRowToSavedBand(row: Row) {
   };
 }
 
-export function createTursoPreferenceRepository({ client }: { client: LibSQLClient }) {
+export function createTursoPreferenceRepository({ client }: { client: LibSQLClient }): PreferenceRepository {
   return {
     async addSavedBand(input: unknown, userId = DEFAULT_USER) {
       const validation = validateSavedBandInput(input);

--- a/services/api/test/preference-repository-interfaces.test.js
+++ b/services/api/test/preference-repository-interfaces.test.js
@@ -1,0 +1,91 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  assertBandRepository,
+  assertBandGroupRepository,
+  assertPreferenceRepository,
+} = require("../src/preferences/preferenceRepository");
+const { createInMemoryPreferenceRepository } = require("../src/preferences/preferenceMemory");
+
+const noop = async () => {};
+
+function bandRepositoryStub() {
+  return {
+    addSavedBand: noop,
+    listSavedBands: noop,
+    updateSavedBand: noop,
+    deleteSavedBand: noop,
+    buildContext: noop,
+    buildContextForIds: noop,
+  };
+}
+
+function bandGroupRepositoryStub() {
+  return {
+    importSavedBands: noop,
+    listGroups: noop,
+    createGroup: noop,
+    renameGroup: noop,
+    deleteGroup: noop,
+    addArtistToGroup: noop,
+    removeArtistFromGroup: noop,
+  };
+}
+
+test("assertBandRepository accepts an object with all 6 BandRepository methods", () => {
+  const resolved = assertBandRepository(bandRepositoryStub());
+  assert.equal(typeof resolved.addSavedBand, "function");
+});
+
+test("assertBandRepository throws when addSavedBand is missing", () => {
+  const repo = bandRepositoryStub();
+  delete repo.addSavedBand;
+  assert.throws(() => assertBandRepository(repo), /missing method addSavedBand/);
+});
+
+test("assertBandRepository throws when buildContext is missing", () => {
+  const repo = bandRepositoryStub();
+  delete repo.buildContext;
+  assert.throws(() => assertBandRepository(repo), /missing method buildContext/);
+});
+
+test("assertBandGroupRepository accepts an object with all 7 BandGroupRepository methods", () => {
+  const resolved = assertBandGroupRepository(bandGroupRepositoryStub());
+  assert.equal(typeof resolved.listGroups, "function");
+});
+
+test("assertBandGroupRepository throws when listGroups is missing", () => {
+  const repo = bandGroupRepositoryStub();
+  delete repo.listGroups;
+  assert.throws(() => assertBandGroupRepository(repo), /missing method listGroups/);
+});
+
+test("assertBandGroupRepository throws when importSavedBands is missing", () => {
+  const repo = bandGroupRepositoryStub();
+  delete repo.importSavedBands;
+  assert.throws(() => assertBandGroupRepository(repo), /missing method importSavedBands/);
+});
+
+test("assertPreferenceRepository still accepts a full 13-method object", () => {
+  const repo = { ...bandRepositoryStub(), ...bandGroupRepositoryStub() };
+  const resolved = assertPreferenceRepository(repo);
+  assert.equal(typeof resolved.addSavedBand, "function");
+  assert.equal(typeof resolved.listGroups, "function");
+});
+
+test("assertPreferenceRepository throws when any method is missing", () => {
+  const repo = { ...bandRepositoryStub(), ...bandGroupRepositoryStub() };
+  delete repo.removeArtistFromGroup;
+  assert.throws(() => assertPreferenceRepository(repo), /missing method removeArtistFromGroup/);
+});
+
+test("the in-memory adapter satisfies assertBandRepository", () => {
+  const resolved = assertBandRepository(createInMemoryPreferenceRepository());
+  assert.equal(typeof resolved.buildContextForIds, "function");
+});
+
+test("the in-memory adapter satisfies assertBandGroupRepository", () => {
+  const resolved = assertBandGroupRepository(createInMemoryPreferenceRepository());
+  assert.equal(typeof resolved.createGroup, "function");
+});


### PR DESCRIPTION
## Summary
- `PreferenceRepository` had 13 methods across three distinct concerns; adding any method meant touching four adapter files and thirteen method lists
- Split into `BandRepository` (6 methods: CRUD + context building) and `BandGroupRepository` (7 methods: group operations + import)
- `PreferenceRepository` remains as a union alias `BandRepository & BandGroupRepository` — no callers change in this PR
- Add `assertBandRepository` / `assertBandGroupRepository` helpers so narrow callsites can validate only the methods they use
- Internal assertion helpers refactored to share a `assertMethods` utility to avoid three-way loop duplication

## Key decisions
- **Additive only**: `PreferenceRepository = BandRepository & BandGroupRepository` means zero changes to routes or `app.ts` — the same 13-method contract is preserved structurally
- **Adapter return-type annotations**: all four adapters now explicitly annotate `: PreferenceRepository` so TypeScript validates them against both split interfaces
- typecheck: clean, no errors

## Test plan
- [x] 10 new tests in `preference-repository-interfaces.test.js` covering both assertion helpers and in-memory adapter conformance
- [x] All 396 pre-existing tests pass (406 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)