### PR TITLE
chore: weekly maintenance 2026-07-29 — dependency updates + security audit

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -4,6 +4,155 @@ Weekly dependency and health checks for the Bandsearch application.
 
 ---
 
+## 2026-07-29
+
+### ⚠️ Backlog status correction — please read first
+
+The working branch for this cycle was seeded assuming four prior maintenance PRs (#92, #93, #94,
+#95) were still open/unmerged against `staging`, stacked behind the still-open #96. **That is no
+longer true.** Checked directly via `mcp__github__pull_request_read` before doing anything else:
+
+| PR | State | Merged at |
+|---|---|---|
+| #92 | **merged** | 2026-07-22T19:21:42Z |
+| #93 | **merged** | 2026-07-22T19:23:05Z |
+| #94 | **merged** | 2026-07-23T12:09:57Z |
+| #95 | **merged** | 2026-07-23T12:18:43Z |
+| #96 | still **open** | — (2026-07-22 cycle, not yet merged) |
+
+All four were merged in the ~17 hours immediately after #96 was opened (visible in `git log`
+on `staging` as explicit `Merge pull request #92/#93/#94/#95` commits ancestors of the tip this
+cycle branched from). **#96 is now the only outstanding maintenance PR** — recommend reviewing
+and merging (or superseding with this one, since the two overlap) rather than treating this as a
+5-PR pile-up. Flagging the correction prominently since propagating a stale "4 unmerged PRs"
+claim forward would have been actively misleading in this PR body.
+
+One consequence: because #94 (2026-07-15 cycle) already landed its `plist`/`quick-xml` fix on
+`staging`, **this cycle's baseline `Cargo.lock` already resolves `plist 1.10.0` / `quick-xml
+0.41.0`** (verified directly — `grep -A1 'name = "plist"' Cargo.lock`). No RUSTSEC-2026-0194/0195
+re-fix was needed this time; see Security audit results below. This is a good sign the backlog
+clearing actually stopped the fix from being reproduced a 4th time.
+
+### Checks performed
+- Reset working branch to `staging`'s current tip (`dee443f`, the merge of #95) before starting —
+  branch had been seeded from an older `main`/`staging` snapshot.
+- Verified `#92`–`#96` state directly via the GitHub API rather than assuming (see correction
+  above) before writing anything into this log or the PR body.
+- Baseline: `npm ci`, `npm run lint`, `npm run typecheck`, `npm run test`, `npm --workspace
+  @bandsearch/desktop run build`, `npm audit` — all before any changes.
+- `npm outdated` per workspace (root, `apps/desktop`, `services/api`, `services/eval`,
+  `shared/schemas`).
+- Rust: `cargo update --dry-run` (`apps/desktop/src-tauri`) to see what's available; installed
+  `cargo-audit` (0.22.2, from source — first attempt hit a transient parallel-build process
+  error, succeeded on retry with `-j 2`); ran `cargo audit`.
+- Confirmed root `pyproject.toml` still declares `dependencies = []` — nothing to audit for
+  Python. `uv.lock` still resolves only the virtual root package.
+- Checked recent CI runs on `staging` via the Actions API — see CI health below.
+- Re-ran the full baseline suite after applying updates.
+
+### CI health (staging)
+Most recent recorded runs on `staging` (`CI` and `Protect main`) are still both `completed` /
+`success` from run `27791377341` / `27791377321`, 2026-06-18 — identical to what the last two
+cycles reported. No newer runs are showing against `staging` in the Actions API despite #92–#96
+merging since; not investigated further as it doesn't block this cycle (this branch's own CI run
+is checked separately after pushing, per the usual gate before opening a PR).
+
+### Fixes applied
+
+- **Security (Rust) — none needed this cycle.** `cargo audit` against the current `staging` tip
+  found **0 vulnerabilities** — only the same 18 informational "unmaintained"/"unsound" warnings
+  seen in every prior cycle (GTK3 `gtk-rs` bindings RUSTSEC-2024-041x series, `proc-macro-error`,
+  the `unic-*` crates, `anyhow` RUSTSEC-2026-0190, `glib` RUSTSEC-2024-0429 — all transitive
+  through `tauri`, no independently-updatable fix upstream). The RUSTSEC-2026-0194/0195
+  `quick-xml` advisories that required a fresh `cargo update -p plist --precise 1.10.0` in each of
+  the last three cycles (#92, #94, this branch's would-be #97) are **already resolved** on this
+  tip via #94 — confirmed `plist 1.10.0` / `quick-xml 0.41.0` in `Cargo.lock` before touching
+  anything. Nothing to fix, so nothing was changed here.
+
+- **Safe npm updates** — `npm update` at root picked up in-range patch/minor bumps across
+  workspaces (no `package.json` range changes required):
+
+  | Workspace | Package | Before | After |
+  |---|---|---|---|
+  | root | `eslint` | 10.6.0 | 10.8.0 |
+  | root | `@playwright/test` (+ `playwright`, `playwright-core`) | 1.61.1 | 1.62.0 |
+  | root | `typescript-eslint` (+ `@typescript-eslint/*` sub-packages) | 8.63.0 | 8.65.0 |
+  | root | `tsx` | 4.23.0 | 4.23.1 |
+  | root | `globals` | 17.7.0 | 17.8.0 |
+  | `apps/desktop` | `react` / `react-dom` | 19.2.7 | 19.2.8 |
+  | `services/api` | `@langchain/langgraph` (+ `@langchain/core`, `@langchain/langgraph-sdk`) | 1.4.7 | 1.4.8 |
+  | `services/api` | `express-rate-limit` | 8.5.2 | 8.6.1 |
+  | `services/api` | `helmet` | 8.2.0 | 8.3.0 |
+  | (transitive, security) | `brace-expansion` | 5.0.7 | 5.0.8 |
+  | (transitive, various) | `@eslint-community/eslint-utils`, `acorn`, `flatted`, `ip-address`, `js-base64`, `langsmith`, `media-typer`, `minimatch`, `ws`, `p-queue` | — | patch bumps only |
+
+  `services/eval` and `shared/schemas` had nothing outdated within range this cycle. The
+  `brace-expansion` bump (transitive, pulled in by `eslint`'s dependency tree) incidentally
+  cleared the one `npm audit` finding present at baseline (see below) — no direct action needed
+  beyond the routine `npm update`.
+
+### Rust dependency audit (informational, not applied)
+`cargo update --dry-run` in `apps/desktop/src-tauri` shows ~114 available non-advisory patch/minor
+bumps across the `tauri` 2.x family and its transitive graph (e.g. `tauri 2.11.0 → 2.11.5`,
+`tauri-utils 2.9.0 → 2.9.3`, `wry 0.55.0 → 0.55.1`, `tao 0.35.0 → 0.35.3`, `serde 1.0.228 →
+1.0.229`, `tokio 1.52.1 → 1.53.1`, plus many more). None are security-driven (`cargo audit` is
+clean), so — consistent with the #96 precedent of keeping security-driven PRs minimal — none were
+applied this cycle. Flagging as available for a future dedicated Rust-dependency-refresh cycle.
+
+### Security audit results
+
+| Check | Result |
+|---|---|
+| `npm audit` (before) | 1 high (`brace-expansion` <=5.0.7 — DoS via unbounded expansion length) |
+| `npm audit` (after) | 0 vulnerabilities |
+| `pip-audit` (manual, scoped) | Clean — `dependencies = []`, no Python runtime deps to audit |
+| `cargo audit` | **0 vulnerabilities** (ran successfully this cycle, `cargo-audit 0.22.2`); 18 informational unmaintained/unsound warnings, same set as every prior cycle, no independent fix available |
+
+### Rust build/test — fully verifiable this cycle (with a caveat)
+Unlike the last three cycles, `cargo check`/`cargo test` were verifiable end-to-end here:
+- **GTK3 dev headers are present in this sandbox this cycle** (`libgtk-3-dev` /
+  `libwebkit2gtk-4.1-dev` were already installed; `pkg-config --exists gdk-3.0` succeeds,
+  `gdk-3.0.pc` resolves at `3.24.41`) — the mirror-blocked/missing-pkgconfig issue noted in the
+  2026-07-22 cycle did not reproduce.
+- Hitting `cargo check` cold still failed, but on a **different, already-documented** issue: the
+  tracked `apps/desktop/src-tauri/binaries/node-x86_64-unknown-linux-gnu` sidecar symlink points
+  at `/usr/bin/node`, which doesn't exist in this sandbox (node lives at `/opt/node22/bin/node`
+  here) — same root cause called out in the 2026-07-08 cycle's Notes.
+- To confirm there was no *other* blocker, temporarily repointed the symlink locally (never
+  staged/committed — reverted with `git checkout -- binaries/node-x86_64-unknown-linux-gnu`
+  immediately after) and re-ran: `cargo check` finished cleanly in ~14s, and `cargo test` passed
+  **20/20** unit tests — identical count to the last cycle that could run it (2026-07-08). This
+  confirms the dependency changes here don't break the Rust build; the sidecar-symlink gap
+  remains a sandbox-only artifact, not a code defect, and was **not** changed in the committed
+  tree.
+- Re-ran `npm run lint`, `npm run typecheck`, `npm run test` (all workspaces), and `apps/desktop`'s
+  `npm run build` after every dependency change — all still green, identical pass counts to
+  baseline (desktop 221/222 + 1 skip unchanged, api 423/423, eval 16/16, schemas 17/17; lint and
+  typecheck clean).
+
+### Notes
+
+- **Lock file drift (pre-existing, not fixed this cycle, call for repo owner)** —
+  `package-lock.json` and `pnpm-lock.yaml` still coexist at the root. CI only reads
+  `package-lock.json` (`npm ci`). `pnpm-lock.yaml` was last modified 2026-05-31;
+  `package-lock.json` was just updated today (2026-07-29). The gap is now **~8.5 weeks and
+  growing every cycle** the pnpm file isn't touched. Not resolved this cycle — dropping one
+  lockfile (or wiring CI/Dependabot to keep both in sync) remains the repo owner's call, not an
+  agent's.
+
+### Major upgrades pending (manual review — not applied)
+
+| Package | Current | Latest | Risk notes |
+|---|---|---|---|
+| `typescript` (root) | `6.0.3` | `7.0.2` | Major rewrite, flagged every cycle since 07-08; needs a dedicated compatibility pass across all 4 npm workspaces + `typescript-eslint`, not a drive-by bump. |
+| `@types/node` (root) | `25.9.5` | `26.1.2` | Type-defs major ahead of `engines: ">=22"` / CI's pinned Node 22 — low risk but flagged per policy; re-evaluate alongside any future Node engine bump. |
+| `better-sqlite3` (services/api) | `12.11.1` | `13.0.2` | Native-addon major — first flagged by #96 (2026-07-22 cycle) and still pending; needs its own rebuild/verification pass across platforms before adopting, not a routine `npm update`. |
+
+No other workspace has a pending major this cycle — `@tauri-apps/*`, `react`/`react-dom`,
+`express`, `zod`, `@langchain/*`, `pg`, etc. are all on current majors.
+
+---
+
 ## 2026-07-15
 
 ### Checks performed

--- a/package-lock.json
+++ b/package-lock.json
@@ -484,9 +484,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
-      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -541,9 +541,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -687,9 +687,9 @@
       }
     },
     "node_modules/@langchain/core": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.2.1.tgz",
-      "integrity": "sha512-NNG/cC5FGuHDOAP56h0ddp8Rfk8p+othWzEK5RV9JIG6RvnF5vGa5r0AEGtKfQieed7s1kC42GuIzVOBvMBL/g==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.2.3.tgz",
+      "integrity": "sha512-F+L5SsciykwDl7eDxacnhDTcWe1IF6jetzfkvI5PPfq6ogWHO7xcjU90SGh/3lqbbS0tgun+qF01KIqxawrCsA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -721,13 +721,13 @@
       }
     },
     "node_modules/@langchain/langgraph": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.4.7.tgz",
-      "integrity": "sha512-2tcyf3QGC7v89kqSxMCtRvzg/3L/4yHtOaWC49A8KieCciWJs7LGaxHoPB6QRxXyUgyR+Zg9Q1ss/XJIE+JuSQ==",
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.4.8.tgz",
+      "integrity": "sha512-DN1Np1XefdBEbp1qBKlt39cwoL743AAGpR5Ipja0gY2YbWvsoQnOTIrjnj/orSAhaUYsdTKS8VSWdFzsHZo6Ig==",
       "license": "MIT",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.3",
-        "@langchain/langgraph-sdk": "~1.9.25",
+        "@langchain/langgraph-sdk": "~1.9.26",
         "@langchain/protocol": "^0.0.18",
         "@standard-schema/spec": "1.1.0"
       },
@@ -752,9 +752,9 @@
       }
     },
     "node_modules/@langchain/langgraph-sdk": {
-      "version": "1.9.25",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.25.tgz",
-      "integrity": "sha512-mRKW8zyQUaHox+HirRFMRrPqOvNbQI3xeXDt6kkk4PbBg77V92bsO1WzUVNrmJ81zCkvxyOrWSK8D6ioCj0a8A==",
+      "version": "1.9.28",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.28.tgz",
+      "integrity": "sha512-4j3XuM0PvtmAbL8mPfBS99ez3+ytRfgbOpAR/nOeaejTRF3Q9dNw2QnaGLGng8wLPtGLoSj+SYgUOVxy9Bv9vg==",
       "license": "MIT",
       "dependencies": {
         "@langchain/protocol": "^0.0.18",
@@ -791,9 +791,9 @@
       "license": "MIT"
     },
     "node_modules/@langchain/langgraph-sdk/node_modules/p-queue": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.1.tgz",
-      "integrity": "sha512-POWdiIPmsUPGwb4FeQ4OBg46aqmcInSWe45CKDsGHiOBiVQM9chqfQTuqhuTzcg2Vz9faTI65at0KkVyVEiCHw==",
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.3.tgz",
+      "integrity": "sha512-NXAOdnEe5FsZJfT4oK84lE1Y5cFFdWlRuOo5tww8DyNMxyRXwn39fIkUtNLKppcPC+UYU/bXujNCUGDv01y7CA==",
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "^5.0.4",
@@ -990,19 +990,19 @@
       "license": "MIT"
     },
     "node_modules/@playwright/test": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
-      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
+      "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.61.1"
+        "playwright": "1.62.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@standard-schema/spec": {
@@ -1365,17 +1365,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.63.0.tgz",
-      "integrity": "sha512-rvwSgqT+DHpWdzfSzPatRLm02a0GlESt++9iy3hLCDY4BgkaLcl8LBi9Yh7XGFBpwcBE/K3024QuXWTpbz4FfQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.63.0",
-        "@typescript-eslint/type-utils": "8.63.0",
-        "@typescript-eslint/utils": "8.63.0",
-        "@typescript-eslint/visitor-keys": "8.63.0",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/type-utils": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -1388,15 +1388,15 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.63.0",
+        "@typescript-eslint/parser": "^8.65.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1404,16 +1404,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.63.0.tgz",
-      "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.63.0",
-        "@typescript-eslint/types": "8.63.0",
-        "@typescript-eslint/typescript-estree": "8.63.0",
-        "@typescript-eslint/visitor-keys": "8.63.0",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1429,14 +1429,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.63.0.tgz",
-      "integrity": "sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.63.0",
-        "@typescript-eslint/types": "^8.63.0",
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1451,14 +1451,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.63.0.tgz",
-      "integrity": "sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.63.0",
-        "@typescript-eslint/visitor-keys": "8.63.0"
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1469,9 +1469,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.63.0.tgz",
-      "integrity": "sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1486,15 +1486,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.63.0.tgz",
-      "integrity": "sha512-Nzzh/OGxVCOjObjaj1CQF2RUasyYy2Jfuh+zZ3PjLzG2fYRriAiZLib9UKtO+CpQAS3YHiAS+ckZDclwqI1TPA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.63.0",
-        "@typescript-eslint/typescript-estree": "8.63.0",
-        "@typescript-eslint/utils": "8.63.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -1511,9 +1511,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.63.0.tgz",
-      "integrity": "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1525,16 +1525,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.63.0.tgz",
-      "integrity": "sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.63.0",
-        "@typescript-eslint/tsconfig-utils": "8.63.0",
-        "@typescript-eslint/types": "8.63.0",
-        "@typescript-eslint/visitor-keys": "8.63.0",
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -1553,16 +1553,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.63.0.tgz",
-      "integrity": "sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.63.0",
-        "@typescript-eslint/types": "8.63.0",
-        "@typescript-eslint/typescript-estree": "8.63.0"
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1577,13 +1577,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.63.0.tgz",
-      "integrity": "sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/types": "8.65.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -1608,9 +1608,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1758,16 +1758,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer": {
@@ -2132,9 +2132,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
-      "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
+      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -2144,7 +2144,7 @@
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/config-helpers": "^0.7.0",
         "@eslint/core": "^1.2.1",
         "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
@@ -2168,7 +2168,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "minimatch": "^10.2.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -2355,11 +2355,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
-      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.1.tgz",
+      "integrity": "sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA==",
       "license": "MIT",
       "dependencies": {
+        "debug": "^4.4.3",
         "ip-address": "^10.2.0"
       },
       "engines": {
@@ -2483,9 +2484,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
+      "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -2594,9 +2595,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.7.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
-      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+      "version": "17.8.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.8.0.tgz",
+      "integrity": "sha512-Zz/LMDZScFmkakeL2cTHzf+PbWKdpU3uclqkZT7TjDG58j5WPt0PpA+n9uPI24fZtlw07q0OtEi84K+umsRzqQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2643,9 +2644,9 @@
       }
     },
     "node_modules/helmet": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.2.0.tgz",
-      "integrity": "sha512-DRgTIUgnWcJ62KyarxxziuqYxKGnR6Rgg19BlbucN/dpmJbl1XOit6qvoOX0ZT+HhWe5OUVhU/a1zpGyc1xA0Q==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.3.0.tgz",
+      "integrity": "sha512-Qgpiaws3Sm30Av8Eah6sjMCZZwjlBu+E68rhpCWBshY1lb09HtLwj5GviX0OyQIn+ulUS0iX0AxN5n3tLZzz1w==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -2759,9 +2760,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.3.1.tgz",
+      "integrity": "sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -2825,9 +2826,9 @@
       "license": "ISC"
     },
     "node_modules/js-base64": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.8.0.tgz",
-      "integrity": "sha512-65kvbemyZhj+ExQt1PEFyBEjL5vAHysu1lJdW1AwhhChkO8ZBPizYk/m9GVrpbS2Je1hF+UYZ+6KywqtZV8mHw==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.9.2.tgz",
+      "integrity": "sha512-6zayE8QlUdiweYI6cETD/XBSqFcoCUlufn/29PJR99r82x1yDnIprRca0YvAYpAW+ez0GuQkVBC6xG5QkD7OjA==",
       "license": "BSD-3-Clause"
     },
     "node_modules/js-tiktoken": {
@@ -2915,9 +2916,9 @@
       }
     },
     "node_modules/langsmith": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.8.0.tgz",
-      "integrity": "sha512-edm/zZ1jMQRt0GzavmJ0YPIsqKkXetffIpmR29li8P0SoZ0MI/xKk/tIAkPnxHCybmzJesIQf5CT7eLQCqv3kA==",
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.8.7.tgz",
+      "integrity": "sha512-QWcc7JwmGy+sPRJwqCf9xLiiSIhwc/i7oVwjQezkx6UzyFlokME3Wxy80qKqirTyJvWG1S9ylqtxBDpFRpas5g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3062,12 +3063,16 @@
       }
     },
     "node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/merge-descriptors": {
@@ -3120,13 +3125,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -3489,35 +3494,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
-      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.1"
+        "playwright-core": "1.62.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
-      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/postgres-array": {
@@ -3695,24 +3700,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.7"
+        "react": "^19.2.8"
       }
     },
     "node_modules/readable-stream": {
@@ -4084,9 +4089,9 @@
       }
     },
     "node_modules/tsx": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
-      "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.28.0"
@@ -4186,16 +4191,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.63.0.tgz",
-      "integrity": "sha512-xgwXyzG4sK9ALkBxbyGkTMMOS+imnW65iPhxCQMK83KhxyoDNW7l+IDqEf9vMdoUidHpOoS967RCq4eMiTexwQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
+      "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.63.0",
-        "@typescript-eslint/parser": "8.63.0",
-        "@typescript-eslint/typescript-estree": "8.63.0",
-        "@typescript-eslint/utils": "8.63.0"
+        "@typescript-eslint/eslint-plugin": "8.65.0",
+        "@typescript-eslint/parser": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4282,9 +4287,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
## ⚠️ Backlog status correction — please read first

The task framing for this cycle assumed four prior maintenance PRs (#92, #93, #94, #95) were still open/unmerged against `staging`, stacked behind the still-open #96. **That is no longer true — verified directly via the GitHub API before writing anything, rather than propagating the assumption:**

| PR | State | Merged at |
|---|---|---|
| [#92](https://github.com/eikrad/bandsearch-app/pull/92) | **merged** | 2026-07-22T19:21:42Z |
| [#93](https://github.com/eikrad/bandsearch-app/pull/93) | **merged** | 2026-07-22T19:23:05Z |
| [#94](https://github.com/eikrad/bandsearch-app/pull/94) | **merged** | 2026-07-23T12:09:57Z |
| [#95](https://github.com/eikrad/bandsearch-app/pull/95) | **merged** | 2026-07-23T12:18:43Z |
| [#96](https://github.com/eikrad/bandsearch-app/pull/96) | still **open** | — (2026-07-22 cycle) |

All four merged within ~17 hours of #96 being opened. **#96 is now the only outstanding maintenance PR** — recommend reviewing and merging it (or treating this PR as its replacement, since the content overlaps) rather than treating this as a 5-PR pile-up. I'm flagging this correction prominently because carrying the stale "4 unmerged PRs" claim forward into this PR body would have been actively misleading.

One direct consequence: because #94 (2026-07-15 cycle) already landed the `plist`/`quick-xml` fix on `staging`, this cycle's baseline already resolves `plist 1.10.0` / `quick-xml 0.41.0` — confirmed by inspecting `Cargo.lock` before touching anything. **No RUSTSEC-2026-0194/0195 re-fix was needed this time** — the backlog actually clearing is what stopped this fix from being reproduced a 4th time.

## Baseline (before changes, on `staging` tip `dee443f`, the merge of #95)
- `npm ci` — clean install
- `npm run lint` / `npm run typecheck` — clean, all workspaces
- `npm run test` — **678/678** (677 pass + 1 pre-existing skip, 0 fail): desktop 222, api 423, eval 16, schemas 17 — matches prior cycles' baseline exactly
- `npm --workspace @bandsearch/desktop run build` — succeeds
- `npm audit` — 1 high (`brace-expansion` <=5.0.7 — DoS via unbounded expansion length)
- `cargo audit` (`apps/desktop/src-tauri`) — installed `cargo-audit 0.22.2` from source (first attempt hit a transient parallel-build error, succeeded on retry with `-j 2`) — **0 vulnerabilities**; only the same 18 informational unmaintained/unsound warnings seen every prior cycle
- Python (`dependencies = []`, `uv.lock` no third-party entries) — nothing to audit, confirmed

## Security fix — none needed for Rust this cycle
`cargo audit` against this tip found 0 vulnerabilities — RUSTSEC-2026-0194/0195 (`quick-xml`, via `plist`) already fixed via merged #94. Only the 18 informational GTK3/`anyhow`/`glib`/`unic-*` warnings remain, unchanged from every prior cycle, no independent fix upstream.

## Dependency updates (`npm update`, safe patch/minor)
| Workspace | Package | Before | After |
|---|---|---|---|
| root | `eslint` | 10.6.0 | 10.8.0 |
| root | `@playwright/test` (+ `playwright`, `playwright-core`) | 1.61.1 | 1.62.0 |
| root | `typescript-eslint` (+ `@typescript-eslint/*`) | 8.63.0 | 8.65.0 |
| root | `tsx` | 4.23.0 | 4.23.1 |
| root | `globals` | 17.7.0 | 17.8.0 |
| apps/desktop | `react` / `react-dom` | 19.2.7 | 19.2.8 |
| services/api | `@langchain/langgraph` (+ `@langchain/core`, `-sdk`) | 1.4.7 | 1.4.8 |
| services/api | `express-rate-limit` | 8.5.2 | 8.6.1 |
| services/api | `helmet` | 8.2.0 | 8.3.0 |
| transitive (security) | `brace-expansion` | 5.0.7 | 5.0.8 |
| transitive (various) | `@eslint-community/eslint-utils`, `acorn`, `flatted`, `ip-address`, `js-base64`, `langsmith`, `media-typer`, `minimatch`, `ws`, `p-queue` | — | patch bumps only |

No `package.json` edits needed anywhere (all within `^` ranges) — only `package-lock.json` changed. The `brace-expansion` bump incidentally cleared the baseline `npm audit` finding. `services/eval` and `shared/schemas`: nothing outdated.

**Rust**: `cargo update --dry-run` shows ~114 available non-advisory patch/minor bumps across the `tauri` 2.x family (`tauri 2.11.0→2.11.5`, `wry 0.55.0→0.55.1`, `tao 0.35.0→0.35.3`, `tokio 1.52.1→1.53.1`, etc.). None are security-driven, so — consistent with #96's precedent of minimal security-only Rust diffs — none applied; flagged for a future dedicated Rust-refresh cycle.

## Majors — flagged, NOT applied
| Package | Current | Latest | Why held back |
|---|---|---|---|
| `typescript` (root) | 6.0.3 | 7.0.2 | Major rewrite, flagged every cycle since 07-08; needs a dedicated compatibility pass across all 4 npm workspaces + `typescript-eslint`. |
| `@types/node` (root) | 25.9.5 | 26.1.2 | Type-defs major ahead of `engines: ">=22"` / CI's pinned Node 22 — low risk but flagged per policy. |
| `better-sqlite3` (services/api) | 12.11.1 | 13.0.2 | Native-addon major, first flagged by #96 and still pending — needs its own rebuild/verification pass, not a routine bump. |

## Security audit summary
| Ecosystem | Tool | Result |
|---|---|---|
| npm (all workspaces) | `npm audit` | 1 high (`brace-expansion`) → **0 after update** |
| Python | manual (`dependencies = []`) | Nothing to audit |
| Rust | `cargo audit` | **0 vulnerabilities** (already fixed via #94); 18 informational warnings unchanged, same set as every prior cycle |

## Known issue — dual lock files (not fixed, flagging again)
`package-lock.json` + `pnpm-lock.yaml` still coexist. `pnpm-lock.yaml` last committed 2026-05-31 — now **~8.5 weeks stale** and growing every cycle. CI uses `npm ci` (`package-lock.json` only). **Not resolved here** — deleting either lockfile remains the repo owner's call, not an agent's.

## Rust build/test — fully verifiable this cycle (with a caveat)
Unlike the last three cycles, `cargo check`/`cargo test` were verifiable end-to-end here:
- GTK3 dev headers (`libgtk-3-dev`, `libwebkit2gtk-4.1-dev`) are already present in this sandbox this cycle — `pkg-config --exists gdk-3.0` succeeds. The mirror-blocked issue from the 2026-07-22 cycle did not reproduce.
- Cold `cargo check` still failed, but on a different, already-documented issue: the tracked `apps/desktop/src-tauri/binaries/node-x86_64-unknown-linux-gnu` sidecar symlink points at `/usr/bin/node`, which doesn't exist in this sandbox (node lives at `/opt/node22/bin/node` here) — same root cause noted in the 2026-07-08 cycle.
- To confirm no *other* blocker existed, temporarily repointed the symlink locally (never staged/committed, reverted immediately via `git checkout --`) and re-ran: `cargo check` finished cleanly (~14s) and `cargo test` passed **20/20** unit tests — identical to the last cycle that could run it (2026-07-08). Confirms this cycle's dependency changes don't break the Rust build. The committed tree is unchanged — the sidecar-symlink gap is a sandbox artifact, not a code defect, and CI (with its own real environment) is the actual verification gate for this.

## Post-change verification
Re-ran full baseline after all changes — identical to pre-change baseline: lint clean, typecheck clean, **678/678 tests** (same breakdown: desktop 221/222+1 skip, api 423/423, eval 16/16, schemas 17/17), desktop build succeeds, `cargo audit` 0 vulnerabilities (still just the 18 informational warnings), `cargo check`/`cargo test` verified via the temporary local symlink workaround (reverted before commit). Husky pre-commit hook (`npm run ci`) passed on the commit.

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` (678/678, all workspaces)
- [x] `apps/desktop` `npm run build`
- [x] `cargo check` / `cargo test` — verified via temporary sidecar-symlink workaround (not committed); 20/20 unit tests passing
- [x] `npm audit` — 0 vulnerabilities after update
- [x] `cargo audit` — 0 vulnerabilities (already fixed via #94)
- [x] Python — confirmed nothing to audit
- [x] Husky pre-commit hook passed

---
_Generated by [Claude Code](https://claude.ai/code/session_016otMXixdLLpmC9a4FVYL65)_