### PR TITLE
chore: weekly maintenance 2026-08-05 — dependency updates + security audit

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -4,6 +4,167 @@ Weekly dependency and health checks for the Bandsearch application.
 
 ---
 
+## 2026-08-05
+
+### Correction / backlog note — please read first
+
+The task framing for this cycle carried forward two stale assumptions from before the session
+started; both were checked directly against the GitHub API and the repo tree before anything was
+touched, rather than propagated:
+
+1. **Open-PR backlog.** Framing assumed #96 (2026-07-22) and #97 (2026-07-29) were still open —
+   that part held up (verified via `list_pull_requests`, state=open): both are indeed still open
+   against `staging`, alongside #98 (docs, base `main`, unrelated). But #96's mergeable state is
+   now `dirty` (conflicts — `staging` has moved on to `dee443f` since #96's base `617d586`, 76
+   commits behind), while #97's is `clean` (still same tip as `staging`'s current head, since no
+   other maintenance PR has merged since). **Recommend closing #96 in favor of #97** (their
+   contents are near-duplicate weekly-maintenance diffs, and #96 would need a manual rebase to
+   even apply) **and merging #97**, then reviewing #98 separately.
+2. **"No Dependabot config and no weekly-audit workflow."** This is **no longer true** — both
+   `.github/dependabot.yml` (npm + cargo + uv + github-actions, all targeting `staging`) and
+   `.github/workflows/weekly-audit.yml` (npm audit + pip-audit + cargo-audit, opens/updates a
+   `security-audit`-labeled issue on findings) already exist on `staging`, added by the merged
+   PR #92 (2026-07-08 cycle) and referenced in the 2026-06-24/07-08/07-15 log entries below. Per
+   this cycle's instructions not to add Dependabot config: nothing was added — it's already
+   there — but the instructions' premise ("this manual PR cycle is the entire mechanism") is
+   stale and worth flagging so it isn't repeated again next week.
+
+### Checks performed
+- Verified the working branch (`claude/eloquent-volta-f8vh9h`) had zero unique commits versus
+  `origin/staging` (`git log claude/eloquent-volta-f8vh9h..origin/staging` showed 76 commits
+  behind; the reverse showed 0 ahead), then reset it to `origin/staging`'s tip (`dee443f`, the
+  merge of #95) before starting — the branch had been seeded stale, same situation as the
+  2026-07-15 cycle.
+- Baseline: `npm ci`, `npm run lint`, `npm run typecheck`, `npm run test`,
+  `npm --workspace @bandsearch/desktop run build` — all green before any changes.
+- `npm outdated` / `npm audit` across all workspaces (root, `apps/desktop`, `services/api`,
+  `services/eval`, `shared/schemas`).
+- Confirmed root `pyproject.toml` still declares `dependencies = []` and `uv.lock` resolves only
+  the `bandsearch` root package itself (`grep -c "^\[\[package\]\]" uv.lock` → 1) — nothing to
+  audit on the Python side, reconfirmed rather than assumed.
+- Installed `cargo-audit` (not cached in this sandbox) via `cargo install cargo-audit --locked`
+  in `apps/desktop/src-tauri` and ran `cargo audit`.
+- Inspected `apps/desktop/src-tauri/Cargo.lock` directly for `plist`/`quick-xml` versions before
+  touching anything.
+- `cargo update --dry-run` in `apps/desktop/src-tauri` for informational (non-security) Rust
+  bumps.
+- Attempted `cargo check` in `apps/desktop/src-tauri` (see Notes for the sandbox blocker hit).
+- Checked recent CI runs on `staging`-targeting PRs via the GitHub Actions API.
+- Re-ran the full baseline suite after applying updates.
+
+### CI health (staging)
+Most recent CI runs for PRs against `staging`/`main` are all `completed` / `success`, including
+#97's own run (`30484908285`, 2026-07-29) and #98's (`30493384140`, 2026-07-29). No red runs
+found in the recent history. GitHub's check-status API for #96 and #97's head commits currently
+reports no check-run contexts registered against the *commit itself* (`pending`/`total_count: 0`
+via `get_status`) — this is a quirk of how `get_status` reports GitHub Actions check-runs (as
+opposed to legacy commit statuses) rather than a sign CI didn't run; the Actions run history above
+confirms both PRs' CI completed successfully at the time they were opened.
+
+### Fixes applied
+
+- **Security fix — npm, high severity, applied.** Baseline `npm audit` found 2 high-severity
+  findings:
+  - `brace-expansion` `4.0.0 - 5.0.8` — DoS via unbounded expansion length / unbounded
+    intermediate arrays (transitive, via `eslint` → `minimatch`).
+  - `ip-address` `<=10.3.0` — leading-zero octet decoding mismatch (decimal vs. octal) and CIDR
+    suffix / IPv4-mapped IPv6 misclassification, enabling SSRF / trust-boundary bypass
+    (transitive, via `services/api`'s `express-rate-limit`).
+
+  `npm audit fix` resolved both cleanly — `brace-expansion` 5.0.7 → 5.0.9, `ip-address` 10.2.0 →
+  10.4.0 (via `express-rate-limit`'s own patch bump, see table below). Only `package-lock.json`
+  changed; no `package.json` edits needed anywhere. `npm audit` after: **0 vulnerabilities**.
+
+- **Rust — no security fix needed this cycle.** Inspected `Cargo.lock` before touching anything:
+  `plist 1.10.0` / `quick-xml 0.41.0` are already resolved (fixed via merged #94, 2026-07-15
+  cycle) — RUSTSEC-2026-0194/0195 remain fixed, confirmed not regressed. `cargo audit` found
+  **0 vulnerabilities**; only informational unmaintained/unsound warnings remain (see security
+  audit table below), same category as every prior cycle, no independent fix upstream.
+
+- **Safe npm updates** — `npm update` at root picked up in-range patch/minor bumps across all
+  workspaces (no `package.json` range changes required):
+
+  | Workspace | Package | Before | After |
+  |---|---|---|---|
+  | root | `eslint` | 10.6.0 | 10.8.0 |
+  | root | `@playwright/test` (+ `playwright`, `playwright-core`) | 1.61.1 | 1.62.1 |
+  | root | `typescript-eslint` (+ `@typescript-eslint/*` sub-packages) | 8.63.0 | 8.66.0 |
+  | root | `tsx` | 4.23.0 | 4.23.8 |
+  | root | `globals` | 17.7.0 | 17.9.0 |
+  | `apps/desktop` | `react` / `react-dom` | 19.2.7 | 19.2.8 |
+  | `services/api` | `@langchain/langgraph` (+ `-sdk`, `p-queue`) | 1.4.7 | 1.4.9 |
+  | `services/api` | `express-rate-limit` | 8.5.2 | 8.6.2 |
+  | `services/api` | `helmet` | 8.2.0 | 8.3.0 |
+  | transitive (security, see above) | `brace-expansion` | 5.0.7 | 5.0.9 |
+  | transitive (security, see above) | `ip-address` | 10.2.0 | 10.4.0 |
+  | transitive (various) | `@eslint/config-helpers`, `ignore` | — | patch bumps only |
+
+  `shared/schemas` had nothing outdated within range. `services/eval` had nothing outdated.
+  `apps/desktop` (beyond react/react-dom) had nothing else outdated.
+
+  **Rust**: `cargo update --dry-run` shows ~150 lines of available non-advisory patch/minor
+  bumps across the `tauri` 2.x family (`tauri 2.11.0→2.11.5`, `tauri-build`/`-codegen`/`-macros`/
+  `-plugin` `2.6.0→2.6.3`, `tauri-runtime 2.11.0→2.11.3`, `tauri-runtime-wry 2.11.0→2.11.4`,
+  `tauri-utils 2.9.0→2.9.3`, `wry 0.55.0→0.55.1`, `hyper 1.9.0→1.11.0`, `regex 1.12.3→1.13.1`,
+  etc., plus several crate additions/removals from transitive resolution churn). None are
+  security-driven, so — consistent with every prior cycle's "keep security-driven PRs minimal"
+  precedent — none applied; flagged for a future dedicated Rust-refresh cycle.
+
+### Majors — flagged, NOT applied
+
+| Package | Current | Latest | Why held back |
+|---|---|---|---|
+| `typescript` (root) | 6.0.3 | 7.0.2 | Major rewrite, flagged every cycle since 07-08; needs a dedicated compatibility pass across all 4 npm workspaces + `typescript-eslint`. |
+| `@types/node` (root) | 25.9.5 | 26.1.2 | Type-defs major ahead of `engines: ">=22"` / CI's pinned Node 22 — low risk but flagged per policy, unchanged from prior cycles. |
+| `better-sqlite3` (`services/api`) | 12.11.1 | 13.0.3 | Native-addon major, first flagged by #96 (12.11.1 → 13.0.1) and still pending — needs its own rebuild/verification pass, not a routine bump. |
+
+### Security audit results
+
+| Ecosystem | Tool | Result |
+|---|---|---|
+| npm (all workspaces) | `npm audit` | 2 high (`brace-expansion`, `ip-address`) → **0 after `npm audit fix`** |
+| Python | manual (`dependencies = []`, `uv.lock` has no third-party entries) | Nothing to audit, reconfirmed |
+| Rust | `cargo audit` (0.22.2, 493 crate deps scanned) | **0 vulnerabilities**. 19 informational unmaintained/unsound warnings (GTK3 `gtk-rs` bindings, `proc-macro-error`, `unic-char-*`/`unic-common`/`unic-ucd-*`, `anyhow` `Error::downcast_mut()` unsoundness, `event-listener` `!Send` unsoundness — new this cycle, `glib` iterator unsoundness) — one more than the 18 seen in prior cycles (`event-listener` RUSTSEC-2026-0221, dated 2026-07-13); no independent fix available, same "informational only, no advisory" category as every prior cycle. |
+
+### Rust dependency audit (informational, not applied)
+
+`cargo update --dry-run` in `apps/desktop/src-tauri` shows dozens of available non-security
+patch/minor bumps across the `tauri` 2.x crate family and its transitive dependencies (see Fixes
+applied above for representative examples). None correspond to a `cargo audit` finding, so none
+were applied this cycle — flagged for a future dedicated "Rust dependency refresh" cycle rather
+than folded into this security-focused pass, consistent with #96/#97's precedent.
+
+### Notes
+
+- **Lock file drift (pre-existing, not fixed this cycle, call for repo owner)** —
+  `package-lock.json` and `pnpm-lock.yaml` still coexist at the root. CI only reads
+  `package-lock.json` (`npm ci`). Not independently re-measured this cycle beyond confirming both
+  files still exist and diverge — per standing guidance this remains the repo owner's call, not
+  an agent's, and is flagged again rather than fixed.
+- **Rust build/test not verifiable in this sandbox this cycle** — `cargo check` in
+  `apps/desktop/src-tauri` fails here for a reason unrelated to today's dependency changes:
+  `gdk-sys`'s build script requires `gdk-3.0.pc` via pkg-config, and this sandbox has GTK3
+  runtime libraries but not the `-dev`/pkg-config files (`pkg-config --exists gdk-3.0` fails).
+  Attempted `apt-get install libgtk-3-dev libwebkit2gtk-4.1-dev` to close the gap — blocked by
+  404s from the Ubuntu package mirrors on several transitive packages (`libjavascriptcoregtk-4.1-dev`,
+  `libwebkit2gtk-4.1-0/-dev`, `libnghttp2-dev`, `libgdk-pixbuf-2.0-dev`, etc.), same category of
+  environment limitation as the 2026-07-22 cycle (mirror-blocked), not the 2026-07-29 cycle's
+  (that cycle had the dev headers already present and hit the sidecar-symlink issue instead — see
+  below). Also confirmed the tracked `apps/desktop/src-tauri/binaries/node-x86_64-unknown-linux-gnu`
+  sidecar symlink is still broken in this sandbox (`-> /usr/bin/node`, which doesn't exist here;
+  real node is at `/opt/node22/bin/node`) — but since the GTK3 pkg-config gap fails the build
+  before the sidecar step is ever reached, there was nothing to gain from temporarily repointing
+  it this cycle, so it was left untouched (not staged, not modified). CI has no `cargo check`/
+  `cargo test` step currently (Rust coverage is `cargo-audit`-via-`weekly-audit.yml` plus
+  Dependabot only) — recommend a real `cargo check`/`cargo test` pass outside this sandbox (or in
+  CI, if a Rust job is ever added) before merging, same recommendation as 2026-07-22.
+- Re-ran `npm run lint`, `npm run typecheck`, `npm run test` (all workspaces), and
+  `apps/desktop`'s `npm --workspace @bandsearch/desktop run build` after every dependency change
+  — all still green, identical pass counts to baseline: **678/678 tests** (desktop 221/222 pass +
+  1 pre-existing skip, api 423/423, eval 16/16, schemas 17/17); lint and typecheck clean.
+
+---
+
 ## 2026-07-15
 
 ### Checks performed

--- a/package-lock.json
+++ b/package-lock.json
@@ -541,9 +541,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -721,13 +721,13 @@
       }
     },
     "node_modules/@langchain/langgraph": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.4.7.tgz",
-      "integrity": "sha512-2tcyf3QGC7v89kqSxMCtRvzg/3L/4yHtOaWC49A8KieCciWJs7LGaxHoPB6QRxXyUgyR+Zg9Q1ss/XJIE+JuSQ==",
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.4.9.tgz",
+      "integrity": "sha512-EvD9rS66Cya09y6rbMgD3Ir8miAkJQFo7FyJOPRPO736Kz3y5TeyeBDOS8ctff/jRc788bPijHx2NVFM79Qqig==",
       "license": "MIT",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.3",
-        "@langchain/langgraph-sdk": "~1.9.25",
+        "@langchain/langgraph-sdk": "~1.9.28",
         "@langchain/protocol": "^0.0.18",
         "@standard-schema/spec": "1.1.0"
       },
@@ -752,9 +752,9 @@
       }
     },
     "node_modules/@langchain/langgraph-sdk": {
-      "version": "1.9.25",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.25.tgz",
-      "integrity": "sha512-mRKW8zyQUaHox+HirRFMRrPqOvNbQI3xeXDt6kkk4PbBg77V92bsO1WzUVNrmJ81zCkvxyOrWSK8D6ioCj0a8A==",
+      "version": "1.9.28",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.28.tgz",
+      "integrity": "sha512-4j3XuM0PvtmAbL8mPfBS99ez3+ytRfgbOpAR/nOeaejTRF3Q9dNw2QnaGLGng8wLPtGLoSj+SYgUOVxy9Bv9vg==",
       "license": "MIT",
       "dependencies": {
         "@langchain/protocol": "^0.0.18",
@@ -791,9 +791,9 @@
       "license": "MIT"
     },
     "node_modules/@langchain/langgraph-sdk/node_modules/p-queue": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.1.tgz",
-      "integrity": "sha512-POWdiIPmsUPGwb4FeQ4OBg46aqmcInSWe45CKDsGHiOBiVQM9chqfQTuqhuTzcg2Vz9faTI65at0KkVyVEiCHw==",
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.3.tgz",
+      "integrity": "sha512-NXAOdnEe5FsZJfT4oK84lE1Y5cFFdWlRuOo5tww8DyNMxyRXwn39fIkUtNLKppcPC+UYU/bXujNCUGDv01y7CA==",
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "^5.0.4",
@@ -990,19 +990,19 @@
       "license": "MIT"
     },
     "node_modules/@playwright/test": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
-      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.61.1"
+        "playwright": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@standard-schema/spec": {
@@ -1365,17 +1365,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.63.0.tgz",
-      "integrity": "sha512-rvwSgqT+DHpWdzfSzPatRLm02a0GlESt++9iy3hLCDY4BgkaLcl8LBi9Yh7XGFBpwcBE/K3024QuXWTpbz4FfQ==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.66.0.tgz",
+      "integrity": "sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.63.0",
-        "@typescript-eslint/type-utils": "8.63.0",
-        "@typescript-eslint/utils": "8.63.0",
-        "@typescript-eslint/visitor-keys": "8.63.0",
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/type-utils": "8.66.0",
+        "@typescript-eslint/utils": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -1388,15 +1388,15 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.63.0",
+        "@typescript-eslint/parser": "^8.66.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1404,16 +1404,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.63.0.tgz",
-      "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.66.0.tgz",
+      "integrity": "sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.63.0",
-        "@typescript-eslint/types": "8.63.0",
-        "@typescript-eslint/typescript-estree": "8.63.0",
-        "@typescript-eslint/visitor-keys": "8.63.0",
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1429,14 +1429,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.63.0.tgz",
-      "integrity": "sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.66.0.tgz",
+      "integrity": "sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.63.0",
-        "@typescript-eslint/types": "^8.63.0",
+        "@typescript-eslint/tsconfig-utils": "^8.66.0",
+        "@typescript-eslint/types": "^8.66.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1451,14 +1451,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.63.0.tgz",
-      "integrity": "sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.66.0.tgz",
+      "integrity": "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.63.0",
-        "@typescript-eslint/visitor-keys": "8.63.0"
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1469,9 +1469,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.63.0.tgz",
-      "integrity": "sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.66.0.tgz",
+      "integrity": "sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1486,15 +1486,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.63.0.tgz",
-      "integrity": "sha512-Nzzh/OGxVCOjObjaj1CQF2RUasyYy2Jfuh+zZ3PjLzG2fYRriAiZLib9UKtO+CpQAS3YHiAS+ckZDclwqI1TPA==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.66.0.tgz",
+      "integrity": "sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.63.0",
-        "@typescript-eslint/typescript-estree": "8.63.0",
-        "@typescript-eslint/utils": "8.63.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0",
+        "@typescript-eslint/utils": "8.66.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -1511,9 +1511,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.63.0.tgz",
-      "integrity": "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.66.0.tgz",
+      "integrity": "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1525,16 +1525,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.63.0.tgz",
-      "integrity": "sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.66.0.tgz",
+      "integrity": "sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.63.0",
-        "@typescript-eslint/tsconfig-utils": "8.63.0",
-        "@typescript-eslint/types": "8.63.0",
-        "@typescript-eslint/visitor-keys": "8.63.0",
+        "@typescript-eslint/project-service": "8.66.0",
+        "@typescript-eslint/tsconfig-utils": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/visitor-keys": "8.66.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -1553,16 +1553,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.63.0.tgz",
-      "integrity": "sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.66.0.tgz",
+      "integrity": "sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.63.0",
-        "@typescript-eslint/types": "8.63.0",
-        "@typescript-eslint/typescript-estree": "8.63.0"
+        "@typescript-eslint/scope-manager": "8.66.0",
+        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1577,13 +1577,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.63.0.tgz",
-      "integrity": "sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.66.0.tgz",
+      "integrity": "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/types": "8.66.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -1758,16 +1758,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer": {
@@ -2132,9 +2132,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
-      "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
+      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -2144,7 +2144,7 @@
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/config-helpers": "^0.7.0",
         "@eslint/core": "^1.2.1",
         "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
@@ -2168,7 +2168,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "minimatch": "^10.2.4",
+        "minimatch": "^10.2.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -2355,11 +2355,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
-      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
       "license": "MIT",
       "dependencies": {
+        "debug": "^4.4.3",
         "ip-address": "^10.2.0"
       },
       "engines": {
@@ -2594,9 +2595,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.7.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
-      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
+      "version": "17.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.9.0.tgz",
+      "integrity": "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2643,9 +2644,9 @@
       }
     },
     "node_modules/helmet": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.2.0.tgz",
-      "integrity": "sha512-DRgTIUgnWcJ62KyarxxziuqYxKGnR6Rgg19BlbucN/dpmJbl1XOit6qvoOX0ZT+HhWe5OUVhU/a1zpGyc1xA0Q==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.3.0.tgz",
+      "integrity": "sha512-Qgpiaws3Sm30Av8Eah6sjMCZZwjlBu+E68rhpCWBshY1lb09HtLwj5GviX0OyQIn+ulUS0iX0AxN5n3tLZzz1w==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -2759,9 +2760,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -3489,35 +3490,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
-      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.1"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
-      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/postgres-array": {
@@ -3695,24 +3696,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.7"
+        "react": "^19.2.8"
       }
     },
     "node_modules/readable-stream": {
@@ -4084,9 +4085,9 @@
       }
     },
     "node_modules/tsx": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
-      "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+      "version": "4.23.8",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.8.tgz",
+      "integrity": "sha512-8W675THjbzfFmLOQzjDBIBna+WjqMGIxmSZ1mMc1+o9qoVsEuAgQu5j5ueLhau8inOkDu9OslVg0FmfBs1RIHw==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.28.0"
@@ -4186,16 +4187,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.63.0.tgz",
-      "integrity": "sha512-xgwXyzG4sK9ALkBxbyGkTMMOS+imnW65iPhxCQMK83KhxyoDNW7l+IDqEf9vMdoUidHpOoS967RCq4eMiTexwQ==",
+      "version": "8.66.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.66.0.tgz",
+      "integrity": "sha512-QlEbBPz/RuJ1XUHj29nm3t0F/O/cSlEnntozqPOYHnnTGAXFamnMBu5i9Vn6vhUPHGAjR+Vl+5J8vPN/BMUrJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.63.0",
-        "@typescript-eslint/parser": "8.63.0",
-        "@typescript-eslint/typescript-estree": "8.63.0",
-        "@typescript-eslint/utils": "8.63.0"
+        "@typescript-eslint/eslint-plugin": "8.66.0",
+        "@typescript-eslint/parser": "8.66.0",
+        "@typescript-eslint/typescript-estree": "8.66.0",
+        "@typescript-eslint/utils": "8.66.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"


### PR DESCRIPTION
## ⚠️ Two stale assumptions in this cycle's framing — corrected up front

1. **Backlog status of #96/#97.** Both are confirmed still **open** via `list_pull_requests`
   (state=open). But #96's `mergeable_state` is now **`dirty`** — its base (`617d586`) is 76
   commits behind current `staging` (`dee443f`), so it conflicts and would need a manual rebase.
   #97's `mergeable_state` is **`clean`** — its base is `staging`'s current tip (no maintenance PR
   has merged since it opened). **Recommend closing #96 in favor of #97** (near-duplicate weekly
   diffs) **and merging #97**, then separately reviewing #98 (docs, base `main`, unrelated).
2. **"No Dependabot config / no weekly-audit workflow exists."** This is **no longer accurate**.
   Both `.github/dependabot.yml` (npm + cargo + uv + github-actions, all → `staging`) and
   `.github/workflows/weekly-audit.yml` (npm audit + pip-audit + cargo-audit, opens/updates a
   `security-audit` issue) already exist on `staging` — added by the merged PR #92 (2026-07-08
   cycle). Nothing was added this cycle (there was nothing missing to add), but flagging so this
   premise isn't carried into next week's cycle again.

## Working branch

Reset `claude/eloquent-volta-f8vh9h` to `origin/staging`'s tip (`dee443f`) before starting —
verified via `git log claude/eloquent-volta-f8vh9h..origin/staging` (76 behind) and the reverse
(0 ahead), so the reset preserved no unique work.

## Baseline (before changes, on `staging` tip `dee443f`, the merge of #95)
- `npm ci` — clean install
- `npm run lint` / `npm run typecheck` — clean, all workspaces
- `npm run test` — **678/678** (677 pass + 1 pre-existing skip, 0 fail): desktop 221/222+1 skip, api 423, eval 16, schemas 17 — matches every prior cycle's baseline
- `npm --workspace @bandsearch/desktop run build` — succeeds
- `npm audit` — 2 high: `brace-expansion` (DoS, unbounded expansion/intermediate arrays), `ip-address` (leading-zero octet decimal/octal mismatch + CIDR/IPv4-mapped-IPv6 misclassification → SSRF/trust-boundary bypass)
- `cargo audit` (`apps/desktop/src-tauri`) — installed `cargo-audit 0.22.2` from source (`cargo install cargo-audit --locked`) — **0 vulnerabilities**; 19 informational unmaintained/unsound warnings (one more than prior cycles' 18 — new: `event-listener` RUSTSEC-2026-0221, `!Send` unsoundness, dated 2026-07-13)
- Python (`dependencies = []`, `uv.lock` resolves only the root package, 1 entry) — nothing to audit, reconfirmed directly

## Security fixes applied

**npm (high severity, both resolved):**
| Finding | Package | Before | After |
|---|---|---|---|
| DoS via unbounded expansion/intermediate arrays | `brace-expansion` | 5.0.7 | 5.0.9 |
| SSRF/trust-boundary bypass (octal/decimal + CIDR/IPv4-mapped misclassification) | `ip-address` | 10.2.0 | 10.4.0 |

`npm audit fix` resolved both cleanly — only `package-lock.json` changed, no `package.json` range edits. `npm audit` after: **0 vulnerabilities**.

**Rust — no fix needed.** Checked `Cargo.lock` before touching anything: `plist 1.10.0` / `quick-xml 0.41.0` already resolved (landed via merged #94) — RUSTSEC-2026-0194/0195 remain fixed, confirmed not regressed. `cargo audit`: 0 vulnerabilities.

## Dependency updates (`npm update`, safe patch/minor)

| Workspace | Package | Before | After |
|---|---|---|---|
| root | `eslint` | 10.6.0 | 10.8.0 |
| root | `@playwright/test` (+ `playwright`, `playwright-core`) | 1.61.1 | 1.62.1 |
| root | `typescript-eslint` (+ `@typescript-eslint/*`) | 8.63.0 | 8.66.0 |
| root | `tsx` | 4.23.0 | 4.23.8 |
| root | `globals` | 17.7.0 | 17.9.0 |
| `apps/desktop` | `react` / `react-dom` | 19.2.7 | 19.2.8 |
| `services/api` | `@langchain/langgraph` (+ `-sdk`, `p-queue`) | 1.4.7 | 1.4.9 |
| `services/api` | `express-rate-limit` | 8.5.2 | 8.6.2 |
| `services/api` | `helmet` | 8.2.0 | 8.3.0 |
| transitive (security) | `brace-expansion`, `ip-address` | — | see table above |

`shared/schemas` and `services/eval`: nothing outdated within range. No `package.json` edits anywhere — only `package-lock.json`.

**Rust**: `cargo update --dry-run` shows ~150 lines of available non-advisory bumps across the `tauri` 2.x family (`tauri 2.11.0→2.11.5`, `tauri-build/-codegen/-macros/-plugin 2.6.0→2.6.3`, `tauri-runtime 2.11.0→2.11.3`, `wry 0.55.0→0.55.1`, `hyper 1.9.0→1.11.0`, `regex 1.12.3→1.13.1`, etc.). None security-driven — none applied, consistent with #96/#97's "keep security PRs minimal" precedent. Flagged for a future dedicated Rust-refresh cycle.

## Majors flagged — NOT applied

| Package | Current | Latest | Why held back |
|---|---|---|---|
| `typescript` (root) | 6.0.3 | 7.0.2 | Major rewrite, flagged every cycle since 07-08; needs a dedicated compatibility pass across all 4 npm workspaces + `typescript-eslint`. |
| `@types/node` (root) | 25.9.5 | 26.1.2 | Ahead of `engines: ">=22"` / CI's pinned Node 22 — low risk but flagged per policy. |
| `better-sqlite3` (`services/api`) | 12.11.1 | 13.0.3 | Native-addon major, first flagged by #96 and still pending — needs its own rebuild/verification pass. |

## Security audit summary

| Ecosystem | Tool | Result |
|---|---|---|
| npm (all workspaces) | `npm audit` | 2 high → **0 after `npm audit fix`** |
| Python | manual (`dependencies = []`) | Nothing to audit |
| Rust | `cargo audit` (493 crates scanned) | **0 vulnerabilities**; 19 informational warnings (unmaintained GTK3 bindings/`proc-macro-error`/`unic-*`, unsound `anyhow`/`event-listener`/`glib`), unchanged in kind from prior cycles |

## Known issue — dual lock files (not fixed, flagging again)

`package-lock.json` + `pnpm-lock.yaml` still coexist. CI uses `npm ci` (`package-lock.json` only). Not independently re-measured this cycle beyond confirming both still exist — remains the repo owner's call, not an agent's.

## Rust build/test — not verifiable in this sandbox this cycle

`cargo check` fails at the `gdk-sys` build script: `gdk-3.0.pc` isn't found via pkg-config (GTK3 runtime libs present, `-dev`/pkg-config files are not). Attempted `apt-get install libgtk-3-dev libwebkit2gtk-4.1-dev` — blocked by 404s from the Ubuntu mirrors on several transitive packages, same category of environment limitation as the 2026-07-22 cycle (mirror-blocked), not the 2026-07-29 cycle (which had headers present and hit the sidecar-symlink issue instead). Also reconfirmed the tracked `apps/desktop/src-tauri/binaries/node-x86_64-unknown-linux-gnu` sidecar symlink is still broken here (`-> /usr/bin/node`, doesn't exist; real node is `/opt/node22/bin/node`) — but since the GTK3 pkg-config gap fails the build before that step is reached, there was nothing to gain from repointing it this cycle, so it was left untouched. CI has no `cargo check`/`cargo test` step currently (Rust coverage is `cargo-audit` via `weekly-audit.yml` + Dependabot only) — recommend a real pass outside this sandbox before merging.

## Post-change verification

Re-ran the full baseline after all changes — identical to pre-change baseline: lint clean, typecheck clean, **678/678 tests** (same breakdown), desktop build succeeds, `npm audit` 0 vulnerabilities, `cargo audit` 0 vulnerabilities (19 informational warnings unchanged). Husky pre-commit hook (`npm run ci`) passed on the commit.

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` (678/678, all workspaces)
- [x] `apps/desktop` `npm run build`
- [x] `npm audit` — 0 vulnerabilities after `npm audit fix`
- [x] `cargo audit` — 0 vulnerabilities
- [ ] `cargo check` / `cargo test` — not verifiable in this sandbox this cycle (GTK3 pkg-config gap, mirror-blocked); recommend running on a full dev machine or in CI before merge
- [x] Python — confirmed nothing to audit
- [x] Husky pre-commit hook passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01TGLb8ADjwbdRMe8e6GYuv9)_