### PR TITLE
docs: add Documentation section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ See [`docs/architecture/ARCHITECTURE.md`](docs/architecture/ARCHITECTURE.md) for
 
 ---
 
+## Documentation
+
+| Path | What it covers |
+|------|----------------|
+| [docs/architecture/ARCHITECTURE.md](docs/architecture/ARCHITECTURE.md) | Full pipeline — nodes, reflection subgraph, state fields, storage, auth, and eval layer |
+| [docs/ROADMAP.md](docs/ROADMAP.md) | Phase-by-phase roadmap with completion status |
+| [docs/adr/0001-prompt-injection-guardrails.md](docs/adr/0001-prompt-injection-guardrails.md) | ADR: prompt injection defence strategy |
+| [docs/design/UI_GUIDELINES.md](docs/design/UI_GUIDELINES.md) | UI layout and component guidelines |
+| [docs/maintenance.md](docs/maintenance.md) | Dependency upgrade notes |
+
+---
+
 ## Tech Stack
 
 | Layer | Technology |


### PR DESCRIPTION
## What changed

Added a **Documentation** section to `README.md` with a table linking to the key files in `docs/`.

The README already had a strong mermaid diagram and comprehensive coverage of features, quick start, auth, and storage. The one gap was that it only linked to `ARCHITECTURE.md` inline, with no overview of the rest of `docs/`. Visitors had to discover `ROADMAP.md`, the ADR, UI guidelines, and maintenance notes on their own.

## Changes

**`README.md`** — inserted a Documentation table between the "How it works" section and "Tech Stack":

| Path | What it covers |
|------|----------------|
| `docs/architecture/ARCHITECTURE.md` | Full pipeline — nodes, reflection subgraph, state, storage, auth, eval layer |
| `docs/ROADMAP.md` | Phase-by-phase roadmap |
| `docs/adr/0001-prompt-injection-guardrails.md` | Prompt injection defence ADR |
| `docs/design/UI_GUIDELINES.md` | UI guidelines |
| `docs/maintenance.md` | Dependency upgrade notes |

No other changes — all existing content is preserved exactly as-is.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZd7EbEkvASeQhWaz6TB5r)_