### PR TITLE
docs: reorganize docs/README.md — separate reference from planning docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,35 +2,43 @@
 
 Navigation guide for the `docs/` folder.
 
-## Contents
+## Core reference
 
 | Path | What it covers |
 |------|----------------|
+| [architecture/ARCHITECTURE.md](architecture/ARCHITECTURE.md) | System architecture — graph pipeline, state fields, integrations, storage, auth — with Mermaid diagrams |
 | [ROADMAP.md](ROADMAP.md) | Phase-by-phase feature roadmap with completion status |
-| [architecture/ARCHITECTURE.md](architecture/ARCHITECTURE.md) | System architecture — graph pipeline, state fields, integrations, storage, auth |
-| [architecture/2026-05-29-eval-architecture.md](architecture/2026-05-29-eval-architecture.md) | Evaluation layer design — three-tier scoring, LLM-as-judge, feedback loop |
-| [architecture/2026-05-30-phase8-implementation-plan.md](architecture/2026-05-30-phase8-implementation-plan.md) | Phase 8 step-by-step implementation plan (eval & quality observability) |
-| [architecture/2026-06-03-auto-update-plan.md](architecture/2026-06-03-auto-update-plan.md) | Auto-update plan — Tauri updater integration and release pipeline |
 | [adr/0001-prompt-injection-guardrails.md](adr/0001-prompt-injection-guardrails.md) | ADR: prompt injection defence — bracket-marker envelope and length caps |
 | [design/UI_GUIDELINES.md](design/UI_GUIDELINES.md) | UI design guidelines — layout, components, responsive behaviour |
 | [design/UI_EXAMPLES.md](design/UI_EXAMPLES.md) | UI copy examples and interaction patterns |
-| [agents/domain.md](agents/domain.md) | Domain knowledge for AI coding agents working in this repo |
-| [agents/issue-tracker.md](agents/issue-tracker.md) | Issue tracking conventions |
-| [agents/triage-labels.md](agents/triage-labels.md) | Triage label definitions |
+| [maintenance.md](maintenance.md) | Dependency versions, upgrade notes, and periodic maintenance tasks |
 
 ## Where to start
 
-- **New to the codebase?** Read [ARCHITECTURE.md](architecture/ARCHITECTURE.md) first, then [ROADMAP.md](ROADMAP.md) to see where the project stands.
+- **New to the codebase?** Read [ARCHITECTURE.md](architecture/ARCHITECTURE.md) first — it covers the full graph pipeline, state, storage, and auth with Mermaid diagrams. Then check [ROADMAP.md](ROADMAP.md) to see where the project stands.
 - **Changing the UI?** Consult [UI_GUIDELINES.md](design/UI_GUIDELINES.md) before writing new components.
 - **Security or prompt design?** See [ADR 0001](adr/0001-prompt-injection-guardrails.md) for the injection defence rationale.
 - **Planning a new feature?** Check [ROADMAP.md](ROADMAP.md) for phase status and open steps before starting.
 
-## Historical planning docs
+## Internal tooling
 
-The `superpowers/` folder contains implementation plans and design specs from earlier development phases. These are reference material, not actively maintained.
+These files are used by AI coding agents working in this repo — not required reading for human contributors.
 
 | Path | What it covers |
 |------|----------------|
+| [agents/domain.md](agents/domain.md) | Domain knowledge for AI coding agents |
+| [agents/issue-tracker.md](agents/issue-tracker.md) | Issue tracking conventions |
+| [agents/triage-labels.md](agents/triage-labels.md) | Triage label definitions |
+
+## Historical planning docs
+
+Implementation plans and design specs from earlier development phases. Kept for reference — not actively maintained.
+
+| Path | What it covers |
+|------|----------------|
+| [architecture/2026-05-29-eval-architecture.md](architecture/2026-05-29-eval-architecture.md) | Evaluation layer design — three-tier scoring, LLM-as-judge, feedback loop |
+| [architecture/2026-05-30-phase8-implementation-plan.md](architecture/2026-05-30-phase8-implementation-plan.md) | Phase 8 implementation plan (eval & quality observability) |
+| [architecture/2026-06-03-auto-update-plan.md](architecture/2026-06-03-auto-update-plan.md) | Auto-update plan — Tauri updater integration and release pipeline |
 | [superpowers/plans/2026-04-30-ui-redesign.md](superpowers/plans/2026-04-30-ui-redesign.md) | UI redesign plan (Phase 3 era) |
 | [superpowers/specs/2026-04-30-tauri-scaffold-design.md](superpowers/specs/2026-04-30-tauri-scaffold-design.md) | Tauri desktop scaffold design spec |
 | [superpowers/specs/2026-05-12-llm-musicbrainz-query-design.md](superpowers/specs/2026-05-12-llm-musicbrainz-query-design.md) | LLM + MusicBrainz query design spec |


### PR DESCRIPTION
## What changed\n\n`docs/README.md` previously had one flat `Contents` table that mixed three very different kinds of files together:\n\n- Current architecture reference (`ARCHITECTURE.md`, ADRs, UI guidelines)\n- Dated implementation plans (`2026-05-29-*`, `2026-05-30-*`, `2026-06-03-*`)\n- Internal AI-agent tooling (`agents/domain.md`, triage labels, etc.)\n\nThis made it hard for someone new to the project to know where to start.\n\n## New structure\n\n| Section | What's there |\n|---|---|\n| **Core reference** | `ARCHITECTURE.md`, `ROADMAP.md`, ADRs, UI guidelines, maintenance — the docs you actually need day to day |\n| **Internal tooling** | `agents/` files — clearly marked as for AI coding agents, not required reading for humans |\n| **Historical planning docs** | All dated `2026-xx-xx` files and `superpowers/` specs — kept for reference, not actively maintained |\n\nNo files were moved or deleted. The `Where to start` section was also tightened to point new readers directly to `ARCHITECTURE.md` first.\n\n## Why now\n\nThe README and core docs (`ARCHITECTURE.md`, ADRs) are already accurate and don't need changes. The only issue was navigability — a first-time reader couldn't tell which files were current reference vs. historical notes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFdBSpa9scNHSoMQjhbg5G)_