### PR TITLE
docs: sync ARCHITECTURE.md with current research graph and desktop routes

### DIFF
--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -102,6 +102,7 @@ The core recommendation logic is a LangGraph state machine defined in `agent/res
 | `preferenceContext` | `string` | Formatted saved-band context |
 | `messages` | `ChatMessage[]` | Conversation history |
 | `mode` | `RecommendationMode` | `fresh` or `preference-aware` |
+| `obscurityTarget` | `string` (optional) | User-selected obscurity target (`Cult Following` / `Underground` / `Truly Obscure`); filters candidates before ranking |
 | `searchPlan` | `SearchPlan` | Planner output (anchor artists, style signals, queries) |
 | `braveHits` | `SearchHitInput[]` | Raw web search results |
 | `extractedCandidates` | `ExtractedCandidate[]` | Band names extracted from snippets |
@@ -120,7 +121,8 @@ flowchart TD
     brave_initial --> extract["extract\nGemini — extracts band names\nfrom search snippets"]
     extract --> verify["verify\nMusicBrainz — adds mbid,\ngenres, tags, URL relations"]
     verify --> reflect_if_needed["reflect_if_needed\nReflection Subgraph\n(runs if verified count < target)"]
-    reflect_if_needed --> rank["rank\nGemini — final ranked list\nwith evidence-grounded why text"]
+    reflect_if_needed --> enrich_lastfm["enrich_lastfm\nLast.fm (optional) — similar-artist\nmatches + listener counts"]
+    enrich_lastfm --> rank["rank\nGemini — final ranked list\nwith evidence-grounded why text"]
     rank --> END(["END"])
 ```
 
@@ -131,6 +133,7 @@ flowchart TD
 | `extract` | Gemini | Identifies band names from snippets; filters out anchor artists |
 | `verify` | MusicBrainz | Looks up each candidate; adds `mbid`, genres, tags, URL relations |
 | `reflect_if_needed` | Reflection Subgraph | Conditionally runs extra searches when verified count < target |
+| `enrich_lastfm` | Last.fm (optional) | Adds similar-artist matches (vs. anchor artists) and listener counts to verified candidates; no-op if `LASTFM_API_KEY` unset |
 | `rank` | Gemini | Produces final ranked list with evidence-grounded `why` text and optional prose reply |
 
 ### Reflection subgraph (`reflectionSubgraph.ts`)
@@ -168,7 +171,7 @@ A shared `ResearchBudget` instance tracks wall-clock time against `RESEARCH_TIME
 | **Brave Search API** | `brave_initial`, `search` | Web discovery for niche and underground artists |
 | **Google Gemini** (`@langchain/google-genai`) | `plan`, `extract`, `assess`, `rank` | All structured reasoning and text generation |
 | **MusicBrainz** | `verify`, `verify_r` | Artist metadata verification (mbid, genres, tags, URL relations) |
-| **Wikidata + Last.fm** | `/artists/image` endpoint | Artist image resolution with Last.fm fallback |
+| **Wikidata + Last.fm** | `/artists/image` endpoint, `enrich_lastfm` node | Artist image resolution with Last.fm fallback; similar-artist matches and listener counts feeding the ranker |
 | **Anthropic Claude** (optional, key supplied via `MISTRAL_API_KEY` — see note below) | Eval layer | Async LLM-as-Judge scoring — never on the critical path |
 | **LangSmith** (optional) | Graph invocation | Distributed tracing for the LangGraph pipeline |
 
@@ -249,7 +252,7 @@ Three-tier progressive auth — determined by the number of registered users at 
 
 - **Stack:** Tauri (Rust shell) + React (TypeScript)
 - **API process:** spawned as a Node.js child process; production builds use a Tauri-bundled Node sidecar
-- **Screens:** Welcome, Settings, Chat (responsive layout via `matchMedia`, breakpoint 767 px)
+- **Screens:** Welcome, Login, Register, Reset Password, Chat, Saved Artists, Settings (responsive layout via `matchMedia`, breakpoint 767 px)
 - **API key storage:** OS config directory (`~/.config/bandsearch/config.json` on Linux)
 
 ---


### PR DESCRIPTION
## Summary

Audited `README.md` and everything under `docs/` (README.md, ROADMAP.md, maintenance.md, architecture/, design/, adr/, agents/) against the actual code. Documentation here is unusually well maintained — most claims (tech stack, quick start, auth, storage, deployment, ROADMAP's open "Polish" items) checked out cleanly. One file had drifted: `docs/architecture/ARCHITECTURE.md`.

- **Main graph diagram + node table** — added the missing `enrich_lastfm` node (Last.fm similar-artist matching + listener counts, wired between `reflect_if_needed` and `rank` in `services/api/src/agent/research/researchGraph.ts`). It was already shown correctly in the top-level README diagram but missing from ARCHITECTURE.md's more detailed diagram/table.
- **External Integrations table** — added `enrich_lastfm` to the Wikidata + Last.fm row's "Used in" column.
- **Graph state table** — added the `obscurityTarget` field (present in `RESEARCH_SCHEMA`, used by `filterCandidatesByObscurity` in the `rank` node) which was missing despite being shipped.
- **Desktop client "Screens" line** — expanded from `Welcome, Settings, Chat` to the actual 7 routes (`Welcome, Login, Register, Reset Password, Chat, Saved Artists, Settings`) per `apps/desktop/src/createHashRouter.ts`.

Everything else — README's tech stack/quick start/auth/storage/deployment sections and mermaid diagram, ROADMAP's open items, maintenance.md's dependency log, ADRs and design docs — was verified accurate and left untouched.

## Test plan
- [x] Cross-checked graph diagram/tables against `services/api/src/agent/research/researchGraph.ts`
- [x] Cross-checked desktop screens against `apps/desktop/src/createHashRouter.ts`
- Docs-only change, no code behavior affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZQ2y57PdLoW4oQW2PpuQg)_