### PR TITLE
Weekly maintenance (2026-07-08): fix quick-xml CVEs, extend Dependabot/audit coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,18 @@ updates:
 
   # Rust (Tauri desktop app)
   - package-ecosystem: "cargo"
-    directory: "/apps/desktop"
+    directory: "/apps/desktop/src-tauri"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    target-branch: "staging"
+    labels:
+      - "dependencies"
+
+  # Python tooling (uv-managed, project root)
+  - package-ecosystem: "uv"
+    directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/workflows/weekly-audit.yml
+++ b/.github/workflows/weekly-audit.yml
@@ -38,10 +38,58 @@ jobs:
             echo "has_vulns=$([ $STATUS -ne 0 ] && echo true || echo false)"
           } >> "$GITHUB_OUTPUT"
 
+      # ── Python audit (pip-audit via uv, project root) ───────────────────────
+      - uses: astral-sh/setup-uv@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Export locked requirements for audit
+        run: uv export --format requirements-txt --no-hashes --output-file /tmp/reqs.txt
+
+      - name: Python security audit (pip-audit)
+        id: py
+        run: |
+          pip install pip-audit --quiet
+          REPORT=$(pip-audit -r /tmp/reqs.txt --format columns 2>&1) || true
+          STATUS=$?
+          {
+            echo "report<<PYEOF"
+            echo "$REPORT"
+            echo "PYEOF"
+            echo "has_vulns=$([ $STATUS -ne 0 ] && echo true || echo false)"
+          } >> "$GITHUB_OUTPUT"
+
+      # ── Rust audit (cargo-audit, Tauri desktop app) ─────────────────────────
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo-audit binary
+        uses: actions/cache@v6
+        with:
+          path: ~/.cargo/bin/cargo-audit
+          key: cargo-audit-${{ runner.os }}
+
+      - name: Install cargo-audit
+        run: which cargo-audit 2>/dev/null || cargo install cargo-audit --locked
+
+      - name: Rust security audit (cargo-audit)
+        id: cargo
+        run: |
+          REPORT=$(cargo audit --file apps/desktop/src-tauri/Cargo.lock 2>&1) || true
+          STATUS=$?
+          {
+            echo "report<<CARGOEOF"
+            echo "$REPORT"
+            echo "CARGOEOF"
+            echo "has_vulns=$([ $STATUS -ne 0 ] && echo true || echo false)"
+          } >> "$GITHUB_OUTPUT"
+
       # ── Step summary ──────────────────────────────────────────────────────
       - name: Write step summary
         env:
           NPM_REPORT: ${{ steps.npm.outputs.report }}
+          PY_REPORT: ${{ steps.py.outputs.report }}
+          CARGO_REPORT: ${{ steps.cargo.outputs.report }}
         run: |
           {
             echo "## Weekly Security Audit — $(date -I)"
@@ -50,14 +98,29 @@ jobs:
             echo '```'
             printf '%s\n' "$NPM_REPORT"
             echo '```'
+            echo ""
+            echo "### Python (pip-audit)"
+            echo '```'
+            printf '%s\n' "$PY_REPORT"
+            echo '```'
+            echo ""
+            echo "### Rust (cargo-audit, apps/desktop)"
+            echo '```'
+            printf '%s\n' "$CARGO_REPORT"
+            echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
       # ── Create / update issue if vulnerabilities found ────────────────────
       - name: Open or update security issue
-        if: steps.npm.outputs.has_vulns == 'true'
+        if: >
+          steps.npm.outputs.has_vulns == 'true' ||
+          steps.py.outputs.has_vulns == 'true' ||
+          steps.cargo.outputs.has_vulns == 'true'
         uses: actions/github-script@v7
         env:
           NPM_REPORT: ${{ steps.npm.outputs.report }}
+          PY_REPORT: ${{ steps.py.outputs.report }}
+          CARGO_REPORT: ${{ steps.cargo.outputs.report }}
         with:
           script: |
             const date = new Date().toISOString().slice(0, 10);
@@ -71,6 +134,16 @@ jobs:
               `### npm audit (all workspaces)`,
               `\`\`\``,
               process.env.NPM_REPORT || '(no output)',
+              `\`\`\``,
+              ``,
+              `### Python (pip-audit)`,
+              `\`\`\``,
+              process.env.PY_REPORT || '(no output)',
+              `\`\`\``,
+              ``,
+              `### Rust (cargo-audit, apps/desktop)`,
+              `\`\`\``,
+              process.env.CARGO_REPORT || '(no output)',
               `\`\`\``,
               ``,
               `_Review and address **high** or **critical** severity items._`,

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2544,9 +2544,9 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
@@ -2690,9 +2690,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -4,6 +4,129 @@ Weekly dependency and health checks for the Bandsearch application.
 
 ---
 
+## 2026-07-08
+
+### Checks performed
+- Rebased working branch onto latest `origin/staging`
+- Baseline: `npm run lint`, `npm run typecheck`, `npm run test` at root (covers `apps/desktop`,
+  `services/api`, `services/eval`, `shared/schemas` via `--workspaces --if-present`) — all green
+  (678 tests total: 222 desktop, 423 api, 16 eval, 17 schemas)
+- Rust: `cargo check`, `cargo test` (`apps/desktop/src-tauri`) — both green (20/20 unit tests)
+- Dependency audit across every ecosystem present:
+  - npm (root + all workspaces) — `npm outdated`, `npm audit`
+  - Python (root `pyproject.toml` / `uv.lock`) — `uv export` + `pip-audit`
+  - Rust (`apps/desktop/src-tauri/Cargo.toml`) — `cargo outdated`-equivalent via `cargo update`
+    dry-run + `cargo audit` (installed `cargo-audit` v0.22.2; not previously present)
+- Re-checked `.github/workflows/ci.yml` Node version vs root `package.json` `engines` — still
+  both Node 22, no regression since the 2026-06-10 fix
+- Reviewed the `.github/dependabot.yml` / `.github/workflows/weekly-audit.yml` added in the
+  2026-06-24 cycle for ecosystem-coverage gaps now that a Python project (`pyproject.toml`,
+  `uv.lock`) exists at the repo root
+
+### Fixes applied
+
+- **Security (high, applied despite being a transitive major bump) — `quick-xml` advisories
+  RUSTSEC-2026-0194 / RUSTSEC-2026-0195** — `cargo audit` flagged two high-severity (CVSS 7.5)
+  issues in `quick-xml 0.39.2` (quadratic run time checking duplicate attribute names; unbounded
+  namespace-declaration allocation enabling memory-exhaustion DoS), pulled in transitively via
+  `plist 1.9.0` (used by `tauri-utils` for Info.plist generation). `plist 1.9.0` pins
+  `quick-xml = "^0.39.2"`, so the fix required bumping `plist` itself — `quick-xml` alone could not
+  be moved to the patched `0.41.0` without it. Ran `cargo update -p plist --precise 1.10.0`, which
+  resolved `quick-xml` to `0.41.0` (fixed). This stayed inside `tauri`'s own declared range
+  (`plist = "^1"`), so no `Cargo.toml` edits were needed — only `Cargo.lock` changed. Re-ran
+  `cargo audit` (0 vulnerabilities, down from 2 high) and re-verified `cargo check` + `cargo test`
+  (20/20) green after the bump. Flagging this prominently per policy: **the underlying `plist`
+  bump (1.9.0 → 1.10.0) was a deeper transitive resolution than a routine patch, applied solely
+  because it was the only path to the security fix.**
+
+- **Dependabot ecosystem gap** — `.github/dependabot.yml` (added 2026-06-24) had no entry for the
+  Python/`uv` project at the repo root. Added a `package-ecosystem: "uv"` entry (directory `/`,
+  weekly, target `staging`).
+- **Dependabot Cargo path bug** — the existing Cargo entry pointed `directory: "/apps/desktop"`,
+  but `Cargo.toml` actually lives at `apps/desktop/src-tauri/Cargo.toml`. Dependabot would never
+  have found a manifest at the configured path. Fixed to `/apps/desktop/src-tauri`.
+- **Weekly audit workflow gap** — `.github/workflows/weekly-audit.yml` (added 2026-06-24) only ran
+  `npm audit`. Extended it to also run `pip-audit` (via `astral-sh/setup-uv` + `uv export`) and
+  `cargo-audit` (against `apps/desktop/src-tauri/Cargo.lock`), modeled on the sibling
+  `eikrad/Job-Tracker` repo's workflow. All three tools now report into the same step summary and
+  the same `security-audit`-labelled issue on high/critical findings.
+
+### Dependency status
+
+**Root workspace (`package.json`)** — patch/minor bumps applied via `npm update`:
+
+| Package | Before | After | Status |
+|---|---|---|---|
+| `tsx` | `4.22.4` | `4.23.0` | Updated (within `^4.22.4` range) |
+| `typescript-eslint` | `8.62.1` | `8.63.0` | Updated (within `^8.62.1` range) |
+| `@types/node` | `25.9.4` | `25.9.5` | Updated (patch only — `26.x` major pending, see below) |
+| `typescript` | `6.0.3` | `6.0.3` | Current within range — `7.x` major pending, see below |
+| `eslint`, `@playwright/test`, `husky`, `globals`, `@eslint/js`, `@types/express` | — | — | No newer versions in range this cycle |
+
+**`apps/desktop` (npm)** — no outdated packages (`@tauri-apps/api`, `@tauri-apps/cli`, `react`,
+`react-dom`, `esbuild` all current).
+
+**`services/api` (npm)** — no outdated packages (`express`, `zod`, `@langchain/langgraph`,
+`@langchain/google-genai`, `better-sqlite3`, `dotenv`, `jsonwebtoken`, `bcryptjs`, `helmet`,
+`express-rate-limit`, `@libsql/client`, `pg` all current).
+
+**`services/eval`, `shared/schemas` (npm)** — no dependencies outdated.
+
+**Root Python (`pyproject.toml` / `uv.lock`)** — `dependencies = []`; no runtime dependencies are
+declared, so there is nothing to bump. `ruff`/`black` are used as lint tools outside the `uv.lock`
+dependency graph (invoked directly or via `.venv` if present).
+
+**`apps/desktop/src-tauri` (Cargo)**:
+
+| Crate | Before | After | Status |
+|---|---|---|---|
+| `plist` (transitive, via `tauri-utils`) | `1.9.0` | `1.10.0` | Updated — security fix, see above |
+| `quick-xml` (transitive, via `plist`) | `0.39.2` | `0.41.0` | Updated — security fix, see above |
+| `tauri`, `tauri-build`, `tauri-plugin-opener`, `serde`/`serde_json`, `dirs` | `2` / `1` / `5` | unchanged | Current within broad `Cargo.toml` constraints |
+
+### Security audit results
+
+| Ecosystem | Tool | Result |
+|---|---|---|
+| npm (all workspaces) | `npm audit` | 0 vulnerabilities |
+| Python (root) | `pip-audit` (via `uv export --format requirements-txt`) | 0 vulnerabilities (no declared runtime deps) |
+| Rust (`apps/desktop/src-tauri`) | `cargo audit` | 2 high (RUSTSEC-2026-0194, RUSTSEC-2026-0195) → **fixed this cycle**; 0 vulnerabilities remaining; 18 informational "unmaintained/unsound" warnings remain (see Notes) |
+
+### Major upgrades pending (not applied — flagged for manual review)
+
+| Package | Current | Latest | Notes |
+|---|---|---|---|
+| `typescript` | `6.0.3` | `7.0.2` | Major rewrite; needs a dedicated compatibility pass across all 4 npm workspaces before adopting |
+| `@types/node` | `25.9.5` | `26.1.1` | Type-defs major tracks a newer Node line than the `engines: ">=22"` floor; low risk but flagged per policy |
+
+### Notes
+
+- **Dual lock files (still open, re-flagged again this cycle):** `package-lock.json` (root) and
+  `pnpm-lock.yaml` both still exist. `pnpm-lock.yaml` was last committed 2026-05-31 — over five
+  weeks stale relative to this cycle — while `package-lock.json` is updated by every npm-based
+  maintenance cycle (most recently this one). Concretely, `pnpm-lock.yaml` still resolves
+  `@types/node` to `25.9.1` and `typescript-eslint`'s peer to `^8.60.0`, while `package-lock.json`
+  now resolves `25.9.5` / `8.63.0` respectively — the drift is real and growing. CI uses `npm ci`
+  (reads only `package-lock.json`), so anyone installing locally with `pnpm install` is working
+  against materially different resolved versions than CI. Not resolved this cycle — removing
+  either lock file is a call for the repo owner, not an agent.
+- **Rust `cargo-audit` "unmaintained"/"unsound" warnings (informational, not blocking):** 18
+  warnings remain after the `quick-xml` fix above — the GTK3 bindings pulled in by `tauri`'s Linux
+  backend (`gtk`, `gtk-sys`, `gdk*`, `atk*`, RUSTSEC-2024-041x series), plus `proc-macro-error`,
+  the `unic-*` crates, and unsound-but-currently-unfixed advisories in `anyhow` and `glib`. These
+  are all transitive through `tauri` itself and have no independently-updatable fix from this
+  repo (no newer non-vulnerable version exists yet upstream); they will keep surfacing via
+  Dependabot's Cargo advisories and the weekly audit workflow until `tauri` moves off GTK3
+  bindings. Not a regression — `cargo audit` exits 0 (warnings only, no vulnerabilities).
+- **Local dev environment requirement:** `apps/desktop/src-tauri/binaries/node-<target-triple>` is
+  a tracked symlink (see `apps/desktop/src-tauri/binaries/README`) that must resolve to a real
+  `node` binary for `cargo check`/`cargo test`/`cargo build` to succeed (Tauri's `externalBin`
+  resource check runs even for `cargo check`). `apps/desktop/test/tauri-config.test.js` skips
+  gracefully with the exact remediation command when the resolved binary is missing — this is
+  expected in environments without a matching system `node` path and is not a code defect.
+
+---
+
 ## 2026-06-24
 
 ### Checks performed

--- a/package-lock.json
+++ b/package-lock.json
@@ -791,9 +791,9 @@
       "license": "MIT"
     },
     "node_modules/@langchain/langgraph-sdk/node_modules/p-queue": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.0.tgz",
-      "integrity": "sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.1.tgz",
+      "integrity": "sha512-POWdiIPmsUPGwb4FeQ4OBg46aqmcInSWe45CKDsGHiOBiVQM9chqfQTuqhuTzcg2Vz9faTI65at0KkVyVEiCHw==",
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "^5.0.4",
@@ -1286,9 +1286,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
-      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.2.tgz",
+      "integrity": "sha512-d3KvEXBSo/lOAMc2u6fkyDHBvetBHeqD7wm/AcXfLpSOQwlmG9D/aQ0SFswVjv05p7ullQS7Mjohj6/VdbZuTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1312,9 +1312,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
-      "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
@@ -1365,17 +1365,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.1.tgz",
-      "integrity": "sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.63.0.tgz",
+      "integrity": "sha512-rvwSgqT+DHpWdzfSzPatRLm02a0GlESt++9iy3hLCDY4BgkaLcl8LBi9Yh7XGFBpwcBE/K3024QuXWTpbz4FfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.62.1",
-        "@typescript-eslint/type-utils": "8.62.1",
-        "@typescript-eslint/utils": "8.62.1",
-        "@typescript-eslint/visitor-keys": "8.62.1",
+        "@typescript-eslint/scope-manager": "8.63.0",
+        "@typescript-eslint/type-utils": "8.63.0",
+        "@typescript-eslint/utils": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -1388,7 +1388,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.62.1",
+        "@typescript-eslint/parser": "^8.63.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -1404,16 +1404,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.1.tgz",
-      "integrity": "sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.63.0.tgz",
+      "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.62.1",
-        "@typescript-eslint/types": "8.62.1",
-        "@typescript-eslint/typescript-estree": "8.62.1",
-        "@typescript-eslint/visitor-keys": "8.62.1",
+        "@typescript-eslint/scope-manager": "8.63.0",
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1429,14 +1429,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.1.tgz",
-      "integrity": "sha512-yQ3RgY5RkSBpsNS1Bx/JQEcA24FOSdfGktoyprAr5u18390UQdtVcfnEv4nIrIshNnavlVyZBKxQwT1fIAE6cg==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.63.0.tgz",
+      "integrity": "sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.62.1",
-        "@typescript-eslint/types": "^8.62.1",
+        "@typescript-eslint/tsconfig-utils": "^8.63.0",
+        "@typescript-eslint/types": "^8.63.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1451,14 +1451,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.1.tgz",
-      "integrity": "sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.63.0.tgz",
+      "integrity": "sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.62.1",
-        "@typescript-eslint/visitor-keys": "8.62.1"
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1469,9 +1469,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.1.tgz",
-      "integrity": "sha512-xadytJqX9vJVQ2fdQjkcIVigwaOJNWkpjdLt6cEQ+xPnrI1fkp+/jZE/I97k9KUjqtpd25i0HeyZf3T6dutv2g==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.63.0.tgz",
+      "integrity": "sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1486,15 +1486,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.1.tgz",
-      "integrity": "sha512-aXM5xlqXiTxPibXB93cLAURfT3rlizf7uMXISCXy66Isr/9hISJx3yDsKl0L7lKa51b8JpFuNKby0/O0pEm9jg==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.63.0.tgz",
+      "integrity": "sha512-Nzzh/OGxVCOjObjaj1CQF2RUasyYy2Jfuh+zZ3PjLzG2fYRriAiZLib9UKtO+CpQAS3YHiAS+ckZDclwqI1TPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.62.1",
-        "@typescript-eslint/typescript-estree": "8.62.1",
-        "@typescript-eslint/utils": "8.62.1",
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0",
+        "@typescript-eslint/utils": "8.63.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -1511,9 +1511,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.1.tgz",
-      "integrity": "sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.63.0.tgz",
+      "integrity": "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1525,16 +1525,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.1.tgz",
-      "integrity": "sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.63.0.tgz",
+      "integrity": "sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.62.1",
-        "@typescript-eslint/tsconfig-utils": "8.62.1",
-        "@typescript-eslint/types": "8.62.1",
-        "@typescript-eslint/visitor-keys": "8.62.1",
+        "@typescript-eslint/project-service": "8.63.0",
+        "@typescript-eslint/tsconfig-utils": "8.63.0",
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -1553,16 +1553,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.1.tgz",
-      "integrity": "sha512-sHtbPfuKNZCG+ih8SyjjucqRntSVmp8XgL5u6o9mAhiSn8ds5o/M/XdM0abweme2Tln3szOstOrZ9OXitvPh0g==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.63.0.tgz",
+      "integrity": "sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.62.1",
-        "@typescript-eslint/types": "8.62.1",
-        "@typescript-eslint/typescript-estree": "8.62.1"
+        "@typescript-eslint/scope-manager": "8.63.0",
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1577,13 +1577,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.1.tgz",
-      "integrity": "sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.63.0.tgz",
+      "integrity": "sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/types": "8.63.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -1608,9 +1608,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1721,20 +1721,20 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -1744,10 +1744,23 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2618,9 +2631,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -2678,9 +2691,9 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -2812,9 +2825,9 @@
       "license": "ISC"
     },
     "node_modules/js-base64": {
-      "version": "3.7.8",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
-      "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.8.0.tgz",
+      "integrity": "sha512-65kvbemyZhj+ExQt1PEFyBEjL5vAHysu1lJdW1AwhhChkO8ZBPizYk/m9GVrpbS2Je1hF+UYZ+6KywqtZV8mHw==",
       "license": "BSD-3-Clause"
     },
     "node_modules/js-tiktoken": {
@@ -2902,9 +2915,9 @@
       }
     },
     "node_modules/langsmith": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.7.2.tgz",
-      "integrity": "sha512-3dZUwQDJluxi2ih5eIygFODtlrQKrs3Tua0Ck3l+DAUkSGFkB1Dc0JPqkGbqiVSN+TQDElnkev/ydAOAz6jndA==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.8.0.tgz",
+      "integrity": "sha512-edm/zZ1jMQRt0GzavmJ0YPIsqKkXetffIpmR29li8P0SoZ0MI/xKk/tIAkPnxHCybmzJesIQf5CT7eLQCqv3kA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3176,9 +3189,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "3.92.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
-      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
@@ -3463,9 +3476,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3623,12 +3636,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -3638,12 +3652,16 @@
       }
     },
     "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/raw-body": {
@@ -3674,15 +3692,6 @@
       },
       "bin": {
         "rc": "cli.js"
-      }
-    },
-    "node_modules/rc/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/react": {
@@ -3769,9 +3778,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3855,14 +3864,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -3998,10 +4007,19 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
       "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
@@ -4066,9 +4084,9 @@
       }
     },
     "node_modules/tsx": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
-      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
+      "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.28.0"
@@ -4168,16 +4186,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.1.tgz",
-      "integrity": "sha512-vymnnM5g0AKQDSAyfP12nMIBvgwgA42syg74kkuZ4x1VuTzwQKwc5h9rGxeShCjny5o+zWAb6OEoz7XLgrIkIw==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.63.0.tgz",
+      "integrity": "sha512-xgwXyzG4sK9ALkBxbyGkTMMOS+imnW65iPhxCQMK83KhxyoDNW7l+IDqEf9vMdoUidHpOoS967RCq4eMiTexwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.62.1",
-        "@typescript-eslint/parser": "8.62.1",
-        "@typescript-eslint/typescript-estree": "8.62.1",
-        "@typescript-eslint/utils": "8.62.1"
+        "@typescript-eslint/eslint-plugin": "8.63.0",
+        "@typescript-eslint/parser": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0",
+        "@typescript-eslint/utils": "8.63.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"


### PR DESCRIPTION
## Summary

Weekly maintenance cycle. Full details in `docs/maintenance.md` (new 2026-07-08 entry at top).

### Security fix (high severity, applied)
- `cargo audit` flagged two **high-severity (CVSS 7.5)** advisories in `quick-xml 0.39.2`:
  - RUSTSEC-2026-0194 — quadratic run time when checking a start tag for duplicate attribute names
  - RUSTSEC-2026-0195 — unbounded namespace-declaration allocation → memory-exhaustion DoS
- `quick-xml` is pulled in transitively via `plist 1.9.0` (used by `tauri-utils` for Info.plist generation). `plist 1.9.0` pins `quick-xml = "^0.39.2"`, so `quick-xml` alone couldn't be bumped to the patched `0.41.0` — `plist` itself had to move.
- Fixed via `cargo update -p plist --precise 1.10.0`, which resolves `quick-xml` to `0.41.0`. This stays within `tauri`'s own declared range (`plist = "^1"`), so **no `Cargo.toml` changes were needed**, only `Cargo.lock`. Re-ran `cargo audit`: **0 vulnerabilities** (down from 2 high). Re-verified `cargo check` and `cargo test` (20/20 passing) green after the bump.
- Flagging prominently per policy since this required a deeper transitive bump than a routine patch, applied specifically because of the vulnerability severity.

### Dependabot / weekly-audit infra gaps fixed
The 2026-06-24 cycle added `.github/dependabot.yml` and `.github/workflows/weekly-audit.yml`, but both had gaps once a Python project (`pyproject.toml` + `uv.lock`) existed at the repo root:
- **`dependabot.yml`**: added a `package-ecosystem: "uv"` entry (root, weekly, target `staging`) for the Python project. Also fixed a pre-existing bug — the Cargo entry pointed `directory: "/apps/desktop"`, but `Cargo.toml` actually lives at `apps/desktop/src-tauri/Cargo.toml`, so Dependabot would never have found a manifest there. Fixed to `/apps/desktop/src-tauri`.
- **`weekly-audit.yml`**: previously only ran `npm audit`. Extended to also run `pip-audit` (via `astral-sh/setup-uv` + `uv export`) and `cargo-audit` (against `apps/desktop/src-tauri/Cargo.lock`), modeled on `eikrad/Job-Tracker`'s workflow. All three now feed the same step summary and the same `security-audit`-labelled issue on high/critical findings.

### Safe (patch/minor) dependency updates applied — `npm update`, root `package.json`
| Package | Before | After |
|---|---|---|
| `tsx` | `4.22.4` | `4.23.0` |
| `typescript-eslint` | `8.62.1` | `8.63.0` |
| `@types/node` | `25.9.4` | `25.9.5` |

No outdated packages in `apps/desktop`, `services/api`, `services/eval`, or `shared/schemas` this cycle. Python has no runtime deps declared (`dependencies = []` in `pyproject.toml`), so nothing to bump there.

### Major upgrades — flagged, NOT applied (pending manual review)
| Package | Current | Latest | Why held back |
|---|---|---|---|
| `typescript` | `6.0.3` | `7.0.2` | Major rewrite; needs a dedicated compatibility pass across all 4 npm workspaces |
| `@types/node` | `25.9.5` | `26.1.1` | Type-defs major ahead of the `engines: ">=22"` floor; low risk but flagged per policy |

### Security audit results
| Ecosystem | Tool | Result |
|---|---|---|
| npm (all workspaces) | `npm audit` | 0 vulnerabilities |
| Python (root) | `pip-audit` (via `uv export`) | 0 vulnerabilities (no declared runtime deps) |
| Rust (`apps/desktop/src-tauri`) | `cargo audit` | 2 high → **fixed this cycle**; 0 vulnerabilities remaining; 18 informational unmaintained/unsound warnings remain (transitive GTK3 bindings inside `tauri` itself, no independently-updatable fix — see `docs/maintenance.md` Notes) |

### CI drift check
Re-checked `.github/workflows/ci.yml` Node version (`22`) against root `package.json` `engines: ">=22"` — still consistent, no regression since the 2026-06-10 fix.

### Known pre-existing issue — re-flagged, not resolved
**Dual lock files:** `package-lock.json` (root) and `pnpm-lock.yaml` both still exist. `pnpm-lock.yaml` was last committed 2026-05-31 (now 5+ weeks stale) while `package-lock.json` is updated by this cycle. Concretely, `pnpm-lock.yaml` still resolves `@types/node` to `25.9.1` and `typescript-eslint` peer to `^8.60.0`, vs. `25.9.5` / `8.63.0` in `package-lock.json` after this PR — the drift is real and growing. CI uses `npm ci` (reads only `package-lock.json`), so local `pnpm install` usage would diverge from CI. **Not resolved in this PR** — deleting either lockfile is a call for the repo owner, not an agent.

## Test plan
- [x] `npm run lint` — green (root + all workspaces + Python ruff/black)
- [x] `npm run typecheck` — green (desktop, api, schemas)
- [x] `npm run test` — green, 678/678 tests passing (222 desktop, 423 api, 16 eval, 17 schemas)
- [x] `cargo check` (apps/desktop/src-tauri) — green
- [x] `cargo test` (apps/desktop/src-tauri) — green, 20/20 unit tests
- [x] `cargo audit` — 0 vulnerabilities (was 2 high, fixed)
- [x] `npm audit` — 0 vulnerabilities
- [x] `pip-audit` — 0 vulnerabilities
- [x] Husky pre-commit hook (runs full `npm run ci`) passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DC8ABenFx3bqsePZipbhVq

---
_Generated by [Claude Code](https://claude.ai/code/session_01DC8ABenFx3bqsePZipbhVq)_