### PR TITLE
docs: fix stale contributor workflow, deploy notes, and architecture gaps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,13 +4,12 @@ Thanks for contributing to Bandsearch.
 
 ## Workflow
 
-1. Create a branch from `main`.
+1. Create a branch from `staging` (not `main` — PRs must target `staging`; `main` only updates by merging `staging` in after validation, and this is enforced by CI).
 2. Keep changes scoped to one phase or concern.
-3. Run CI checks locally:
-   - `npm run lint`
-   - `npm run typecheck`
-   - `npm run test`
-4. Open a pull request with:
+3. Run checks locally before committing (the same checks also run automatically via a husky pre-commit hook):
+   - `npm run ci` — lint + typecheck + test in one command
+   - `npm run test:e2e` — Playwright end-to-end smoke tests, if you touched user-facing flows
+4. Open a pull request against `staging` with:
    - clear summary
    - test evidence
    - follow-up tasks (if any)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -142,7 +142,7 @@ The existing migration script targets local SQLite and Postgres. It needs to als
 Deploy the Express API as a Render Web Service.
 
 **Action:**
-1. Add a `render.yaml` to the repo root declaring the web service: `type: web`, build command `npm install --prefix services/api`, start command `npm start --prefix services/api`, health check path `/`, and `region: frankfurt`. ✓ Done
+1. Add a `render.yaml` to the repo root declaring the web service: `type: web`, build command `npm install`, start command `npm start` (run at the repo root — the root `package.json` scripts delegate to the API workspace), health check path `/`, and `region: frankfurt`. ✓ Done
 2. Configure required environment variables in `render.yaml` (non-secret keys) and via the Render dashboard (secrets): `GEMINI_API_KEY`, `BRAVE_API_KEY`, `TURSO_DATABASE_URL`, `TURSO_AUTH_TOKEN`, `JWT_SECRET`, `PREFERENCE_STORE=turso`. Render injects `PORT` automatically. ✓ Done
 3. Verify the `start` script in `services/api/package.json` works — it already uses `tsx`; confirm the installed Node.js version on Render matches local (specify `engines.node` in `package.json` if needed). ✓ Done (`"start": "tsx src/server.ts"` added; `engines.node: ">=22"` added to root `package.json`; `tsx` moved to `services/api` production deps)
 4. Connect the GitHub repository to Render; auto-deploy triggers on push to `main`. — manual step via Render dashboard

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -39,6 +39,8 @@ bandsearch-app/
 └── tests/               — End-to-end tests (Playwright)
 ```
 
+Root `main.py` / `pyproject.toml` / `uv.lock` are an unused placeholder scaffold, kept only so `npm run lint:py` (ruff + black) has something to check — they're not part of the running application.
+
 ---
 
 ## System topology
@@ -87,6 +89,21 @@ The API is an Express.js application structured as follows:
 | `routes/registerBandsearchRoutes.ts` | Mounts all route handlers (auth, recommendations, preferences, sessions, artist search) |
 | `recommendationPipeline.ts` | Lifecycle manager for the research graph — exposes `recommend()` and `whenReady()` |
 | `agent/research/researchService.ts` | Thin wrapper around `invokeResearchGraph()` with error handling |
+
+### REST routes
+
+Registered by `routes/registerBandsearchRoutes.ts` (auth, recommendations, sessions, preferences, artist search) and `eval/evalRoutes.ts` (eval dashboard and data).
+
+| Group | Routes |
+|-------|--------|
+| Health / version | `GET /health`, `GET /version` |
+| Auth | `GET /auth/status`, `POST /auth/register`, `POST /auth/login`, `POST /auth/reset-password` |
+| Recommendations | `POST /recommendations` |
+| Sessions | `POST /sessions`, `GET /sessions`, `GET /sessions/:id`, `POST /sessions/:id/messages` |
+| Artists | `GET /artists/search`, `GET /artists/image` |
+| Preferences | `GET/POST /preferences`, `PATCH/DELETE /preferences/:id`, `GET /preferences/context`, `GET /preferences/export`, `POST /preferences/import`, `POST /preferences/turso/test` |
+| Preference groups | `GET/POST /preferences/groups`, `POST /preferences/groups/auto`, `PATCH/DELETE /preferences/groups/:id`, `POST /preferences/groups/:id/artists`, `DELETE /preferences/groups/:id/artists/:savedBandId` |
+| Eval | `GET /eval/events`, `GET /eval/metrics`, `POST /eval/baseline`, `GET /eval/baselines`, `POST /eval/feedback`, `GET /eval/dashboard` (Basic Auth if `EVAL_DASHBOARD_PASSWORD` is set) |
 
 ---
 
@@ -204,6 +221,10 @@ flowchart LR
 
 Eval data is stored in `recommendation_events`, `llm_eval_scores`, `recommendation_feedback`, and `eval_baselines` tables.
 
+A dashboard at `GET /eval/dashboard` visualizes this data; set `EVAL_DASHBOARD_ENABLED=true` to expose it, and `EVAL_DASHBOARD_PASSWORD` to gate it behind HTTP Basic Auth (recommended whenever the API is publicly reachable — see `.env.example`).
+
+The `services/eval` workspace holds the golden dataset (`golden-set.json`), judge calibration data, and `run-golden.ts`/`run-calibration.ts` runners for evaluating the pipeline offline, outside of live traffic.
+
 > **Note on `MISTRAL_API_KEY`:** despite the variable name, the judge worker (`eval/judgeWorker.ts`) sends this key to Anthropic's API (`claude-opus-4-8`), not Mistral's. The naming is a known mismatch in the code — worth renaming to `ANTHROPIC_API_KEY` in a follow-up, but documented here as the current, actual behavior.
 
 ---
@@ -249,7 +270,7 @@ Three-tier progressive auth — determined by the number of registered users at 
 
 - **Stack:** Tauri (Rust shell) + React (TypeScript)
 - **API process:** spawned as a Node.js child process; production builds use a Tauri-bundled Node sidecar
-- **Screens:** Welcome, Settings, Chat (responsive layout via `matchMedia`, breakpoint 767 px)
+- **Screens:** Welcome, Login, Register, Reset Password, Settings, Chat, Saved Artists (responsive layout via `matchMedia`, breakpoint 767 px), plus supporting UI like `FeedbackReactionBar` (Tier 3 eval feedback) and `ObscurityTargetPicker`
 - **API key storage:** OS config directory (`~/.config/bandsearch/config.json` on Linux)
 
 ---


### PR DESCRIPTION
## Summary

Documentation audit and cleanup — no code changes. Compared `README.md`, `docs/`, `CONTRIBUTING.md`, and `AGENTS.md` against the actual code (`services/api`, `apps/desktop`, `render.yaml`, `.github/workflows/`) and fixed the drift found.

- `CONTRIBUTING.md` told contributors to branch from and PR against `main`, and didn't mention `npm run ci`, the husky pre-commit hook, or Playwright e2e tests — all of which contradicted the actual staging-first workflow that `protect-main.yml` enforces
- `docs/ROADMAP.md`'s description of `render.yaml` didn't match the shipped file (no `--prefix services/api` flags; build/start actually run at the repo root)
- `docs/architecture/ARCHITECTURE.md`'s desktop "Screens" list was stale — missing Login, Register, Reset Password, and Saved Artists, all of which are shipped
- Added docs coverage for things that existed in code but had no write-up: the `/eval/dashboard` Basic Auth gate (`EVAL_DASHBOARD_PASSWORD`), the `services/eval` offline eval workspace, the actual REST route surface (auth/sessions/preferences/eval), and a note on the unused root Python placeholder scaffold so it doesn't confuse new readers

`README.md` was reviewed and found to already accurately reflect the current state, so it was left unchanged.

## Test plan

- [x] Docs-only change — no code touched
- [ ] Reviewer: skim the `ARCHITECTURE.md` diff for accuracy against `services/api/src/routes/registerBandsearchRoutes.ts` and `services/api/src/eval/evalRoutes.ts`


---
_Generated by [Claude Code](https://claude.ai/code/session_01PNF3ZDiYqqSmYDUKzm75Zu)_