### PR TITLE
docs: correct LLM-judge vendor, stale config defaults, resolved roadmap items

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,9 +11,21 @@ BRAVE_API_KEY=your_brave_search_api_key
 # Eval & Quality Observability (Phase 8): activates the /eval/* routes and the
 # async eval worker
 # - Obscurity scoring uses LASTFM_API_KEY above
-# - LLM-as-Judge uses MISTRAL_API_KEY
+# - LLM-as-Judge uses MISTRAL_API_KEY — despite the name, this key is sent to
+#   Anthropic's API (Claude judge model), not Mistral
+# - EVAL_DASHBOARD_PASSWORD adds HTTP Basic Auth to GET /eval/dashboard (leave
+#   unset only for local/trusted environments)
 # EVAL_DASHBOARD_ENABLED=true
+# EVAL_DASHBOARD_PASSWORD=choose_a_password
 # MISTRAL_API_KEY=your_mistral_api_key_here
+
+# Auth (optional)
+# - JWT_SECRET: set for sessions that survive a server restart; a random
+#   secret is generated in memory if unset
+# - REGISTRATION_OPEN=false disables POST /auth/register (e.g. after you've
+#   created your account on a shared deployment)
+# JWT_SECRET=your_long_random_secret
+# REGISTRATION_OPEN=true
 
 # Storage: sqlite (default, no setup needed), memory (no persistence), postgres
 # PREFERENCE_STORE=sqlite
@@ -32,7 +44,7 @@ BRAVE_API_KEY=your_brave_search_api_key
 # LANGSMITH_TRACING=true
 # LANGSMITH_PROJECT=bandsearch-dev
 
-CORS_ORIGIN=http://localhost:1420TGyj81krmIKW9SdgD9rZOHZiETPnUitX
+CORS_ORIGIN=http://localhost:1420
 MUSICBRAINZ_TIMEOUT_MS=5000
 MUSICBRAINZ_RETRIES=1
 
@@ -40,6 +52,6 @@ MUSICBRAINZ_RETRIES=1
 # RESEARCH_MAX_INITIAL_SEARCHES=6
 # RESEARCH_MAX_REFLECTION_SEARCHES=4
 # RESEARCH_TOTAL_SEARCH_BUDGET=10
-# RESEARCH_TIMEOUT_MS=25000
+# RESEARCH_TIMEOUT_MS=45000
 # RESEARCH_TARGET_VERIFIED_CANDIDATES=8
 # RECOMMENDATION_PIPELINE_READY_TIMEOUT_MS=45000

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Common optional variables:
 | `JWT_SECRET` | *(auto-generated)* | Set for persistent sessions across restarts |
 | `PREFERENCE_STORE` | `sqlite` | `sqlite`, `memory`, `postgres`, or `turso` |
 | `LASTFM_API_KEY` | — | Last.fm fallback for artist images and obscurity scoring |
-| `MISTRAL_API_KEY` | — | Activates async LLM-as-judge eval scoring |
+| `MISTRAL_API_KEY` | — | Activates the async LLM-as-judge eval scoring — despite the name, it's sent to Anthropic's API (Claude judge model), not Mistral |
 | `LANGSMITH_API_KEY` | — | LangSmith distributed tracing |
 
 See `.env.example` for all options including storage backends, timeouts, search budgets, and CORS settings.

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,3 +34,4 @@ The `superpowers/` folder contains implementation plans and design specs from ea
 | [superpowers/plans/2026-04-30-ui-redesign.md](superpowers/plans/2026-04-30-ui-redesign.md) | UI redesign plan (Phase 3 era) |
 | [superpowers/specs/2026-04-30-tauri-scaffold-design.md](superpowers/specs/2026-04-30-tauri-scaffold-design.md) | Tauri desktop scaffold design spec |
 | [superpowers/specs/2026-05-12-llm-musicbrainz-query-design.md](superpowers/specs/2026-05-12-llm-musicbrainz-query-design.md) | LLM + MusicBrainz query design spec |
+| [superpowers/specs/2026-06-13-stop-retry-buttons-design.md](superpowers/specs/2026-06-13-stop-retry-buttons-design.md) | Stop/retry buttons in the chat UI — design spec |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -88,7 +88,7 @@ Three-layer system to measure recommendation quality over time: automatic obscur
 - [x] Step 2: Last.fm obscurity scoring — async worker enriches events with `listeners` count and tier (`cult` / `underground` / `obscure`) per band after the response is sent ✓ Done
 - [x] Step 3: Obscurity target setting — three-button UI (`Cult Following` / `Underground` / `Truly Obscure`), `obscurityTarget` field threaded through request body → planner prompt → event log ✓ Done
 - [x] Step 4: Search source quality + deterministic evidence checks — URL heuristic for discovery sources plus `citation_support_rate` and `generic_why_flag` per band; stored per event, no LLM needed ✓ Done
-- [x] Step 5: LLM-as-judge worker — async Claude judge scoring each band on relevance, obscurity fit, evidence quality, and discovery value; activated by `ANTHROPIC_API_KEY`; silently skipped if absent ✓ Done
+- [x] Step 5: LLM-as-judge worker — async Claude judge scoring each band on relevance, obscurity fit, evidence quality, and discovery value; activated by `MISTRAL_API_KEY` (env var name is a known mismatch — the key is actually sent to Anthropic's API, not Mistral's); silently skipped if absent ✓ Done
 - [x] Step 5b: Judge calibration — ~20–30 hand-labeled recommendations + ~15–20 GroUSE-style unit tests; compute judge–human agreement rate before trusting Layer 2 dashboard deltas ✓ Done
 - [x] Step 6: Baseline snapshots — `eval_baselines` table + `POST /eval/baseline` endpoint; named snapshots of aggregated metrics before experiments; filterable by `pipeline_version` ✓ Done
 - [x] Step 7: Developer dashboard — `GET /eval/dashboard` serving a standalone HTML+Chart.js page with overview panel (current vs. baseline delta), pipeline funnel panel, human–LLM alignment metrics, trend charts, obscurity distribution, and event log; guarded by `EVAL_DASHBOARD_ENABLED=true` ✓ Done
@@ -215,13 +215,9 @@ Tester werden direkt in der App über neue Versionen informiert. Windows & Linux
 
 The following refactors were identified during architecture review but not yet implemented. Each has a clear action and known files.
 
-### 1. Extract auto-group inference out of the route handler
+### 1. Extract auto-group inference out of the route handler ✓ Done
 
-**Files:** `services/api/src/routes/registerBandsearchRoutes.ts` (lines 290–322)
-
-The logic that fetches saved bands, calls MusicBrainz for each artist's genre, and creates/updates groups lives inline in the `POST /preferences/auto-group` HTTP handler. It is untested, has a race condition when two concurrent requests try to create the same genre group, and cannot be reused by non-HTTP callers (e.g. the import flow).
-
-**Action:** Extract a `bandGroupInference` module (or similar name grounded in domain vocabulary) with one function: given a band name and MusicBrainz metadata, return zero or more group assignments. The route handler calls this and applies the result. Move the MusicBrainz I/O, deduplication, and group upsert logic inside the new module. Add unit tests for at least the race condition and the silent-MusicBrainz-failure path.
+Resolved — the inference logic now lives in `services/api/src/preferences/bandGroupInference.ts`, with its own tests in `services/api/test/band-group-inference.test.js`. `POST /preferences/groups/auto` in `registerBandsearchRoutes.ts` just calls into it.
 
 ---
 
@@ -235,13 +231,9 @@ All four implementations carry 13 methods covering three distinct concerns: band
 
 ---
 
-### 3. Consolidate the HTTP retry seam shared by integration clients
+### 3. Consolidate the HTTP retry seam shared by integration clients ✓ Done
 
-**Files:** `services/api/src/integrations/musicbrainz.ts`, `braveSearch.ts`
-
-`fetchWithTimeoutAndRetry` is copied verbatim in both files — same function, same signature, same AbortController pattern. A bug fix or timeout policy change must be applied in two places.
-
-**Action:** Extract `fetchWithTimeoutAndRetry` into a shared `services/api/src/integrations/httpClient.ts` module. Both `musicbrainz.ts` and `braveSearch.ts` import from it. Add a focused test for the retry and timeout behaviour in the new shared module; remove the duplicated copies from both clients.
+Resolved — `fetchWithTimeoutAndRetry` now lives in `services/api/src/integrations/httpClient.ts`, imported by both `musicbrainz.ts` and `braveSearch.ts`, with its own test in `services/api/test/http-client.test.js`.
 
 ---
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -30,7 +30,7 @@ bandsearch-app/
 ├── apps/
 │   └── desktop/         — Tauri + React desktop application (Rust + TypeScript)
 ├── services/
-│   └── api/             — Express.js API server (TypeScript, Node.js 20+)
+│   └── api/             — Express.js API server (TypeScript, Node.js 22+)
 │   └── eval/            — Golden dataset and eval runner
 ├── shared/
 │   └── schemas/         — Shared TypeScript validation contracts
@@ -71,7 +71,7 @@ graph TD
 
     API -.->|optional| LASTFM[Last.fm\nartist images + obscurity score]
     PIPELINE -.->|optional tracing| LANGSMITH[LangSmith]
-    API -.->|optional async eval| MISTRAL[Mistral\nLLM-as-Judge]
+    API -.->|optional async eval| CLAUDE[Anthropic Claude\nLLM-as-Judge]
 ```
 
 ---
@@ -157,7 +157,7 @@ flowchart TD
 
 ### Budget management (`researchBudget.ts`)
 
-A shared `ResearchBudget` instance tracks wall-clock time against `RESEARCH_TIMEOUT_MS` (default 25 s). Each node calls `budget.allocate(ms)` to claim a per-operation slice. When the budget is exhausted, conditional edges route directly to `END` rather than timing out mid-flight.
+A shared `ResearchBudget` instance tracks wall-clock time against `RESEARCH_TIMEOUT_MS` (default 45 s — generous because the Brave Search free plan throttles to 1 request/second). Each node calls `budget.allocate(ms)` to claim a per-operation slice. When the budget is exhausted, conditional edges route directly to `END` rather than timing out mid-flight.
 
 ---
 
@@ -169,7 +169,7 @@ A shared `ResearchBudget` instance tracks wall-clock time against `RESEARCH_TIME
 | **Google Gemini** (`@langchain/google-genai`) | `plan`, `extract`, `assess`, `rank` | All structured reasoning and text generation |
 | **MusicBrainz** | `verify`, `verify_r` | Artist metadata verification (mbid, genres, tags, URL relations) |
 | **Wikidata + Last.fm** | `/artists/image` endpoint | Artist image resolution with Last.fm fallback |
-| **Mistral** (optional) | Eval layer | Async LLM-as-Judge scoring — never on the critical path |
+| **Anthropic Claude** (optional, key supplied via `MISTRAL_API_KEY` — see note below) | Eval layer | Async LLM-as-Judge scoring — never on the critical path |
 | **LangSmith** (optional) | Graph invocation | Distributed tracing for the LangGraph pipeline |
 
 ---
@@ -186,7 +186,7 @@ flowchart LR
         direction TB
         T1["Tier 1 — Automatic metrics\nobscurity score · funnel counts\nsearch source quality"]
         T15["Tier 1.5 — Deterministic checks\ncitation support rate\ngeneric-why detection"]
-        T2["Tier 2 — LLM-as-Judge\nMistral scores each band\nrelevance · obscurity_fit\nevidence_quality · discovery_value"]
+        T2["Tier 2 — LLM-as-Judge\nClaude scores each band\nrelevance · obscurity_fit\nevidence_quality · discovery_value"]
         T3["Tier 3 — Human feedback\nimplicit saves · explicit batch reactions"]
         T1 --> T15 --> T2
     end
@@ -199,10 +199,12 @@ flowchart LR
 |-------|-----------|------|---------|
 | **1 — Automatic metrics** | Runs immediately | After every request | Obscurity score (Last.fm listener count), funnel counts (hits / extracted / verified), search source quality |
 | **1.5 — Deterministic checks** | Runs immediately | After every request | Citation support rate (evidence URLs per recommendation), generic-why detection |
-| **2 — LLM-as-Judge** | Async, fire-and-forget | When `MISTRAL_API_KEY` is set | Mistral scores each band on `relevance`, `obscurity_fit`, `evidence_quality`, `discovery_value` |
+| **2 — LLM-as-Judge** | Async, fire-and-forget | When `MISTRAL_API_KEY` is set | Claude scores each band on `relevance`, `obscurity_fit`, `evidence_quality`, `discovery_value` |
 | **3 — Human feedback** | Event-driven | User action | Implicit saves + explicit one-tap batch reactions |
 
 Eval data is stored in `recommendation_events`, `llm_eval_scores`, `recommendation_feedback`, and `eval_baselines` tables.
+
+> **Note on `MISTRAL_API_KEY`:** despite the variable name, the judge worker (`eval/judgeWorker.ts`) sends this key to Anthropic's API (`claude-opus-4-8`), not Mistral's. The naming is a known mismatch in the code — worth renaming to `ANTHROPIC_API_KEY` in a follow-up, but documented here as the current, actual behavior.
 
 ---
 
@@ -263,7 +265,7 @@ Three-tier progressive auth — determined by the number of registered users at 
 | Decision | Rationale |
 |----------|----------|
 | **Gemini for all graph nodes** | Consistent structured-JSON output across plan / extract / reflect / rank; low temperature (0.2) for planning reduces variance |
-| **Mistral as optional async judge** | Keeps the LLM judge off the critical response path; eval can be added/removed without touching the graph |
+| **Claude as optional async judge** | Keeps the LLM judge off the critical response path; eval can be added/removed without touching the graph |
 | **Budget-aware graph** | Hard wall-clock deadline enforced via `researchBudget.ts`; conditional edges bypass remaining nodes gracefully instead of timing out mid-flight |
 | **Pluggable storage** | Abstract repository pattern allows SQLite → Postgres → Turso swap without touching business logic |
 | **Progressive auth** | Single-user deployments require no configuration; auth activates as users are added |


### PR DESCRIPTION
## Summary

Audited `README.md`, `docs/`, and `.env.example` against the actual code (`services/api/src/`). The docs here are generally thorough and well kept; this PR fixes the discrepancies that survived a direct code check, most notably one that affects a real feature:

- **LLM-judge vendor mismatch**: README, `docs/architecture/ARCHITECTURE.md` (table + two Mermaid diagrams), `.env.example`, and `docs/ROADMAP.md` all described the async eval judge as using **Mistral**. It doesn't — `services/api/src/eval/judgeWorker.ts` sends the `MISTRAL_API_KEY` value to **Anthropic's API** (`api.anthropic.com`, model `claude-opus-4-8`) as the `x-api-key` header. `app.ts` even has a `// Use Mistral API key` comment next to a parameter literally named `anthropicApiKey`. Docs now describe the real, current behavior. **Worth a follow-up code change** to rename the env var to `ANTHROPIC_API_KEY` — left untouched here since renaming a config var is a behavior/deployment change, not a docs fix, and is called out as a note in `ARCHITECTURE.md` and `ROADMAP.md`.
- Fixed `RESEARCH_TIMEOUT_MS`'s documented default (25s → actual 45s) in `ARCHITECTURE.md` and `.env.example`.
- Fixed a stale "Node.js 20+" line in `ARCHITECTURE.md` (root `package.json` requires 22+, matching the README).
- Marked two `docs/ROADMAP.md` "Pending Deepening" items as done — `bandGroupInference.ts` and `httpClient.ts` already exist with their own tests; the roadmap was describing tech debt that had already been paid down.
- Fixed a corrupted `CORS_ORIGIN` value in `.env.example` (`http://localhost:1420TGyj81krmIKW9SdgD9rZOHZiETPnUitX` → `http://localhost:1420`) — worth checking this wasn't an accidentally-committed credential fragment, since it's now in git history.
- Documented two real, undocumented env vars that gate security-relevant behavior: `EVAL_DASHBOARD_PASSWORD` (Basic Auth on the eval dashboard) and `REGISTRATION_OPEN` (toggles public registration).
- Added the missing `2026-06-13-stop-retry-buttons-design.md` spec to `docs/README.md`'s historical docs index.

**Not addressed here (flagged, not fixed — out of scope for a docs PR):** a stray Python scaffold (`main.py`, `pyproject.toml`) and duplicate npm/pnpm lockfiles exist at the repo root with no documentation of their purpose; `tauri.conf.json` declares version `0.2.0` while the rest of the monorepo is on `0.4.0-alpha.0`; and the root `npm run dev`/`start` scripts point at `services/api/src/server.js`, which doesn't exist (the real file is `server.ts` — works today only because of `tsx`'s resolution behavior).

## Test plan

- [ ] Render the updated Mermaid diagrams to confirm they're valid
- [ ] Confirm `.env.example` still parses/works for a fresh `cp .env.example .env`
- [ ] Decide whether to follow up on the `MISTRAL_API_KEY` → `ANTHROPIC_API_KEY` rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RgYsAfpZDbMBw6rpp8RFm

---
_Generated by [Claude Code](https://claude.ai/code/session_014RgYsAfpZDbMBw6rpp8RFm)_