### PR TITLE
docs: add maintenance.md to docs/README.md contents table

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Navigation guide for the `docs/` folder.
 | Path | What it covers |
 |------|----------------|
 | [ROADMAP.md](ROADMAP.md) | Phase-by-phase feature roadmap with completion status |
+| [maintenance.md](maintenance.md) | Weekly dependency audit — package versions, applied fixes, and pending upgrades |
 | [architecture/ARCHITECTURE.md](architecture/ARCHITECTURE.md) | System architecture — graph pipeline, state fields, integrations, storage, auth |
 | [architecture/2026-05-29-eval-architecture.md](architecture/2026-05-29-eval-architecture.md) | Evaluation layer design — three-tier scoring, LLM-as-judge, feedback loop |
 | [architecture/2026-05-30-phase8-implementation-plan.md](architecture/2026-05-30-phase8-implementation-plan.md) | Phase 8 step-by-step implementation plan (eval & quality observability) |
@@ -24,6 +25,7 @@ Navigation guide for the `docs/` folder.
 - **Changing the UI?** Consult [UI_GUIDELINES.md](design/UI_GUIDELINES.md) before writing new components.
 - **Security or prompt design?** See [ADR 0001](adr/0001-prompt-injection-guardrails.md) for the injection defence rationale.
 - **Planning a new feature?** Check [ROADMAP.md](ROADMAP.md) for phase status and open steps before starting.
+- **Checking dependencies or build health?** See [maintenance.md](maintenance.md) for the latest dependency audit and pending upgrades.
 
 ## Historical planning docs
 


### PR DESCRIPTION
## What

`docs/maintenance.md` exists and is kept up to date (last entry 2026-06-10) but was not listed in `docs/README.md`, making it invisible to anyone using the docs index as a navigation guide.

## Changes

- **`docs/README.md`** — Added `maintenance.md` to the Contents table and added a "Checking dependencies or build health?" bullet to the "Where to start" section.

## Why only this

The rest of the docs are in good shape:
- `docs/architecture/ARCHITECTURE.md` is comprehensive with Mermaid diagrams covering the full pipeline, reflection subgraph, eval layer, storage, and auth.
- The root `README.md` has a clear workflow Mermaid diagram and covers all current features.
- All other files in `docs/README.md` table already exist and are up to date.

No other changes were needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MFKVURMaQ4Zm12xYKnBXRR)_