### PR TITLE
docs: reconcile README/architecture docs with actual runtime behavior

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,9 +11,11 @@ BRAVE_API_KEY=your_brave_search_api_key
 # Eval & Quality Observability (Phase 8): activates the /eval/* routes and the
 # async eval worker
 # - Obscurity scoring uses LASTFM_API_KEY above
-# - LLM-as-Judge uses MISTRAL_API_KEY
+# - LLM-as-Judge uses MISTRAL_API_KEY (despite the name, this currently must be
+#   an Anthropic API key — see docs/architecture/ARCHITECTURE.md, Evaluation layer)
 # EVAL_DASHBOARD_ENABLED=true
-# MISTRAL_API_KEY=your_mistral_api_key_here
+# EVAL_DASHBOARD_PASSWORD=your_dashboard_password_here
+# MISTRAL_API_KEY=your_anthropic_api_key_here
 
 # Storage: sqlite (default, no setup needed), memory (no persistence), postgres
 # PREFERENCE_STORE=sqlite
@@ -32,7 +34,7 @@ BRAVE_API_KEY=your_brave_search_api_key
 # LANGSMITH_TRACING=true
 # LANGSMITH_PROJECT=bandsearch-dev
 
-CORS_ORIGIN=http://localhost:1420TGyj81krmIKW9SdgD9rZOHZiETPnUitX
+CORS_ORIGIN=http://localhost:1420
 MUSICBRAINZ_TIMEOUT_MS=5000
 MUSICBRAINZ_RETRIES=1
 
@@ -40,6 +42,6 @@ MUSICBRAINZ_RETRIES=1
 # RESEARCH_MAX_INITIAL_SEARCHES=6
 # RESEARCH_MAX_REFLECTION_SEARCHES=4
 # RESEARCH_TOTAL_SEARCH_BUDGET=10
-# RESEARCH_TIMEOUT_MS=25000
+# RESEARCH_TIMEOUT_MS=45000
 # RESEARCH_TARGET_VERIFIED_CANDIDATES=8
 # RECOMMENDATION_PIPELINE_READY_TIMEOUT_MS=45000

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -22,9 +22,9 @@ AI-powered music recommendations for niche and lesser-known artists. Combines co
 
 - **Obscurity target** — a user-selectable signal (`Cult Following` / `Underground` / `Truly Obscure`) passed to the planner to tune search queries toward less or more obscure artists. Stored per recommendation event.
 
-- **Eval layer** — an async, non-blocking quality-scoring system that runs after the HTTP response is sent. Three tiers: (1) automatic metrics — Last.fm obscurity score and pipeline funnel counts; (1.5) deterministic checks — citation support rate and generic-why detection; (2) LLM-as-judge — Claude scores each band asynchronously (optional, requires `ANTHROPIC_API_KEY`).
+- **Eval layer** — an async, non-blocking quality-scoring system that runs after the HTTP response is sent. Three tiers: (1) automatic metrics — Last.fm obscurity score and pipeline funnel counts; (1.5) deterministic checks — citation support rate and generic-why detection; (2) LLM-as-judge — Claude scores each band asynchronously (optional, requires `MISTRAL_API_KEY`).
 
-- **LLM-as-judge** — an async eval worker using Claude to score each recommended band on relevance, obscurity fit, evidence quality, and discovery value. Only active when `ANTHROPIC_API_KEY` is set; never on the critical response path.
+- **LLM-as-judge** — an async eval worker using Claude to score each recommended band on relevance, obscurity fit, evidence quality, and discovery value. Only active when `MISTRAL_API_KEY` is set (the env var name is a leftover from an incomplete Mistral migration — the actual HTTP call still goes to Anthropic's API; see `docs/architecture/ARCHITECTURE.md`). Never on the critical response path.
 
 - **Golden dataset** — a curated set of queries in `services/eval/golden-set.json` with expected `nuggets` (bands that should appear) and `antiBands` (bands that should not). The eval runner (`run-golden.ts`) computes `antiBandRate@8` and fails CI if it exceeds 50%.
 

--- a/README.md
+++ b/README.md
@@ -133,16 +133,18 @@ Bandsearch uses optional local multi-user auth (bcrypt + 30-day JWT).
 
 **JWT secret:** Set `JWT_SECRET` in your environment for persistent sessions. Without it, a random secret is generated on startup and all tokens are invalidated on restart.
 
+**Creating a user without the app:** `npm run create-user --workspace @bandsearch/api -- --email you@example.com --name "Your Name" --password "secret"` creates a user directly against the configured database (SQLite or Turso).
+
 The desktop client persists the token in browser storage and injects it as `Authorization: Bearer` on every API call. The login/register/reset-password screens are shown automatically on startup when the API requires authentication.
 
 ---
 
 ## Storage
 
-Bandsearch uses two persistence domains:
+Bandsearch uses two persistence domains, both selected by the same `PREFERENCE_STORE` variable:
 
-- **Preferences store** (`saved_bands`, groups) — configurable via `PREFERENCE_STORE`.
-- **Session store** (`chat_sessions`, `chat_messages`) — local SQLite in `DATABASE_PATH` (default `bandsearch.db`), with in-memory fallback if SQLite is unavailable.
+- **Preferences store** (`saved_bands`, groups) and **auth store** (`users`).
+- **Session store** (`chat_sessions`, `chat_messages`) — SQLite by default (`DATABASE_PATH`, in-memory fallback if SQLite is unavailable), or Turso/libSQL when `PREFERENCE_STORE=turso`.
 
 | `PREFERENCE_STORE` | Description |
 |--------------------|-------------|
@@ -198,20 +200,20 @@ Turso URL and auth token can also be saved through the **Settings** screen in th
 | `TURSO_DATABASE_URL` | — | Required when `PREFERENCE_STORE=turso` |
 | `TURSO_AUTH_TOKEN` | — | Turso auth token (omit for local libSQL) |
 | `CORS_ORIGIN` | `*` | Allowed browser origin |
-| `RECOMMENDATION_TIMEOUT_MS` | `8000` | Gemini request timeout |
 | `RECOMMENDATION_PIPELINE_READY_TIMEOUT_MS` | `45000` | Max wait before HTTP listen while the pipeline initializes |
 | `MUSICBRAINZ_TIMEOUT_MS` | `5000` | MusicBrainz request timeout |
 | `MUSICBRAINZ_RETRIES` | `1` | MusicBrainz retry attempts |
 | `LASTFM_API_KEY` | — | Optional — Last.fm fallback for artist images and obscurity scoring (listener counts) |
-| `MISTRAL_API_KEY` | — | Optional — activates the async LLM-as-judge eval worker (Mistral scores recommendations after the response is sent) |
-| `EVAL_DASHBOARD_ENABLED` | — | Set `true` to enable the developer eval dashboard at `/eval/dashboard` |
+| `MISTRAL_API_KEY` | — | Optional — activates the async LLM-as-judge eval worker after the response is sent. Despite the name, the current implementation calls Anthropic's Claude API (`claude-opus-4-8`) with this key, a leftover from an incomplete Mistral migration — see [ARCHITECTURE.md](docs/architecture/ARCHITECTURE.md#evaluation-layer) |
+| `EVAL_DASHBOARD_ENABLED` | — | Set `true` to enable the developer eval dashboard and `/eval/*` routes (404 otherwise) |
+| `EVAL_DASHBOARD_PASSWORD` | — | Optional — HTTP Basic Auth password for `/eval/dashboard` |
 | `LANGSMITH_API_KEY` | — | Optional LangSmith tracing |
 | `LANGSMITH_TRACING` | — | Set `true` to enable tracing |
 | `LANGSMITH_PROJECT` | — | LangSmith project name |
 | `RESEARCH_MAX_INITIAL_SEARCHES` | `6` | Max Brave queries on first pass |
 | `RESEARCH_MAX_REFLECTION_SEARCHES` | `4` | Cap on extra queries after reflection |
 | `RESEARCH_TOTAL_SEARCH_BUDGET` | `10` | Max Brave calls per recommendation request |
-| `RESEARCH_TIMEOUT_MS` | `25000` | Upper bound for the multi-step research workflow |
+| `RESEARCH_TIMEOUT_MS` | `45000` | Upper bound (ms) for the multi-step research workflow — generous by default because the Brave free plan throttles to 1 req/sec |
 | `RESEARCH_TARGET_VERIFIED_CANDIDATES` | `8` | Verified MusicBrainz hits before skipping reflection |
 
 ---
@@ -290,6 +292,12 @@ Response includes `recommendations`, optional `assistantReply` (conversational p
 | `GET` | `/sessions/:id` | Get one session with messages |
 | `POST` | `/sessions/:id/messages` | Add message to session |
 
+### Storage diagnostics
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/preferences/turso/test` | Test a Turso connection string + auth token before saving (used by the Settings screen) |
+
 ### Artist Discovery
 
 | Method | Path | Description |
@@ -299,12 +307,16 @@ Response includes `recommendations`, optional `assistantReply` (conversational p
 
 ### Eval
 
-Requires `EVAL_DASHBOARD_ENABLED=true` in the environment.
+All `/eval/*` routes return 404 unless `EVAL_DASHBOARD_ENABLED=true`.
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `GET` | `/eval/dashboard` | Developer quality dashboard — pipeline funnel, obscurity distribution, LLM-judge alignment, trend charts, and event log |
+| `GET` | `/eval/dashboard` | Developer quality dashboard (HTML) — pipeline funnel, obscurity distribution, LLM-judge alignment, trend charts, and event log. Protected by HTTP Basic Auth if `EVAL_DASHBOARD_PASSWORD` is set |
+| `GET` | `/eval/events` | List recent recommendation events with their per-band eval scores (`?limit=`, max 200) |
+| `GET` | `/eval/metrics` | Aggregated metrics for current events, plus delta vs. the latest baseline |
+| `GET` | `/eval/baselines` | List saved baseline snapshots |
 | `POST` | `/eval/baseline` | Save a named snapshot of current aggregated metrics for before/after comparison |
+| `POST` | `/eval/feedback` | Log user feedback (`good`, `too_mainstream`, `wrong_direction`) for a recommendation event |
 
 ---
 
@@ -312,6 +324,7 @@ Requires `EVAL_DASHBOARD_ENABLED=true` in the environment.
 
 ```bash
 npm test          # run all workspace tests
+npm run test:e2e  # Playwright end-to-end tests (spins up the API + a static frontend build)
 npm run ci        # lint + typecheck + test
 ```
 
@@ -332,6 +345,8 @@ apps/desktop/     — Tauri + React desktop client
 services/api/     — Express API
 services/eval/    — golden dataset and eval runner (anti-band gate, nugget coverage)
 shared/schemas/   — shared validation contracts (TypeScript contracts.ts + tests)
+tests/e2e/        — Playwright end-to-end tests
+scripts/          — repo-wide build/lint utilities (e.g. Python lint wrapper)
 docs/             — architecture docs, ADRs, design specs, roadmap
 ```
 
@@ -346,6 +361,14 @@ In development (browser or embedded webview), the chat UI chooses **mobile vs de
 - [Brave Search](https://brave.com/search/api/) — web search API used for niche artist discovery.
 
 ---
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the branch/PR workflow and commit conventions. This project also has a [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Security
+
+See [SECURITY.md](SECURITY.md) for how to report a vulnerability.
 
 ## License
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -88,7 +88,7 @@ Three-layer system to measure recommendation quality over time: automatic obscur
 - [x] Step 2: Last.fm obscurity scoring — async worker enriches events with `listeners` count and tier (`cult` / `underground` / `obscure`) per band after the response is sent ✓ Done
 - [x] Step 3: Obscurity target setting — three-button UI (`Cult Following` / `Underground` / `Truly Obscure`), `obscurityTarget` field threaded through request body → planner prompt → event log ✓ Done
 - [x] Step 4: Search source quality + deterministic evidence checks — URL heuristic for discovery sources plus `citation_support_rate` and `generic_why_flag` per band; stored per event, no LLM needed ✓ Done
-- [x] Step 5: LLM-as-judge worker — async Claude judge scoring each band on relevance, obscurity fit, evidence quality, and discovery value; activated by `ANTHROPIC_API_KEY`; silently skipped if absent ✓ Done
+- [x] Step 5: LLM-as-judge worker — async Claude judge scoring each band on relevance, obscurity fit, evidence quality, and discovery value; activated by `ANTHROPIC_API_KEY` at the time (later renamed to `MISTRAL_API_KEY` — see ARCHITECTURE.md's Evaluation layer note; the underlying call is still to Anthropic); silently skipped if absent ✓ Done
 - [x] Step 5b: Judge calibration — ~20–30 hand-labeled recommendations + ~15–20 GroUSE-style unit tests; compute judge–human agreement rate before trusting Layer 2 dashboard deltas ✓ Done
 - [x] Step 6: Baseline snapshots — `eval_baselines` table + `POST /eval/baseline` endpoint; named snapshots of aggregated metrics before experiments; filterable by `pipeline_version` ✓ Done
 - [x] Step 7: Developer dashboard — `GET /eval/dashboard` serving a standalone HTML+Chart.js page with overview panel (current vs. baseline delta), pipeline funnel panel, human–LLM alignment metrics, trend charts, obscurity distribution, and event log; guarded by `EVAL_DASHBOARD_ENABLED=true` ✓ Done
@@ -217,7 +217,7 @@ The following refactors were identified during architecture review but not yet i
 
 **Files:** `services/api/src/routes/registerBandsearchRoutes.ts` (lines 290–322)
 
-The logic that fetches saved bands, calls MusicBrainz for each artist's genre, and creates/updates groups lives inline in the `POST /preferences/auto-group` HTTP handler. It is untested, has a race condition when two concurrent requests try to create the same genre group, and cannot be reused by non-HTTP callers (e.g. the import flow).
+The logic that fetches saved bands, calls MusicBrainz for each artist's genre, and creates/updates groups lives inline in the `POST /preferences/groups/auto` HTTP handler. It is untested, has a race condition when two concurrent requests try to create the same genre group, and cannot be reused by non-HTTP callers (e.g. the import flow).
 
 **Action:** Extract a `bandGroupInference` module (or similar name grounded in domain vocabulary) with one function: given a band name and MusicBrainz metadata, return zero or more group assignments. The route handler calls this and applies the result. Move the MusicBrainz I/O, deduplication, and group upsert logic inside the new module. Add unit tests for at least the race condition and the silent-MusicBrainz-failure path.
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -70,7 +70,7 @@ graph TD
 
     API -.->|optional| LASTFM[Last.fm\nartist images + obscurity score]
     PIPELINE -.->|optional tracing| LANGSMITH[LangSmith]
-    API -.->|optional async eval| MISTRAL[Mistral\nLLM-as-Judge]
+    API -.->|optional async eval| CLAUDE[Anthropic Claude\nLLM-as-Judge]
 ```
 
 ---
@@ -168,7 +168,7 @@ A shared `ResearchBudget` instance tracks wall-clock time against `RESEARCH_TIME
 | **Google Gemini** (`@langchain/google-genai`) | `plan`, `extract`, `assess`, `rank` | All structured reasoning and text generation |
 | **MusicBrainz** | `verify`, `verify_r` | Artist metadata verification (mbid, genres, tags, URL relations) |
 | **Wikidata + Last.fm** | `/artists/image` endpoint | Artist image resolution with Last.fm fallback |
-| **Mistral** (optional) | Eval layer | Async LLM-as-Judge scoring — never on the critical path |
+| **Anthropic Claude** (optional) | Eval layer (`judgeWorker.ts`) | Async LLM-as-Judge scoring — never on the critical path. Activated by `MISTRAL_API_KEY` (naming leftover from an incomplete provider migration — see note below) |
 | **LangSmith** (optional) | Graph invocation | Distributed tracing for the LangGraph pipeline |
 
 ---
@@ -181,10 +181,12 @@ Full design in [2026-05-29-eval-architecture.md](2026-05-29-eval-architecture.md
 |-------|-----------|--------|
 | **1 — Automatic metrics** | Runs immediately | Obscurity score (Last.fm listener count), funnel counts (hits / extracted / verified), search source quality |
 | **1.5 — Deterministic checks** | Runs immediately | Citation support rate (evidence URLs per recommendation), generic-why detection |
-| **2 — LLM-as-Judge** | Async, fire-and-forget | Mistral scores each band on `relevance`, `obscurity_fit`, `evidence_quality`, `discovery_value` — only when `MISTRAL_API_KEY` is set |
+| **2 — LLM-as-Judge** | Async, fire-and-forget | Anthropic Claude (`claude-opus-4-8`) scores each band on `relevance`, `obscurity_fit`, `evidence_quality`, `discovery_value` — only when `MISTRAL_API_KEY` is set |
 | **3 — Human feedback** | Event-driven | Implicit saves + explicit one-tap batch reactions |
 
 Eval data is stored in `recommendation_events`, `llm_eval_scores`, `recommendation_feedback`, and `eval_baselines` tables.
+
+**Known inconsistency:** the eval worker's config field and env var are both named for Mistral (`mistralApiKey` / `MISTRAL_API_KEY`), but `services/api/src/eval/judgeWorker.ts` calls the Anthropic Messages API (`https://api.anthropic.com/v1/messages`, model `claude-opus-4-8`) with that key. This is a leftover from a provider-rename commit that updated the config/docs but not the actual HTTP call. Functionally: set `MISTRAL_API_KEY` to a valid **Anthropic** API key to enable this layer.
 
 ---
 
@@ -205,7 +207,7 @@ Tables: `saved_bands` (rating, categories, notes), `artist_groups`
 
 ### Session store
 
-SQLite (`bandsearch.db`) with in-memory fallback. Tables: `chat_sessions`, `chat_messages`.
+SQLite (`bandsearch.db`) with in-memory fallback, or Turso/libSQL when `PREFERENCE_STORE=turso` (`tursoChatSessionRepository`). Tables: `chat_sessions`, `chat_messages`.
 
 ### Auth store
 
@@ -245,7 +247,7 @@ Three-tier progressive auth — determined by the number of registered users at 
 | Decision | Rationale |
 |----------|----------|
 | **Gemini for all graph nodes** | Consistent structured-JSON output across plan / extract / reflect / rank; low temperature (0.2) for planning reduces variance |
-| **Mistral as optional async judge** | Keeps the LLM judge off the critical response path; eval can be added/removed without touching the graph |
+| **Optional async LLM judge** | Keeps the LLM judge off the critical response path; eval can be added/removed without touching the graph (currently wired to Anthropic Claude — see Evaluation layer note) |
 | **Budget-aware graph** | Hard wall-clock deadline enforced via `researchBudget.ts`; conditional edges bypass remaining nodes gracefully instead of timing out mid-flight |
 | **Pluggable storage** | Abstract repository pattern allows SQLite → Postgres → Turso swap without touching business logic |
 | **Progressive auth** | Single-user deployments require no configuration; auth activates as users are added |


### PR DESCRIPTION
## Summary

Documentation maintenance pass comparing `README.md`, `docs/`, and `CONTEXT.md` against the actual code. Most of the existing documentation (docs/README.md index, docs/architecture/ARCHITECTURE.md diagrams, docs/ROADMAP.md phase log, ADRs, design docs) was already accurate and current — this PR fixes the specific spots where it had drifted from reality.

**README.md**
- `RESEARCH_TIMEOUT_MS` default corrected: `25000` → `45000` (actual default in `config/env.ts` / `recommendationPipeline.ts`)
- Removed `RECOMMENDATION_TIMEOUT_MS` from the env var table — this variable doesn't exist anywhere in the code
- Added missing `EVAL_DASHBOARD_PASSWORD` env var and the `/eval/events`, `/eval/metrics`, `/eval/baselines`, `/eval/feedback`, and `/preferences/turso/test` routes, which existed in code but weren't documented
- Noted that Turso now also backs the session/auth store (Phase 9.1), not just preferences
- Documented the `create-user` script for headless user creation
- Added `Contributing` and `Security` sections linking the existing `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md` (previously unreferenced from the README)
- Clarified that `MISTRAL_API_KEY` currently drives an **Anthropic Claude** API call, not Mistral (see below)

**docs/architecture/ARCHITECTURE.md**
- Same `MISTRAL_API_KEY` → Anthropic clarification, in the topology diagram, integrations table, evaluation-layer table, and design-decisions table
- Session store section now mentions the Turso adapter

**Root cause note — the Mistral/Claude mix-up:** commit `5942296` ("Switch LLM-as-Judge from Anthropic Claude to Mistral") renamed the config field and docs from `anthropicApiKey`/`ANTHROPIC_API_KEY` to `mistralApiKey`/`MISTRAL_API_KEY`, but `services/api/src/eval/judgeWorker.ts` and `app.ts` still call `https://api.anthropic.com/v1/messages` with model `claude-opus-4-8` — the actual HTTP call was never changed. Docs are now updated to describe what the code actually does rather than what it claims to do; the underlying code inconsistency itself is left untouched since this PR is documentation-only.

**.env.example**
- Removed a stray token that had been accidentally appended to the `CORS_ORIGIN=` line (introduced in the same commit above) — this would have broken the example if copied verbatim
- Fixed the `RESEARCH_TIMEOUT_MS` example default to match code
- Added `EVAL_DASHBOARD_PASSWORD` example line

**docs/ROADMAP.md**
- Fixed a route path typo in the backlog notes: `/preferences/auto-group` → `/preferences/groups/auto` (the actual route)
- Added a note to the Phase 8 Step 5 log clarifying the later env var rename

**CONTEXT.md**
- Updated the `Eval layer` / `LLM-as-judge` glossary entries to reference `MISTRAL_API_KEY` (with the same Anthropic clarification) instead of the now-unused `ANTHROPIC_API_KEY`

No code changes. No new Mermaid diagrams were added since README.md and ARCHITECTURE.md already each contain simple, accurate diagrams of the recommendation pipeline.

## Test plan

- [ ] Docs-only change — no functional tests apply
- [ ] Skim-read the updated README and ARCHITECTURE.md sections for accuracy against `services/api/src/config/env.ts`, `services/api/src/eval/judgeWorker.ts`, and `services/api/src/routes/registerBandsearchRoutes.ts`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01GzUJt9VmK2b2CDid6Yz6KH)_