### PR TITLE
docs: separate active docs from historical planning files

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,15 +8,13 @@ Navigation guide for the `docs/` folder.
 |------|----------------|
 | [ROADMAP.md](ROADMAP.md) | Phase-by-phase feature roadmap with completion status |
 | [architecture/ARCHITECTURE.md](architecture/ARCHITECTURE.md) | System architecture — graph pipeline, state fields, integrations, storage, auth |
-| [architecture/2026-05-29-eval-architecture.md](architecture/2026-05-29-eval-architecture.md) | Evaluation layer design — three-tier scoring, LLM-as-judge, feedback loop |
-| [architecture/2026-05-30-phase8-implementation-plan.md](architecture/2026-05-30-phase8-implementation-plan.md) | Phase 8 step-by-step implementation plan (eval & quality observability) |
-| [architecture/2026-06-03-auto-update-plan.md](architecture/2026-06-03-auto-update-plan.md) | Auto-update plan — Tauri updater integration and release pipeline |
 | [adr/0001-prompt-injection-guardrails.md](adr/0001-prompt-injection-guardrails.md) | ADR: prompt injection defence — bracket-marker envelope and length caps |
 | [design/UI_GUIDELINES.md](design/UI_GUIDELINES.md) | UI design guidelines — layout, components, responsive behaviour |
 | [design/UI_EXAMPLES.md](design/UI_EXAMPLES.md) | UI copy examples and interaction patterns |
 | [agents/domain.md](agents/domain.md) | Domain knowledge for AI coding agents working in this repo |
 | [agents/issue-tracker.md](agents/issue-tracker.md) | Issue tracking conventions |
 | [agents/triage-labels.md](agents/triage-labels.md) | Triage label definitions |
+| [maintenance.md](maintenance.md) | Dependency versions and periodic maintenance notes |
 
 ## Where to start
 
@@ -27,10 +25,13 @@ Navigation guide for the `docs/` folder.
 
 ## Historical planning docs
 
-The `superpowers/` folder contains implementation plans and design specs from earlier development phases. These are reference material, not actively maintained.
+The `superpowers/` folder and the dated files below are implementation plans and design specs from earlier development phases. These are reference material, not actively maintained.
 
 | Path | What it covers |
 |------|----------------|
+| [architecture/2026-05-29-eval-architecture.md](architecture/2026-05-29-eval-architecture.md) | Evaluation layer design — three-tier scoring, LLM-as-judge, feedback loop |
+| [architecture/2026-05-30-phase8-implementation-plan.md](architecture/2026-05-30-phase8-implementation-plan.md) | Phase 8 step-by-step implementation plan (eval & quality observability) |
+| [architecture/2026-06-03-auto-update-plan.md](architecture/2026-06-03-auto-update-plan.md) | Auto-update plan — Tauri updater integration and release pipeline |
 | [superpowers/plans/2026-04-30-ui-redesign.md](superpowers/plans/2026-04-30-ui-redesign.md) | UI redesign plan (Phase 3 era) |
 | [superpowers/specs/2026-04-30-tauri-scaffold-design.md](superpowers/specs/2026-04-30-tauri-scaffold-design.md) | Tauri desktop scaffold design spec |
 | [superpowers/specs/2026-05-12-llm-musicbrainz-query-design.md](superpowers/specs/2026-05-12-llm-musicbrainz-query-design.md) | LLM + MusicBrainz query design spec |


### PR DESCRIPTION
## What changed

**`docs/README.md`** — the dated implementation-plan files in `docs/architecture/` were listed in the main Contents table alongside `ARCHITECTURE.md`, as if they're primary reference documents. For an external reader, this is noisy and misleading.

Moved them to the existing **Historical planning docs** section, which already held the `superpowers/` entries:

| Before | After |
|---|---|
| `2026-05-29-eval-architecture.md` in main table | Moved to Historical planning docs |
| `2026-05-30-phase8-implementation-plan.md` in main table | Moved to Historical planning docs |
| `2026-06-03-auto-update-plan.md` in main table | Moved to Historical planning docs |

The actual files are **not moved or deleted** — only their position in the navigation index changed.

## What was not changed

- `ARCHITECTURE.md` — already accurate and comprehensive with Mermaid diagrams; no changes needed
- `README.md` — already reflects current state with Mermaid workflow diagram; no changes needed
- All other docs — up to date

## Review checklist

- [ ] `docs/README.md` Contents table shows only current-state docs
- [ ] Historical planning docs section now includes all dated planning files
- [ ] No files were deleted or moved on disk

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMYNEGE4VfRSE7ARB7oVt9)_