### PR TITLE
chore: weekly maintenance 2026-07-22 — dependency updates + security audit

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2544,9 +2544,9 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
@@ -2690,9 +2690,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -4,6 +4,148 @@ Weekly dependency and health checks for the Bandsearch application.
 
 ---
 
+## 2026-07-22
+
+### Backlog warning — read this first
+
+Four PRs from prior maintenance cycles are still open and unmerged against `staging`,
+all created 2026-07-08 or 2026-07-15:
+
+| PR | Date | Contents |
+|---|---|---|
+| [#92](https://github.com/eikrad/bandsearch-app/pull/92) | 2026-07-08 | Maintenance: quick-xml/plist CVE fix (`cargo update -p plist --precise 1.10.0`), Dependabot `uv` ecosystem entry + directory-path bugfix, `weekly-audit.yml` extended with `pip-audit`/`cargo-audit` |
+| [#93](https://github.com/eikrad/bandsearch-app/pull/93) | 2026-07-08 | Docs: `CONTRIBUTING.md`, `ROADMAP.md`, `ARCHITECTURE.md` drift fixes |
+| [#94](https://github.com/eikrad/bandsearch-app/pull/94) | 2026-07-15 | Maintenance: same quick-xml/plist CVE fix (re-applied independently since #92 hadn't landed), npm patch/minor bumps |
+| [#95](https://github.com/eikrad/bandsearch-app/pull/95) | 2026-07-15 | Docs: `ARCHITECTURE.md` sync (`enrich_lastfm` node, `obscurityTarget`, desktop routes) |
+
+**This PR does not touch any of them.** Every cycle that lands on top of `staging` without
+these merging first repeats the same CVE fix and grows lockfile churn. Recommend the repo
+owner review and either merge or close this backlog before/alongside this cycle's PR —
+in particular, verify directly whether #92's and #94's `plist`/`quick-xml` fix is
+independently duplicated here (it is — see below) before merging more than one of them.
+
+### Checks performed
+- `git fetch origin staging` + reset working branch to `staging` tip (`617d586`) before starting
+- Verified directly (not assumed) whether PR #92's `plist`/`quick-xml` CVE fix was already on
+  `staging`: it was **not** — `origin/staging`'s `apps/desktop/src-tauri/Cargo.lock` still
+  resolved `plist 1.9.0` / `quick-xml 0.39.2` at the start of this cycle
+- Full baseline (lint, typecheck, test, desktop build) before and after changes
+- `npm outdated` per workspace (root, `apps/desktop`, `services/api`, `services/eval`, `shared/schemas`)
+- `npm audit` before and after
+- `cargo audit` — **ran successfully this cycle** (prior cycle's `phf_macros`/linker issue did
+  not reproduce here; `cargo-audit 0.22.2` installed and ran cleanly)
+- Confirmed Python (`pyproject.toml` `dependencies = []`, `uv.lock` has no third-party entries) —
+  still nothing to audit or update
+- Re-checked `.github/workflows/ci.yml` Node version (`22`) against `engines: ">=22"` — still consistent
+
+### Security fix (high severity, applied)
+
+`cargo audit` confirmed the same two advisories flagged by #92/#94, still present on `staging`:
+- **RUSTSEC-2026-0194** — quadratic run time when checking a start tag for duplicate attribute names (CVSS 7.5, high)
+- **RUSTSEC-2026-0195** — unbounded namespace-declaration allocation in `NsReader` → memory-exhaustion DoS (CVSS 7.5, high)
+
+Both in `quick-xml 0.39.2`, pulled transitively via `plist 1.9.0` (used by `tauri-utils` for
+Info.plist generation). Fixed the same way as the pending PRs:
+
+```
+cargo update -p plist --precise 1.10.0
+```
+
+`plist 1.10.0` requires `quick-xml ^0.41.0`, resolving the vulnerable version. Stays within
+`tauri`'s declared range — only `Cargo.lock` changed (4 lines: `plist` + `quick-xml` version/checksum).
+Re-ran `cargo audit` after: **0 vulnerabilities** (down from 2 high). 18 informational
+unmaintained/unsound warnings remain (transitive GTK3 bindings inside `tauri` itself — `atk`,
+`gdk`, `gtk`, `gtk-sys` family, plus `proc-macro-error`, `unic-*`, `anyhow` `Error::downcast_mut`
+unsoundness, `glib` iterator unsoundness). None have an independently-updatable fix; same set
+noted in the 2026-07-08 cycle.
+
+**Note for the repo owner:** this is the *third* time this exact fix has been produced
+independently (#92, #94, and now this cycle) because none of the PRs carrying it have merged.
+Merging any one of #92/#94 (or this PR) resolves it for `staging`; the other two become no-ops
+that should be closed rather than merged.
+
+### Safe (patch/minor) dependency updates applied — `npm update`
+
+| Workspace | Package | Before | After |
+|---|---|---|---|
+| root | `eslint` | `10.6.0` | `10.7.0` |
+| root | `tsx` | `4.22.4` | `4.23.1` |
+| root | `typescript-eslint` | `8.62.1` | `8.65.0` |
+| root | `@types/node` | `25.9.4` | `25.9.5` |
+| `apps/desktop` | `react` | `19.2.7` | `19.2.8` |
+| `apps/desktop` | `react-dom` | `19.2.7` | `19.2.8` |
+| `services/api` | `@langchain/langgraph` | `1.4.7` | `1.4.8` |
+| `services/api` | `express-rate-limit` | `8.5.2` | `8.6.0` |
+| `services/api` | `helmet` | `8.2.0` | `8.3.0` |
+
+`services/eval` and `shared/schemas` had nothing outdated this cycle. All bumps were within
+existing `^` constraints — no `package.json` range edits needed, only `package-lock.json`
+(190 insertions / 171 deletions). This `npm update` also incidentally cleared the two
+vulnerabilities `npm audit` reported at baseline (`body-parser` DoS, `brace-expansion` DoS —
+both transitive, fixed by the patch-level resolution bump, no direct action needed).
+
+Rust: only the security-driven `plist` bump above was applied. `cargo update --dry-run`
+shows a broader set of patch/minor bumps available across the `tauri` 2.x family (`tauri
+2.11.0→2.11.5`, `tauri-build 2.6.0→2.6.3`, `tokio 1.52.1→1.53.1`, `wry`, `zbus`, `time`, etc.)
+— none tied to an advisory, so left unapplied this cycle to keep the security PR's diff
+minimal and reviewable; flagging as available for a future cycle or the repo owner's discretion.
+
+### Major upgrades — flagged, NOT applied (pending manual review)
+
+| Package | Current | Latest | Why held back |
+|---|---|---|---|
+| `typescript` (root) | `6.0.3` | `7.0.2` | Major rewrite; flagged every cycle since 2026-07-08; needs a dedicated compatibility pass with `typescript-eslint` across all 4 npm workspaces |
+| `@types/node` (root) | `25.9.5` | `26.1.1` | Type-defs major ahead of the `engines: ">=22"` floor / CI's pinned Node 22 — low risk but flagged per policy |
+| `better-sqlite3` (`services/api`) | `12.11.1` | `13.0.1` | New major this cycle (not flagged before); native-addon rebuild risk, needs its own verification pass before bumping |
+
+No other workspace has a pending major (`@tauri-apps/*`, `express`, `zod`, `@langchain/*`, `pg`, etc. all current).
+
+### Security audit results
+
+| Ecosystem | Tool | Result |
+|---|---|---|
+| npm (all workspaces) | `npm audit` | 2 (1 low, 1 high) at baseline → **0 after `npm update`** |
+| Python (root) | manual (`dependencies = []`, `uv.lock` has no third-party entries) | Nothing to audit — confirmed |
+| Rust (`apps/desktop/src-tauri`) | `cargo audit` | 2 high (RUSTSEC-2026-0194, -0195) → **fixed this cycle**; 0 vulnerabilities remaining; 18 informational unmaintained/unsound warnings unchanged (see above) |
+
+### Known issue — dual lock files (not fixed, flagging again)
+
+`package-lock.json` (root) and `pnpm-lock.yaml` still coexist. `pnpm-lock.yaml` was last
+committed 2026-05-31 — now **~7.5 weeks stale** and growing every cycle it isn't touched or
+removed, while `package-lock.json` was updated again by this cycle's `npm update`. CI uses
+`npm ci` (reads only `package-lock.json`), so local `pnpm install` usage would diverge from
+CI. **Not resolved in this PR** — deleting either lockfile is a call for the repo owner, not an agent.
+
+### Sandbox/toolchain notes
+
+- `cargo audit` ran cleanly this cycle (installed `cargo-audit 0.22.2` from source without
+  issue) — the `phf_macros`/linker problem noted in the 2026-07-15 cycle did not reproduce here.
+- `cargo check` / `cargo build` (`apps/desktop/src-tauri`) still **cannot complete** in this
+  sandbox: `gdk-sys` (transitive GTK3 dependency via `tauri`) requires `gdk-3.0.pc` via
+  `pkg-config`, and only GTK3 runtime libraries are present here, not the `-dev`/pkg-config
+  files. Attempted `apt-get install libgtk-3-dev libwebkit2gtk-4.1-dev` — partially blocked by
+  404s from the mirror for several transitive packages (`xdg-desktop-portal`, `webkit2gtk`,
+  `gdk-pixbuf`, etc.), so the dev headers could not be installed. This is an environment
+  limitation, not a code issue — same category of gap noted in the 2026-07-15 cycle (missing
+  self-contained linker) though the specific cause differs this time. Recommend a real
+  `cargo check`/`cargo test` pass on a machine with full GTK3 dev packages (or in CI, which
+  currently has no `cargo` step) before merging any Rust dependency change, including this one.
+- JS/TS side fully verifiable: `npm run lint`, `npm run typecheck`, `npm run test`, and
+  `npm --workspace @bandsearch/desktop run build` all ran to completion in this sandbox.
+
+### Post-change verification
+
+Re-ran the full baseline suite after all changes — identical to pre-change baseline:
+- `npm run lint` — clean (root + all workspaces + Python ruff/black)
+- `npm run typecheck` — clean (desktop, api, schemas)
+- `npm run test` — **678/678** (677 pass + 1 pre-existing skip, 0 fail) — desktop 222
+  (221 pass, 1 skip), api 423, eval 16, schemas 17 — same counts as baseline
+- `apps/desktop` `npm run build` — succeeds
+- `cargo audit` (`apps/desktop/src-tauri`) — 0 vulnerabilities after the `plist` bump
+- `cargo check`/`cargo test` — not verifiable in this sandbox (GTK3 dev headers missing, see above)
+
+---
+
 ## 2026-06-24
 
 ### Checks performed

--- a/package-lock.json
+++ b/package-lock.json
@@ -484,9 +484,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
-      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -687,9 +687,9 @@
       }
     },
     "node_modules/@langchain/core": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.2.1.tgz",
-      "integrity": "sha512-NNG/cC5FGuHDOAP56h0ddp8Rfk8p+othWzEK5RV9JIG6RvnF5vGa5r0AEGtKfQieed7s1kC42GuIzVOBvMBL/g==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.2.3.tgz",
+      "integrity": "sha512-F+L5SsciykwDl7eDxacnhDTcWe1IF6jetzfkvI5PPfq6ogWHO7xcjU90SGh/3lqbbS0tgun+qF01KIqxawrCsA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -721,13 +721,13 @@
       }
     },
     "node_modules/@langchain/langgraph": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.4.7.tgz",
-      "integrity": "sha512-2tcyf3QGC7v89kqSxMCtRvzg/3L/4yHtOaWC49A8KieCciWJs7LGaxHoPB6QRxXyUgyR+Zg9Q1ss/XJIE+JuSQ==",
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.4.8.tgz",
+      "integrity": "sha512-DN1Np1XefdBEbp1qBKlt39cwoL743AAGpR5Ipja0gY2YbWvsoQnOTIrjnj/orSAhaUYsdTKS8VSWdFzsHZo6Ig==",
       "license": "MIT",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.3",
-        "@langchain/langgraph-sdk": "~1.9.25",
+        "@langchain/langgraph-sdk": "~1.9.26",
         "@langchain/protocol": "^0.0.18",
         "@standard-schema/spec": "1.1.0"
       },
@@ -752,9 +752,9 @@
       }
     },
     "node_modules/@langchain/langgraph-sdk": {
-      "version": "1.9.25",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.25.tgz",
-      "integrity": "sha512-mRKW8zyQUaHox+HirRFMRrPqOvNbQI3xeXDt6kkk4PbBg77V92bsO1WzUVNrmJ81zCkvxyOrWSK8D6ioCj0a8A==",
+      "version": "1.9.28",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.28.tgz",
+      "integrity": "sha512-4j3XuM0PvtmAbL8mPfBS99ez3+ytRfgbOpAR/nOeaejTRF3Q9dNw2QnaGLGng8wLPtGLoSj+SYgUOVxy9Bv9vg==",
       "license": "MIT",
       "dependencies": {
         "@langchain/protocol": "^0.0.18",
@@ -791,9 +791,9 @@
       "license": "MIT"
     },
     "node_modules/@langchain/langgraph-sdk/node_modules/p-queue": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.0.tgz",
-      "integrity": "sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==",
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.3.tgz",
+      "integrity": "sha512-NXAOdnEe5FsZJfT4oK84lE1Y5cFFdWlRuOo5tww8DyNMxyRXwn39fIkUtNLKppcPC+UYU/bXujNCUGDv01y7CA==",
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "^5.0.4",
@@ -1286,9 +1286,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
-      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.2.tgz",
+      "integrity": "sha512-d3KvEXBSo/lOAMc2u6fkyDHBvetBHeqD7wm/AcXfLpSOQwlmG9D/aQ0SFswVjv05p7ullQS7Mjohj6/VdbZuTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1312,9 +1312,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
-      "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
@@ -1365,17 +1365,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.1.tgz",
-      "integrity": "sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.62.1",
-        "@typescript-eslint/type-utils": "8.62.1",
-        "@typescript-eslint/utils": "8.62.1",
-        "@typescript-eslint/visitor-keys": "8.62.1",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/type-utils": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -1388,15 +1388,15 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.62.1",
+        "@typescript-eslint/parser": "^8.65.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1404,16 +1404,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.1.tgz",
-      "integrity": "sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.62.1",
-        "@typescript-eslint/types": "8.62.1",
-        "@typescript-eslint/typescript-estree": "8.62.1",
-        "@typescript-eslint/visitor-keys": "8.62.1",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1429,14 +1429,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.1.tgz",
-      "integrity": "sha512-yQ3RgY5RkSBpsNS1Bx/JQEcA24FOSdfGktoyprAr5u18390UQdtVcfnEv4nIrIshNnavlVyZBKxQwT1fIAE6cg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.62.1",
-        "@typescript-eslint/types": "^8.62.1",
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1451,14 +1451,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.1.tgz",
-      "integrity": "sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.62.1",
-        "@typescript-eslint/visitor-keys": "8.62.1"
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1469,9 +1469,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.1.tgz",
-      "integrity": "sha512-xadytJqX9vJVQ2fdQjkcIVigwaOJNWkpjdLt6cEQ+xPnrI1fkp+/jZE/I97k9KUjqtpd25i0HeyZf3T6dutv2g==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1486,15 +1486,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.1.tgz",
-      "integrity": "sha512-aXM5xlqXiTxPibXB93cLAURfT3rlizf7uMXISCXy66Isr/9hISJx3yDsKl0L7lKa51b8JpFuNKby0/O0pEm9jg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.62.1",
-        "@typescript-eslint/typescript-estree": "8.62.1",
-        "@typescript-eslint/utils": "8.62.1",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -1511,9 +1511,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.1.tgz",
-      "integrity": "sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1525,16 +1525,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.1.tgz",
-      "integrity": "sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.62.1",
-        "@typescript-eslint/tsconfig-utils": "8.62.1",
-        "@typescript-eslint/types": "8.62.1",
-        "@typescript-eslint/visitor-keys": "8.62.1",
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -1553,16 +1553,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.1.tgz",
-      "integrity": "sha512-sHtbPfuKNZCG+ih8SyjjucqRntSVmp8XgL5u6o9mAhiSn8ds5o/M/XdM0abweme2Tln3szOstOrZ9OXitvPh0g==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.62.1",
-        "@typescript-eslint/types": "8.62.1",
-        "@typescript-eslint/typescript-estree": "8.62.1"
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1577,13 +1577,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.1.tgz",
-      "integrity": "sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/types": "8.65.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -1608,9 +1608,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1721,20 +1721,20 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -1744,10 +1744,23 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2119,9 +2132,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
-      "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
+      "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -2342,11 +2355,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
-      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
       "license": "MIT",
       "dependencies": {
+        "debug": "^4.4.3",
         "ip-address": "^10.2.0"
       },
       "engines": {
@@ -2470,9 +2484,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
+      "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -2618,9 +2632,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -2630,9 +2644,9 @@
       }
     },
     "node_modules/helmet": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.2.0.tgz",
-      "integrity": "sha512-DRgTIUgnWcJ62KyarxxziuqYxKGnR6Rgg19BlbucN/dpmJbl1XOit6qvoOX0ZT+HhWe5OUVhU/a1zpGyc1xA0Q==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.3.0.tgz",
+      "integrity": "sha512-Qgpiaws3Sm30Av8Eah6sjMCZZwjlBu+E68rhpCWBshY1lb09HtLwj5GviX0OyQIn+ulUS0iX0AxN5n3tLZzz1w==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -2678,9 +2692,9 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -2812,9 +2826,9 @@
       "license": "ISC"
     },
     "node_modules/js-base64": {
-      "version": "3.7.8",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
-      "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.9.1.tgz",
+      "integrity": "sha512-U73qptcvf/HIOauFOmqT3a0mDUp0MYlfd15oqoe9kqZt5XhiXVb+HG09sLvI9PQ9tZIBFS4nlErai8zbWazP0g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/js-tiktoken": {
@@ -2902,9 +2916,9 @@
       }
     },
     "node_modules/langsmith": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.7.2.tgz",
-      "integrity": "sha512-3dZUwQDJluxi2ih5eIygFODtlrQKrs3Tua0Ck3l+DAUkSGFkB1Dc0JPqkGbqiVSN+TQDElnkev/ydAOAz6jndA==",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.8.4.tgz",
+      "integrity": "sha512-e2zdhPUV/mLwVv+Gde/0gLGnCOE/zvZ3gGNh/rvkzrxsDz7qgUT4CJVUmJE2GwQ1A3FPtWKzy08oo//VV1nBFA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3176,9 +3190,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "3.92.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
-      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
@@ -3463,9 +3477,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3623,12 +3637,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -3638,12 +3653,16 @@
       }
     },
     "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/raw-body": {
@@ -3676,34 +3695,25 @@
         "rc": "cli.js"
       }
     },
-    "node_modules/rc/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.7"
+        "react": "^19.2.8"
       }
     },
     "node_modules/readable-stream": {
@@ -3769,9 +3779,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3855,14 +3865,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -3998,10 +4008,19 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
       "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
@@ -4066,9 +4085,9 @@
       }
     },
     "node_modules/tsx": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
-      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.28.0"
@@ -4168,16 +4187,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.1.tgz",
-      "integrity": "sha512-vymnnM5g0AKQDSAyfP12nMIBvgwgA42syg74kkuZ4x1VuTzwQKwc5h9rGxeShCjny5o+zWAb6OEoz7XLgrIkIw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
+      "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.62.1",
-        "@typescript-eslint/parser": "8.62.1",
-        "@typescript-eslint/typescript-estree": "8.62.1",
-        "@typescript-eslint/utils": "8.62.1"
+        "@typescript-eslint/eslint-plugin": "8.65.0",
+        "@typescript-eslint/parser": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4264,9 +4283,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
## ⚠️ Backlog warning — please read before merging

Four PRs from prior maintenance cycles are still open and unmerged against `staging`, all created 2026-07-08 or 2026-07-15:

| PR | Date | Contents |
|---|---|---|
| [#92](https://github.com/eikrad/bandsearch-app/pull/92) | 2026-07-08 | Maintenance: quick-xml/plist CVE fix, Dependabot `uv` ecosystem + directory bugfix, `weekly-audit.yml` extended with `pip-audit`/`cargo-audit` |
| [#93](https://github.com/eikrad/bandsearch-app/pull/93) | 2026-07-08 | Docs: `CONTRIBUTING.md`, `ROADMAP.md`, `ARCHITECTURE.md` drift fixes |
| [#94](https://github.com/eikrad/bandsearch-app/pull/94) | 2026-07-15 | Maintenance: same quick-xml/plist CVE fix (re-applied independently since #92 hadn't landed), npm patch/minor bumps |
| [#95](https://github.com/eikrad/bandsearch-app/pull/95) | 2026-07-15 | Docs: `ARCHITECTURE.md` sync (`enrich_lastfm` node, `obscurityTarget`, desktop routes) |

**This PR does not touch, merge, or close any of them** (out of scope per instructions). But this is now the **third independent time** the same quick-xml CVE fix has been produced (#92, #94, and this PR) because none of the backlog PRs have merged — every additional cycle on top of unmerged `staging` repeats work and grows lockfile/doc drift. **Recommend reviewing and merging one of #92/#94 (they're near-duplicates) and closing the other, merging #93 and #95 (docs, independent), and merging this PR** — in whichever order makes sense, but the pile-up itself is the main finding of this cycle.

I verified this directly rather than assuming: fetched `origin/staging`'s actual tip and checked `apps/desktop/src-tauri/Cargo.lock` — it still resolved `plist 1.9.0` / `quick-xml 0.39.2` (vulnerable), confirming #92's fix has **not** landed on `staging`.

## Baseline (before changes, on `staging` tip `617d586`)
- `npm ci` — clean install
- `npm run lint` / `npm run typecheck` — clean, all workspaces
- `npm run test` — **678/678** (677 pass + 1 pre-existing skip, 0 fail): desktop 222, api 423, eval 16, schemas 17 — matches prior cycles' baseline
- `npm --workspace @bandsearch/desktop run build` — succeeds
- `npm audit` — 2 vulnerabilities (1 low: body-parser, 1 high: brace-expansion), both transitive
- `cargo audit` (`apps/desktop/src-tauri`) — **ran successfully this cycle** (prior cycle's `phf_macros`/linker issue did not reproduce here) — found 2 high (RUSTSEC-2026-0194, RUSTSEC-2026-0195, both quick-xml 0.39.2, CVSS 7.5) + 18 informational unmaintained/unsound warnings (GTK3 bindings, `anyhow`, `glib` — no independent fix, same set as 2026-07-08 cycle)
- Python (`dependencies = []`, `uv.lock` no third-party entries) — nothing to audit, confirmed

## Security fix (high severity, applied)
Same fix as #92/#94: `cargo update -p plist --precise 1.10.0` → bumps `plist 1.9.0→1.10.0`, transitively `quick-xml 0.39.2→0.41.0`. Only `Cargo.lock` changed (4 lines). `cargo audit` after: **0 vulnerabilities** (18 informational warnings unchanged, no independent fix available).

## Dependency updates (`npm update`, safe patch/minor)
| Workspace | Package | Before | After |
|---|---|---|---|
| root | `eslint` | 10.6.0 | 10.7.0 |
| root | `tsx` | 4.22.4 | 4.23.1 |
| root | `typescript-eslint` | 8.62.1 | 8.65.0 |
| root | `@types/node` | 25.9.4 | 25.9.5 |
| apps/desktop | `react` / `react-dom` | 19.2.7 | 19.2.8 |
| services/api | `@langchain/langgraph` | 1.4.7 | 1.4.8 |
| services/api | `express-rate-limit` | 8.5.2 | 8.6.0 |
| services/api | `helmet` | 8.2.0 | 8.3.0 |

No `package.json` edits needed (all within `^` ranges) — only `package-lock.json` (190+/171-). This incidentally cleared both baseline `npm audit` findings. `services/eval` and `shared/schemas`: nothing outdated. Rust: only the security-driven `plist` bump applied; `cargo update --dry-run` shows further non-advisory patch/minor bumps available across the `tauri` 2.x family — left unapplied to keep this PR's diff minimal, flagged for a future cycle.

## Majors — flagged, NOT applied
| Package | Current | Latest | Why held back |
|---|---|---|---|
| `typescript` | 6.0.3 | 7.0.2 | Major rewrite, flagged every cycle since 07-08; needs dedicated compat pass with `typescript-eslint` |
| `@types/node` | 25.9.5 | 26.1.1 | Ahead of `engines: ">=22"` floor; low risk but flagged per policy |
| `better-sqlite3` (services/api) | 12.11.1 | 13.0.1 | **New this cycle** — native-addon rebuild risk, needs its own verification pass |

## Security audit summary
| Ecosystem | Tool | Result |
|---|---|---|
| npm (all workspaces) | `npm audit` | 2 (1 low, 1 high) → **0 after update** |
| Python | manual (`dependencies = []`) | Nothing to audit |
| Rust | `cargo audit` | 2 high → **fixed**; 18 informational warnings unchanged |

## Known issue — dual lock files (not fixed, flagging again)
`package-lock.json` + `pnpm-lock.yaml` still coexist. `pnpm-lock.yaml` last committed 2026-05-31 — now **~7.5 weeks stale** and growing every cycle. CI uses `npm ci` (`package-lock.json` only). **Not resolved here** — deleting either lockfile is the repo owner's call, not an agent's.

## Sandbox/toolchain limitations
- `cargo audit` worked cleanly this cycle (installed `cargo-audit 0.22.2` from source).
- `cargo check`/`cargo build` (`apps/desktop/src-tauri`) still **cannot complete** here: `gdk-sys` needs `gdk-3.0.pc` via pkg-config; only GTK3 runtime libs are present, not `-dev`/pkg-config files. Attempted `apt-get install libgtk-3-dev libwebkit2gtk-4.1-dev` — partially blocked by mirror 404s on several transitive packages. Environment limitation, not a code issue (same category as the 2026-07-15 cycle's linker gap, different root cause). CI has no `cargo` step currently — recommend a real `cargo check`/`cargo test` pass outside this sandbox before merging any Rust change, including this one.
- JS/TS side fully verified in-sandbox: lint, typecheck, test, and desktop build all completed.

## Post-change verification
Re-ran full baseline after all changes — identical to pre-change baseline: lint clean, typecheck clean, **678/678 tests** (same breakdown), desktop build succeeds, `cargo audit` 0 vulnerabilities. Husky pre-commit hook (`npm run ci`) passed on the commit.

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` (678/678, all workspaces)
- [x] `apps/desktop` `npm run build`
- [ ] `cargo check`/`cargo test` — not verifiable in this sandbox (GTK3 dev headers missing); recommend running on a full dev machine or in CI before merge
- [x] `npm audit` — 0 vulnerabilities after update
- [x] `cargo audit` — 0 vulnerabilities after `plist` bump
- [x] Python — confirmed nothing to audit
- [x] Husky pre-commit hook passed

https://claude.ai/code/session_015xKVM5JwrUSFgdq5JGcoFd


---
_Generated by [Claude Code](https://claude.ai/code/session_015xKVM5JwrUSFgdq5JGcoFd)_