### PR TITLE
fix(desktop): make lint and typecheck actually cover this workspace

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Tauri + React desktop client",
   "scripts": {
-    "lint": "eslint \"src/**/*.js\" --max-warnings=0 --no-error-on-unmatched-pattern",
+    "lint": "eslint \"src/**/*.{js,ts}\" \"test/**/*.{js,ts}\" \"scripts/**/*.js\" --max-warnings=0 --no-error-on-unmatched-pattern",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "test": "tsx --test",
     "build": "node scripts/build.js",

--- a/apps/desktop/scripts/build.js
+++ b/apps/desktop/scripts/build.js
@@ -1,6 +1,7 @@
 const esbuild = require("esbuild");
 const fs = require("node:fs");
 
+/** @type {import("esbuild").BuildOptions} */
 const config = {
   entryPoints: ["./src/browserEntry.ts"],
   bundle: true,

--- a/apps/desktop/src/bootstrapDesktopApp.ts
+++ b/apps/desktop/src/bootstrapDesktopApp.ts
@@ -1,3 +1,5 @@
+import type { SavedBand } from "./domain.js";
+import type { ChatMessage } from "./chatClient.js";
 import {
   createChatClient,
   createInitialChatState,
@@ -7,7 +9,14 @@ import {
 
 const VALID_VIEWS = ["chat", "saved-artists"];
 
-function buildPriorityContext(savedBands: any[], selectedArtistIds: string[]): string {
+type DesktopAppState = {
+  messages: ChatMessage[];
+  savedBands: SavedBand[];
+  selectedArtistIds: string[];
+  currentSessionId: string | null;
+};
+
+function buildPriorityContext(savedBands: SavedBand[], selectedArtistIds: string[]): string {
   if (!selectedArtistIds.length) return "";
   const selected = savedBands.filter((b) => selectedArtistIds.includes(b.id));
   if (!selected.length) return "";
@@ -27,20 +36,25 @@ export function bootstrapDesktopApp({
   getToken = null,
 }: BootstrapDesktopAppOptions = {}) {
   const chatClient = createChatClient({ apiBaseUrl, fetchImpl: fetchImpl ?? fetch, getToken });
-  let state: any = { ...createInitialChatState(), savedBands: [], selectedArtistIds: [], currentSessionId: null };
+  let state: DesktopAppState = {
+    ...createInitialChatState(),
+    savedBands: [],
+    selectedArtistIds: [],
+    currentSessionId: null,
+  };
   let currentView = "chat";
   let pendingSelectedArtistIds: string[] = [];
   let currentAbortController: AbortController | null = null;
 
   function findLatestRecommendationByName(artistName: string) {
     const messages = state.messages || [];
-    const latestAssistant = [...messages].reverse().find((m: any) => m.role === "assistant");
+    const latestAssistant = [...messages].reverse().find((m) => m.role === "assistant");
     const recommendations = latestAssistant?.recommendations || [];
-    return recommendations.find((item: any) => item.artist === artistName);
+    return recommendations.find((item) => item.artist === artistName);
   }
 
-  function upsertSavedBand(savedBand: any) {
-    const existingIndex = state.savedBands.findIndex((item: any) => item.id === savedBand.id);
+  function upsertSavedBand(savedBand: SavedBand) {
+    const existingIndex = state.savedBands.findIndex((item) => item.id === savedBand.id);
     if (existingIndex >= 0) {
       const nextSavedBands = [...state.savedBands];
       nextSavedBands[existingIndex] = savedBand;
@@ -61,12 +75,12 @@ export function bootstrapDesktopApp({
       pendingSelectedArtistIds = Array.isArray(ids) ? [...ids] : [];
     },
     async startSession(title = "Untitled") {
-      const result = await chatClient.createSession(title) as any;
+      const result = await chatClient.createSession(title);
       state = { ...state, currentSessionId: result.session.id };
       return result.session;
     },
     async listSessions() {
-      const result = await chatClient.listSessions() as any;
+      const result = await chatClient.listSessions();
       return result.sessions;
     },
     async requestRecommendations(query: string, mode = "fresh", obscurityTarget?: string) {
@@ -75,14 +89,14 @@ export function bootstrapDesktopApp({
       if (pendingSelectedArtistIds.length > 0) pendingSelectedArtistIds = [];
       let priorityContext = buildPriorityContext(state.savedBands, effectiveIds);
       if (mode === "preference-aware" && effectiveIds.length > 0) priorityContext = "";
-      const conversationHistory = (state.messages || []).flatMap((m: any) => {
+      const conversationHistory = (state.messages || []).flatMap((m) => {
         if (m.role === "user") return [{ role: "user", content: m.content }];
         if (m.role === "assistant") {
           const text =
             typeof m.content === "string" && m.content.trim()
               ? m.content
               : m.recommendations
-                ? m.recommendations.map((r: any) => r.artist).join(", ")
+                ? m.recommendations.map((r) => r.artist).join(", ")
                 : "";
           return [{ role: "assistant", content: text }];
         }
@@ -95,7 +109,7 @@ export function bootstrapDesktopApp({
         const result = await chatClient.fetchRecommendations(
           query, mode, priorityContext, conversationHistory, effectiveIds, obscurityTarget, controller.signal,
         );
-        state = applyAssistantMessage(state, result as any);
+        state = applyAssistantMessage(state, result);
         return result;
       } catch (error) {
         if ((error as Error).name === "AbortError") {
@@ -133,14 +147,14 @@ export function bootstrapDesktopApp({
         categories: options.categories || [],
         note: options.note || recommendation?.why || "Saved from recommendation card.",
       };
-      const result = await chatClient.createPreference(payload) as any;
+      const result = await chatClient.createPreference(payload);
       upsertSavedBand(result.savedBand);
       return result.savedBand;
     },
     async rateBand(artistName: string, rating = 5) {
-      let savedBand = state.savedBands.find((item: any) => item.name === artistName);
+      let savedBand = state.savedBands.find((item) => item.name === artistName);
       if (!savedBand) savedBand = await this.saveBand(artistName, { rating });
-      const result = await chatClient.updatePreference(savedBand.id, { rating }) as any;
+      const result = await chatClient.updatePreference(savedBand.id, { rating });
       upsertSavedBand(result.savedBand);
       return result.savedBand;
     },
@@ -151,10 +165,10 @@ export function bootstrapDesktopApp({
     },
     async deleteSavedBand(id: string) {
       await chatClient.deletePreference(id);
-      state = { ...state, savedBands: state.savedBands.filter((b: any) => b.id !== id) };
+      state = { ...state, savedBands: state.savedBands.filter((b) => b.id !== id) };
     },
     async searchArtists(query: string) {
-      const result = await chatClient.searchArtists(query) as any;
+      const result = await chatClient.searchArtists(query);
       return result.artists || [];
     },
     async exportPreferences() {

--- a/apps/desktop/src/browserEntry.ts
+++ b/apps/desktop/src/browserEntry.ts
@@ -1,13 +1,14 @@
 import { startDesktopBrowserApp } from "./startDesktopBrowserApp.js";
+import type { StartDesktopBrowserAppOptions } from "./startDesktopBrowserApp.js";
 
 function canAutoBoot(): boolean {
-  return typeof globalThis !== "undefined" && !!(globalThis as any).document;
+  return typeof globalThis !== "undefined" && !!globalThis.document;
 }
 
-export function bootBrowserDesktopApp(options: Record<string, any> = {}): any {
+export function bootBrowserDesktopApp(options: StartDesktopBrowserAppOptions = {}) {
   const p = startDesktopBrowserApp(options);
-  if (p && typeof (p as any).catch === "function") {
-    void (p as any).catch((err: unknown) => {
+  if (p && typeof p.catch === "function") {
+    void p.catch((err: unknown) => {
       console.error("[bandsearch] boot failed", err);
     });
   }
@@ -15,7 +16,7 @@ export function bootBrowserDesktopApp(options: Record<string, any> = {}): any {
 }
 
 if (canAutoBoot()) {
-  const doc = (globalThis as any).document;
+  const doc = globalThis.document;
   if (doc.readyState === "loading") {
     doc.addEventListener("DOMContentLoaded", () => {
       void bootBrowserDesktopApp();

--- a/apps/desktop/src/chatAppModel.ts
+++ b/apps/desktop/src/chatAppModel.ts
@@ -1,3 +1,12 @@
+import type {
+  RecommendationItem,
+  RecommendationMeta,
+  SavedBand,
+  ChatStateMessage,
+} from "./domain.js";
+
+export type { RecommendationItem, RecommendationMeta, SavedBand, ChatStateMessage };
+
 export type RenderableRecommendation = {
   title: string;
   why: string;
@@ -17,8 +26,23 @@ export type ConversationMessage =
 
 export type ChatAppModel = ReturnType<typeof createChatAppModel>;
 
-function toRenderableRecommendation(item: any, savedBands: any[]): RenderableRecommendation {
-  const savedBand = savedBands.find((s: any) => s.name === item.artist) ?? null;
+/** The slice of the bootstrapped app this model drives. */
+export type ChatAppCollaborator = {
+  requestRecommendations(
+    query: string,
+    mode: string,
+    obscurityTarget: string | undefined,
+  ): Promise<{ meta?: RecommendationMeta } | undefined>;
+  sendFeedback?(eventId: string, feedbackType: string): Promise<unknown>;
+  getState(): { messages?: ChatStateMessage[]; savedBands?: SavedBand[] };
+  cancelSearch?(): void;
+};
+
+function toRenderableRecommendation(
+  item: RecommendationItem,
+  savedBands: SavedBand[],
+): RenderableRecommendation {
+  const savedBand = savedBands.find((s) => s.name === item.artist) ?? null;
   return {
     title: item.artist,
     why: item.why || "",
@@ -33,12 +57,12 @@ function toRenderableRecommendation(item: any, savedBands: any[]): RenderableRec
   };
 }
 
-export function createChatAppModel({ app }: { app: any }) {
+export function createChatAppModel({ app }: { app: ChatAppCollaborator }) {
   let mode = "fresh";
   let obscurityTarget: string | undefined = "underground";
   let loadingState = false;
   let lastQuery = "";
-  let lastMeta: { modeUsed: string; usedPreferenceContext: boolean; eventId?: string } = {
+  let lastMeta: RecommendationMeta = {
     modeUsed: "fresh",
     usedPreferenceContext: false,
   };
@@ -51,7 +75,7 @@ export function createChatAppModel({ app }: { app: any }) {
     feedbackDismissed = false;
     loadingState = true;
     try {
-      const response = await app.requestRecommendations(query, mode, obscurityTarget) as any;
+      const response = await app.requestRecommendations(query, mode, obscurityTarget);
       lastMeta = response.meta ?? lastMeta;
       return response;
     } catch (error) {
@@ -100,12 +124,12 @@ export function createChatAppModel({ app }: { app: any }) {
       feedbackDismissed = true;
       const eventId = lastMeta.eventId;
       if (!eventId) return;
-      await app.sendFeedback(eventId, feedbackType);
+      await app.sendFeedback?.(eventId, feedbackType);
     },
     getConversation(): ConversationMessage[] | null {
       const appState = app.getState();
-      const messages: any[] = appState.messages || [];
-      const savedBands: any[] = appState.savedBands || [];
+      const messages: ChatStateMessage[] = appState.messages || [];
+      const savedBands: SavedBand[] = appState.savedBands || [];
       if (messages.length === 0) return null;
 
       const conversation: ConversationMessage[] = [];
@@ -115,7 +139,7 @@ export function createChatAppModel({ app }: { app: any }) {
           conversation.push({ id: `user-${i}`, role: "user", content: msg.content || "" });
         } else if (msg.role === "assistant") {
           const cards = (Array.isArray(msg.recommendations) ? msg.recommendations : []).map(
-            (item: any) => toRenderableRecommendation(item, savedBands),
+            (item) => toRenderableRecommendation(item, savedBands),
           );
           conversation.push({
             id: `assistant-${i}`,

--- a/apps/desktop/src/chatClient.ts
+++ b/apps/desktop/src/chatClient.ts
@@ -1,3 +1,12 @@
+import type {
+  ArtistGroup,
+  ArtistSearchResult,
+  ChatSession,
+  RecommendationItem,
+  RecommendationMeta,
+  RecommendationResponse,
+  SavedBand,
+} from "./domain.js";
 export class BandsearchHttpError extends Error {
   status?: number;
   code?: string;
@@ -73,7 +82,7 @@ export function createChatClient({ apiBaseUrl, fetchImpl = fetch, getToken = nul
         signal,
       });
       await ensureOk(response);
-      return response.json();
+      return response.json() as Promise<RecommendationResponse>;
     },
 
     async sendFeedback(eventId: string, feedbackType: string) {
@@ -109,7 +118,7 @@ export function createChatClient({ apiBaseUrl, fetchImpl = fetch, getToken = nul
     async listPreferences() {
       const response = await fetchImpl(`${baseUrl}/preferences`, { method: "GET", headers: jsonHeaders() });
       await ensureOk(response);
-      const data = await response.json() as { savedBands?: unknown[] };
+      const data = await response.json() as { savedBands?: SavedBand[] };
       return data.savedBands || [];
     },
 
@@ -125,7 +134,7 @@ export function createChatClient({ apiBaseUrl, fetchImpl = fetch, getToken = nul
     async fetchSavedBands() {
       const response = await fetchImpl(`${baseUrl}/preferences`, { method: "GET", headers: jsonHeaders() });
       await ensureOk(response);
-      return response.json();
+      return response.json() as Promise<{ savedBands: SavedBand[] }>;
     },
 
     async searchArtists(query: string) {
@@ -134,7 +143,7 @@ export function createChatClient({ apiBaseUrl, fetchImpl = fetch, getToken = nul
         { headers: jsonHeaders() },
       );
       await ensureOk(response);
-      return response.json();
+      return response.json() as Promise<{ artists: ArtistSearchResult[] }>;
     },
 
     async createSession(title = "Untitled") {
@@ -144,13 +153,13 @@ export function createChatClient({ apiBaseUrl, fetchImpl = fetch, getToken = nul
         body: JSON.stringify({ title }),
       });
       await ensureOk(response);
-      return response.json();
+      return response.json() as Promise<{ session: ChatSession }>;
     },
 
     async listSessions() {
       const response = await fetchImpl(`${baseUrl}/sessions`, { method: "GET", headers: jsonHeaders() });
       await ensureOk(response);
-      return response.json();
+      return response.json() as Promise<{ sessions: ChatSession[] }>;
     },
 
     async appendSessionMessage(sessionId: string, message: unknown) {
@@ -182,7 +191,7 @@ export function createChatClient({ apiBaseUrl, fetchImpl = fetch, getToken = nul
     async listGroups() {
       const response = await fetchImpl(`${baseUrl}/preferences/groups`, { method: "GET", headers: jsonHeaders() });
       await ensureOk(response);
-      const data = await response.json() as { groups?: unknown[] };
+      const data = await response.json() as { groups?: ArtistGroup[] };
       return data.groups || [];
     },
 
@@ -211,7 +220,7 @@ export function createChatClient({ apiBaseUrl, fetchImpl = fetch, getToken = nul
         headers: jsonHeaders(),
       });
       await ensureOk(response);
-      const data = await response.json() as { groups?: unknown[] };
+      const data = await response.json() as { groups?: ArtistGroup[] };
       return data.groups || [];
     },
   };
@@ -219,16 +228,24 @@ export function createChatClient({ apiBaseUrl, fetchImpl = fetch, getToken = nul
 
 export type ChatClient = ReturnType<typeof createChatClient>;
 
-export type ChatMessage = { role: "user" | "assistant"; content: string; recommendations?: unknown[]; meta?: unknown };
+export type ChatMessage = {
+  role: "user" | "assistant";
+  content: string;
+  recommendations?: RecommendationItem[];
+  meta?: RecommendationMeta;
+};
 export type ChatState = { messages: ChatMessage[]; savedBands: unknown[]; selectedArtistIds: string[]; currentSessionId: string | null };
 
 export function createInitialChatState(): Pick<ChatState, "messages"> {
   return { messages: [] };
 }
 
-export function buildLocalAssistantFallback(recommendations: unknown[], queryHint = ""): string {
+export function buildLocalAssistantFallback(
+  recommendations: RecommendationItem[],
+  queryHint = "",
+): string {
   const names = Array.isArray(recommendations)
-    ? recommendations.map((r: any) => r && r.artist).filter((n: unknown) => typeof n === "string" && (n as string).trim())
+    ? recommendations.map((r) => r && r.artist).filter((n) => typeof n === "string" && n.trim())
     : [];
   const tail = names.length
     ? `: ${names.slice(0, 3).join(", ")}. Want to go heavier or softer, or narrow the era or region next?`
@@ -238,20 +255,25 @@ export function buildLocalAssistantFallback(recommendations: unknown[], queryHin
   return `${head}${tail}`;
 }
 
-export function applyAssistantMessage(state: ChatState, recommendationResponse: Record<string, unknown>): ChatState {
-  let assistantReply =
-    typeof recommendationResponse.assistantReply === "string" ? recommendationResponse.assistantReply.trim() : "";
+// Only `messages` is read; everything else is passed through untouched. Taking
+// the narrower shape lets callers hand over the result of
+// createInitialChatState(), which does not carry the rest of ChatState yet.
+export function applyAssistantMessage<S extends Pick<ChatState, "messages">>(
+  state: S,
+  recommendationResponse: RecommendationResponse,
+): S {
+  let assistantReply = recommendationResponse.assistantReply?.trim() ?? "";
   if (!assistantReply && Array.isArray(recommendationResponse.recommendations)) {
     const lastUser = [...state.messages].reverse().find((m) => m.role === "user");
     assistantReply = buildLocalAssistantFallback(
-      recommendationResponse.recommendations as unknown[],
+      recommendationResponse.recommendations,
       lastUser && typeof lastUser.content === "string" ? lastUser.content : "",
     );
   }
   const nextMessage: ChatMessage = {
     role: "assistant",
     content: assistantReply,
-    recommendations: recommendationResponse.recommendations as unknown[] | undefined,
+    recommendations: recommendationResponse.recommendations,
     meta: recommendationResponse.meta,
   };
   return { ...state, messages: [...state.messages, nextMessage] };

--- a/apps/desktop/src/chatRenderAdapter.ts
+++ b/apps/desktop/src/chatRenderAdapter.ts
@@ -52,6 +52,13 @@ function getLatestCards(conversation: ConversationMessage[] | null, isMobile: bo
   return [];
 }
 
+/** A card as the view renders it — derived so the view cannot drift from the adapter. */
+export type CardViewProps = ReturnType<typeof buildCardViewProps>;
+export type MessageViewProps = ReturnType<typeof buildMessageViewProps>[number];
+export type ChatViewProps = ReturnType<typeof buildViewProps> & {
+  actionStatus?: { type: "success" | "error"; message: string } | null;
+};
+
 function buildViewProps(desktopUi: DesktopChatUiStack) {
   const viewport = desktopUi.getViewport();
   const isMobile = viewport === "mobile";

--- a/apps/desktop/src/createSavedArtistsShell.ts
+++ b/apps/desktop/src/createSavedArtistsShell.ts
@@ -1,10 +1,28 @@
-export function createSavedArtistsShell({ app }: { app: any }) {
+import type { ArtistGroup, ArtistSearchResult, SavedBand } from "./domain.js";
+
+/** The slice of the bootstrapped app this shell drives. */
+export type SavedArtistsShellCollaborator = {
+  listSavedBands(): Promise<SavedBand[]>;
+  listGroups(): Promise<ArtistGroup[]>;
+  getState(): { selectedArtistIds: string[] };
+  toggleArtistSelection(id: string): void;
+  searchArtists(query: string): Promise<ArtistSearchResult[]>;
+  saveBand(name: string, options?: { note?: string }): Promise<unknown>;
+  deleteSavedBand(id: string): Promise<unknown>;
+  exportPreferences(): Promise<unknown[]>;
+  importPreferences(bands: unknown[]): Promise<unknown>;
+  createGroup(name: string): Promise<unknown>;
+  deleteGroup(id: string): Promise<unknown>;
+  autoGroup(): Promise<unknown>;
+};
+
+export function createSavedArtistsShell({ app }: { app: SavedArtistsShellCollaborator }) {
   let state: {
-    savedArtists: any[];
-    groups: any[];
-    selectedIds: any[];
+    savedArtists: SavedBand[];
+    groups: ArtistGroup[];
+    selectedIds: string[];
     searchQuery: string;
-    searchResults: any[];
+    searchResults: ArtistSearchResult[];
     isSearching: boolean;
   } = {
     savedArtists: [],
@@ -47,7 +65,7 @@ export function createSavedArtistsShell({ app }: { app: any }) {
         state = { ...state, isSearching: false };
       }
     },
-    async addArtist(mbArtist: any) {
+    async addArtist(mbArtist: ArtistSearchResult) {
       await app.saveBand(mbArtist.name, { note: mbArtist.disambiguation || "Added via search." });
       await reloadAll();
     },

--- a/apps/desktop/src/desktopChatUiStack.ts
+++ b/apps/desktop/src/desktopChatUiStack.ts
@@ -1,4 +1,8 @@
-import { createChatAppModel, type ConversationMessage } from "./chatAppModel.js";
+import {
+  createChatAppModel,
+  type ChatAppCollaborator,
+  type ConversationMessage,
+} from "./chatAppModel.js";
 
 export type DesktopChatUiStack = {
   setViewport(next: string): void;
@@ -25,7 +29,7 @@ export function createDesktopChatUiStack({
   app,
   viewport = "desktop",
 }: {
-  app: any;
+  app: ChatAppCollaborator;
   viewport?: string;
 }): DesktopChatUiStack {
   let viewportState = normalizeViewport(viewport);
@@ -69,7 +73,7 @@ export function createDesktopChatUiStack({
       return appModel.submitFeedback(feedbackType);
     },
     cancelSearch() {
-      (app as any).cancelSearch?.();
+      app.cancelSearch?.();
     },
     async retryLastSearch() {
       return appModel.retryLastSearch();

--- a/apps/desktop/src/domain.ts
+++ b/apps/desktop/src/domain.ts
@@ -1,0 +1,70 @@
+// Shapes exchanged with the API, shared by the client, the app, the view
+// models and the React views.
+//
+// These are deliberately permissive about optional fields: the API is the
+// source of truth and older rows may lack newer columns, so the views already
+// guard with defaults. What they buy is a name for each payload, so a change on
+// one side stops compiling on the other instead of drifting silently.
+
+/** A recommendation as the API sends it, before it is turned into a card. */
+export type RecommendationItem = {
+  artist: string;
+  why?: string;
+  country?: string;
+  genres?: string[];
+  sourceSignals?: string[];
+  connection?: string;
+  imageUrl?: string | null;
+  musicbrainzArtistId?: string;
+};
+
+export type RecommendationMeta = {
+  modeUsed?: string;
+  usedPreferenceContext?: boolean;
+  eventId?: string;
+};
+
+export type RecommendationResponse = {
+  recommendations?: RecommendationItem[];
+  assistantReply?: string;
+  meta?: RecommendationMeta;
+};
+
+/** A saved preference row. */
+export type SavedBand = {
+  id: string;
+  name: string;
+  rating?: number | null;
+  note?: string;
+  categories?: string[];
+  musicbrainzArtistId?: string;
+};
+
+/** A MusicBrainz hit from artist search. */
+export type ArtistSearchResult = {
+  id: string;
+  name: string;
+  score?: number;
+  disambiguation?: string;
+};
+
+/** A band grouping, either user-made or inferred. */
+export type ArtistGroup = {
+  id: string;
+  name: string;
+  memberIds: string[];
+};
+
+export type ChatSession = {
+  id: string;
+  title: string;
+  createdAt?: string;
+};
+
+/** A message as it sits in the app's chat state. */
+export type ChatStateMessage = {
+  role: string;
+  content?: string;
+  recommendations?: RecommendationItem[];
+  meta?: RecommendationMeta;
+};

--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -2,23 +2,44 @@ import { createChatRenderAdapter } from "./chatRenderAdapter.js";
 import { createSavedArtistsModel } from "./savedArtistsModel.js";
 import { createDesktopReactShell } from "./ui/createDesktopReactShell.js";
 import { createDesktopReactMount } from "./ui/mountDesktopReactApp.js";
+import type { DesktopReactMountOptions } from "./ui/mountDesktopReactApp.js";
+import type { ChatAppCollaborator } from "./chatAppModel.js";
+import type { SavedArtistsCollaborator } from "./savedArtistsModel.js";
+import type { ChatHandlers } from "./ui/viewTypes.js";
 import { createDesktopChatUiStack } from "./desktopChatUiStack.js";
 import { bootstrapDesktopApp } from "./bootstrapDesktopApp.js";
 
 export { bootstrapDesktopApp };
 
-function bootstrapDesktopUi(options: any) {
+/** Everything index.ts asks of the bootstrapped app, across both screens. */
+type DesktopAppCollaborator = ChatAppCollaborator &
+  SavedArtistsCollaborator & {
+    getView?(): string;
+    navigate?(view: string): unknown;
+    saveBand?(artistName: string): unknown;
+    rateBand?(artistName: string, rating?: number): unknown;
+    setPendingStyleRef?(ids: string[]): void;
+  };
+
+function bootstrapDesktopUi(options: { app: DesktopAppCollaborator; viewport?: string }) {
   return createDesktopChatUiStack(options);
 }
 
-function bootstrapDesktopRenderAdapter({ app, viewport = "desktop" }: { app: any; viewport?: string }) {
+function bootstrapDesktopRenderAdapter({ app, viewport = "desktop" }: { app: DesktopAppCollaborator; viewport?: string }) {
   const desktopUi = bootstrapDesktopUi({ app, viewport });
-  const adapter = createChatRenderAdapter({ desktopUi }) as any;
-  adapter.desktopUi = desktopUi;
-  return adapter;
+  // The adapter carries the stack so the shell can reach cancel/retry.
+  return Object.assign(createChatRenderAdapter({ desktopUi }), { desktopUi });
 }
 
-function bootstrapDesktopReactShell({ app, viewport = "desktop", actionHandlers = {} }: { app: any; viewport?: string; actionHandlers?: any }) {
+function bootstrapDesktopReactShell({
+  app,
+  viewport = "desktop",
+  actionHandlers = {},
+}: {
+  app: DesktopAppCollaborator;
+  viewport?: string;
+  actionHandlers?: Partial<ChatHandlers>;
+}) {
   const renderAdapter = bootstrapDesktopRenderAdapter({ app, viewport });
   const savedArtistsModel = createSavedArtistsModel({ app });
   const mergedActionHandlers = {
@@ -46,20 +67,20 @@ function bootstrapDesktopReactShell({ app, viewport = "desktop", actionHandlers 
       app.navigate?.("chat");
     },
     getSavedArtistsViewPropsImpl: () => savedArtistsModel.getScreenState(),
-    cancelSearchImpl: () => (renderAdapter.desktopUi as any).cancelSearch?.(),
-    retryLastSearchImpl: () => (renderAdapter.desktopUi as any).retryLastSearch?.(),
-  }) as any;
+    cancelSearchImpl: () => renderAdapter.desktopUi.cancelSearch(),
+    retryLastSearchImpl: () => renderAdapter.desktopUi.retryLastSearch(),
+  });
   shell.desktopUi = renderAdapter.desktopUi;
   return shell;
 }
 
 export type BootstrapDesktopReactAppOptions = {
-  app?: any;
+  app?: DesktopAppCollaborator;
   viewport?: string;
   actionHandlers?: Record<string, unknown>;
-  router?: any;
-  savedArtistsShell?: any;
-  getSettingsViewProps?: () => Promise<any>;
+  router?: DesktopReactMountOptions["router"];
+  savedArtistsShell?: DesktopReactMountOptions["savedArtistsShell"];
+  getSettingsViewProps?: () => Promise<unknown>;
   saveGeminiApiKey?: (apiKey: string) => Promise<void>;
   saveBraveApiKey?: (apiKey: string) => Promise<void>;
   saveTursoConfig?: (url: string, token: string) => Promise<void>;

--- a/apps/desktop/src/platformLinks.ts
+++ b/apps/desktop/src/platformLinks.ts
@@ -4,7 +4,7 @@ interface PlatformDef {
   buildUrl: (name: string) => string;
 }
 
-interface PlatformLink {
+export interface PlatformLink {
   platform: string;
   label: string;
   url: string;

--- a/apps/desktop/src/savedArtistsModel.ts
+++ b/apps/desktop/src/savedArtistsModel.ts
@@ -1,11 +1,26 @@
-export function createSavedArtistsModel({ app }: { app: any }) {
+import type { ArtistGroup, ArtistSearchResult, SavedBand } from "./domain.js";
+
+/** The slice of the bootstrapped app this model drives. */
+export type SavedArtistsCollaborator = {
+  listSavedBands(): Promise<SavedBand[]>;
+  deleteSavedBand(id: string): Promise<unknown>;
+  searchArtists(query: string): Promise<ArtistSearchResult[]>;
+  // NOTE: bootstrapDesktopApp exposes importPreferences/autoGroup, not these.
+  // Optional here so the mismatch is visible rather than a runtime TypeError.
+  importArtists?(bands: unknown[]): Promise<{ imported: number; skipped: number; failed?: number }>;
+  listGroups(): Promise<ArtistGroup[]>;
+  createGroup(name: string): Promise<unknown>;
+  autoGroupByGenre?(): Promise<unknown>;
+};
+
+export function createSavedArtistsModel({ app }: { app: SavedArtistsCollaborator }) {
   const state: {
-    savedArtists: any[];
+    savedArtists: SavedBand[];
     selectedIds: Set<string>;
-    searchResults: any[];
+    searchResults: ArtistSearchResult[];
     isSearching: boolean;
     isLoading: boolean;
-    groups: any[];
+    groups: ArtistGroup[];
   } = {
     savedArtists: [],
     selectedIds: new Set(),
@@ -83,7 +98,8 @@ export function createSavedArtistsModel({ app }: { app: any }) {
       return [...state.savedArtists];
     },
 
-    async importArtists(bands: any[]) {
+    async importArtists(bands: unknown[]) {
+      if (!app.importArtists) throw new Error("app does not implement importArtists");
       const result = await app.importArtists(bands);
       state.savedArtists = await app.listSavedBands();
       return result;
@@ -100,8 +116,15 @@ export function createSavedArtistsModel({ app }: { app: any }) {
     },
 
     async autoGroupByGenre() {
+      if (!app.autoGroupByGenre) throw new Error("app does not implement autoGroupByGenre");
       await app.autoGroupByGenre();
       state.groups = await app.listGroups();
     },
   };
 }
+
+/** The screen state the saved-artists view renders, derived so the two cannot drift. */
+export type SavedArtistsScreenState = ReturnType<
+  ReturnType<typeof createSavedArtistsModel>["getScreenState"]
+>;
+export type SavedArtistItem = SavedArtistsScreenState["artists"][number];

--- a/apps/desktop/src/savedArtistsModel.ts
+++ b/apps/desktop/src/savedArtistsModel.ts
@@ -5,12 +5,6 @@ export type SavedArtistsCollaborator = {
   listSavedBands(): Promise<SavedBand[]>;
   deleteSavedBand(id: string): Promise<unknown>;
   searchArtists(query: string): Promise<ArtistSearchResult[]>;
-  // NOTE: bootstrapDesktopApp exposes importPreferences/autoGroup, not these.
-  // Optional here so the mismatch is visible rather than a runtime TypeError.
-  importArtists?(bands: unknown[]): Promise<{ imported: number; skipped: number; failed?: number }>;
-  listGroups(): Promise<ArtistGroup[]>;
-  createGroup(name: string): Promise<unknown>;
-  autoGroupByGenre?(): Promise<unknown>;
 };
 
 export function createSavedArtistsModel({ app }: { app: SavedArtistsCollaborator }) {
@@ -20,6 +14,10 @@ export function createSavedArtistsModel({ app }: { app: SavedArtistsCollaborator
     searchResults: ArtistSearchResult[];
     isSearching: boolean;
     isLoading: boolean;
+    // Never written here: grouping lives in createSavedArtistsShell, and the
+    // saved-artists screen is served from that shell in the running app. Kept
+    // so the screen-state shape stays whole — see ROADMAP "Saved-Artists:
+    // Modell und Shell zusammenführen".
     groups: ArtistGroup[];
   } = {
     savedArtists: [],
@@ -92,33 +90,6 @@ export function createSavedArtistsModel({ app }: { app: SavedArtistsCollaborator
       } finally {
         state.isSearching = false;
       }
-    },
-
-    async exportArtists() {
-      return [...state.savedArtists];
-    },
-
-    async importArtists(bands: unknown[]) {
-      if (!app.importArtists) throw new Error("app does not implement importArtists");
-      const result = await app.importArtists(bands);
-      state.savedArtists = await app.listSavedBands();
-      return result;
-    },
-
-    async loadGroups() {
-      state.groups = await app.listGroups();
-    },
-
-    async createGroup(name: string) {
-      const result = await app.createGroup(name);
-      state.groups = await app.listGroups();
-      return result;
-    },
-
-    async autoGroupByGenre() {
-      if (!app.autoGroupByGenre) throw new Error("app does not implement autoGroupByGenre");
-      await app.autoGroupByGenre();
-      state.groups = await app.listGroups();
     },
   };
 }

--- a/apps/desktop/src/ui/ChatAppView.ts
+++ b/apps/desktop/src/ui/ChatAppView.ts
@@ -1,3 +1,6 @@
+import type { CardViewProps, ChatViewProps, MessageViewProps } from "../chatRenderAdapter.js";
+import type { ChatHandlers } from "./viewTypes.js";
+import type { PlatformLink } from "../platformLinks.js";
 import * as React from "react";
 import { ObscurityTargetPicker } from "./ObscurityTargetPicker.js";
 import { FeedbackReactionBar } from "./FeedbackReactionBar.js";
@@ -22,7 +25,7 @@ function getTheme(modeValue: string) {
   };
 }
 
-function ModePill({ modeValue, modeOptions, onModeChange }: { modeValue: string; modeOptions: any[]; onModeChange: (v: string) => void }) {
+function ModePill({ modeValue, modeOptions, onModeChange }: { modeValue: string; modeOptions: { value: string; label: string }[]; onModeChange: (v: string) => void }) {
   return React.createElement(
     "div",
     { className: "mode-pill" },
@@ -73,7 +76,7 @@ function GenreChips({ genres, textTertiary, border }: { genres: string[] | null 
   );
 }
 
-function PlatformLinks({ links }: { links: any[] | null | undefined }) {
+function PlatformLinks({ links }: { links: PlatformLink[] | null | undefined }) {
   if (!links?.length) return null;
   return React.createElement(
     "div",
@@ -103,7 +106,7 @@ function PlatformLinks({ links }: { links: any[] | null | undefined }) {
   );
 }
 
-function renderCardActions(card: any, theme: ReturnType<typeof getTheme>, handlers: any) {
+function renderCardActions(card: CardViewProps, theme: ReturnType<typeof getTheme>, handlers: ChatHandlers) {
   const btnStyle = {
     backgroundColor: theme.buttonBg,
     color: theme.buttonText,
@@ -165,7 +168,7 @@ function renderCardActions(card: any, theme: ReturnType<typeof getTheme>, handle
   return actions;
 }
 
-function RecommendationCard({ card, theme, isMobile, handlers }: { card: any; theme: ReturnType<typeof getTheme>; isMobile: boolean; handlers: any }) {
+function RecommendationCard({ card, theme, isMobile, handlers }: { card: CardViewProps; theme: ReturnType<typeof getTheme>; isMobile: boolean; handlers: ChatHandlers }) {
   const cardStyles = {
     article: {
       backgroundColor: theme.cardBg,
@@ -194,7 +197,7 @@ function RecommendationCard({ card, theme, isMobile, handlers }: { card: any; th
       marginBottom: "8px",
       fontStyle: "italic",
     },
-    actions: { display: "flex", gap: "8px", flexWrap: (isMobile ? "wrap" : "nowrap") as any },
+    actions: { display: "flex", gap: "8px", flexWrap: isMobile ? "wrap" : "nowrap" } as React.CSSProperties,
   };
 
   return React.createElement(
@@ -212,7 +215,7 @@ function RecommendationCard({ card, theme, isMobile, handlers }: { card: any; th
             borderRadius: "6px",
             marginBottom: "10px",
           },
-          onError: (e: any) => {
+          onError: (e: React.SyntheticEvent<HTMLImageElement>) => {
             e.currentTarget.style.display = "none";
           },
         })
@@ -341,7 +344,7 @@ function SearchInProgress({ visible, theme, onStop }: { visible: boolean; theme:
   );
 }
 
-function StatusBanner({ actionStatus }: { actionStatus: any }) {
+function StatusBanner({ actionStatus }: { actionStatus: ChatViewProps["actionStatus"] }) {
   if (!actionStatus) return null;
   const isError = actionStatus.type === "error";
   return React.createElement(
@@ -361,7 +364,7 @@ function StatusBanner({ actionStatus }: { actionStatus: any }) {
   );
 }
 
-function findLastAssistantWithCardsIndex(messages: any[] | null | undefined): number {
+function findLastAssistantWithCardsIndex(messages: MessageViewProps[] | null | undefined): number {
   if (!messages?.length) return -1;
   for (let i = messages.length - 1; i >= 0; i--) {
     const m = messages[i];
@@ -370,14 +373,14 @@ function findLastAssistantWithCardsIndex(messages: any[] | null | undefined): nu
   return -1;
 }
 
-function getLatestAssistantCards(messages: any[] | null | undefined): any[] {
+function getLatestAssistantCards(messages: MessageViewProps[] | null | undefined): CardViewProps[] {
   const idx = findLastAssistantWithCardsIndex(messages);
   if (idx === -1) return [];
-  const m = (messages as any[])[idx];
+  const m = messages![idx];
   return Array.isArray(m.cards) ? m.cards : [];
 }
 
-function DesktopResultsRail({ cards, theme, isMobile, handlers }: { cards: any[]; theme: ReturnType<typeof getTheme>; isMobile: boolean; handlers: any }) {
+function DesktopResultsRail({ cards, theme, isMobile, handlers }: { cards: CardViewProps[]; theme: ReturnType<typeof getTheme>; isMobile: boolean; handlers: ChatHandlers }) {
   if (!cards?.length) return null;
   return React.createElement(
     "aside",
@@ -434,7 +437,7 @@ function EmptyState({ modeValue, textSecondary, textTertiary }: { modeValue: str
 }
 
 function UserMessageBubble({ msg, isLastUser, isSearching, theme, onRetry }: {
-  msg: any;
+  msg: MessageViewProps;
   isLastUser: boolean;
   isSearching: boolean;
   theme: ReturnType<typeof getTheme>;
@@ -491,10 +494,10 @@ function UserMessageBubble({ msg, isLastUser, isSearching, theme, onRetry }: {
 }
 
 function MessageThread({ messages, theme, isMobile, handlers, assistantCardsMode = "thread", isSearching = false }: {
-  messages: any[] | null | undefined;
+  messages: MessageViewProps[] | null | undefined;
   theme: ReturnType<typeof getTheme>;
   isMobile: boolean;
-  handlers: any;
+  handlers: ChatHandlers;
   assistantCardsMode?: string;
   isSearching?: boolean;
 }) {
@@ -502,7 +505,7 @@ function MessageThread({ messages, theme, isMobile, handlers, assistantCardsMode
   const railLatest = assistantCardsMode === "rail-latest";
   const lastAssistantCardsIdx = railLatest ? findLastAssistantWithCardsIndex(messages) : -1;
   const lastUserIdx = messages
-    ? messages.reduce((last: number, msg: any, idx: number) => msg.role === "user" ? idx : last, -1)
+    ? messages.reduce((last: number, msg, idx: number) => (msg.role === "user" ? idx : last), -1)
     : -1;
 
   return React.createElement(
@@ -527,7 +530,7 @@ function MessageThread({ messages, theme, isMobile, handlers, assistantCardsMode
 
         if (!assistantText && !hasCards) return null;
 
-        const cardGrid = (cards: any[]) =>
+        const cardGrid = (cards: CardViewProps[]) =>
           React.createElement(
             "div",
             { style: { display: "grid", gap: "10px" } },
@@ -619,7 +622,7 @@ function MessageThread({ messages, theme, isMobile, handlers, assistantCardsMode
                   },
                   onClick: () => {
                     const text = msg.cards
-                      .map((c: any) => `${c.title}${c.why ? ` — ${c.why}` : ""}`)
+                      .map((c) => `${c.title}${c.why ? ` — ${c.why}` : ""}`)
                       .join("\n");
                     handlers.onCopyAll(text);
                   },
@@ -648,7 +651,7 @@ function MessageThread({ messages, theme, isMobile, handlers, assistantCardsMode
   );
 }
 
-export function ChatAppView({ viewProps, handlers }: { viewProps: any; handlers: any }) {
+export function ChatAppView({ viewProps, handlers }: { viewProps: ChatViewProps; handlers: ChatHandlers }) {
   const theme = getTheme(viewProps.modeValue);
   const isMobile = viewProps.viewport === "mobile";
   const searchInFlight = viewProps.isLoading === true;
@@ -818,7 +821,7 @@ export function ChatAppView({ viewProps, handlers }: { viewProps: any; handlers:
               : React.createElement(
                   "section",
                   { style: { display: "grid", gap: "8px" } },
-                  viewProps.cards.map((card: any) =>
+                  viewProps.cards.map((card) =>
                     React.createElement(RecommendationCard, {
                       key: card.title,
                       card,
@@ -855,10 +858,10 @@ export function ChatAppView({ viewProps, handlers }: { viewProps: any; handlers:
         "form",
         {
           "aria-busy": searchInFlight,
-          onSubmit: (event: any) => {
+          onSubmit: (event: React.FormEvent<HTMLFormElement>) => {
             event.preventDefault();
-            const form = event.currentTarget as any;
-            const queryInput = form.querySelector('input[name="query"]') as any;
+            const form = event.currentTarget;
+            const queryInput = form.querySelector('input[name="query"]') as HTMLInputElement | null;
             const query = String(queryInput?.value || "").trim();
             if (!query || viewProps.queryDisabled) return;
             queryInput.value = "";

--- a/apps/desktop/src/ui/SavedArtistsView.ts
+++ b/apps/desktop/src/ui/SavedArtistsView.ts
@@ -1,3 +1,6 @@
+import type { ArtistGroup, ArtistSearchResult } from "../domain.js";
+import type { SavedArtistItem as SavedArtistItemProps, SavedArtistsScreenState } from "../savedArtistsModel.js";
+import type { SavedArtistsHandlers } from "./viewTypes.js";
 import * as React from "react";
 
 const theme = {
@@ -14,7 +17,7 @@ const theme = {
   buttonText: "#c8d4e8",
 };
 
-function SavedArtistItem({ artist, handlers }: { artist: any; handlers: any }) {
+function SavedArtistItem({ artist, handlers }: { artist: SavedArtistItemProps; handlers: SavedArtistsHandlers }) {
   const itemStyles = {
     li: {
       display: "flex",
@@ -94,7 +97,7 @@ function SavedArtistItem({ artist, handlers }: { artist: any; handlers: any }) {
   );
 }
 
-function SearchResultItem({ result, handlers }: { result: any; handlers: any }) {
+function SearchResultItem({ result, handlers }: { result: ArtistSearchResult; handlers: SavedArtistsHandlers }) {
   const styles = {
     li: {
       display: "flex",
@@ -142,7 +145,7 @@ function SearchResultItem({ result, handlers }: { result: any; handlers: any }) 
   );
 }
 
-function SearchResultsList({ results, handlers }: { results: any[]; handlers: any }) {
+function SearchResultsList({ results, handlers }: { results: ArtistSearchResult[]; handlers: SavedArtistsHandlers }) {
   const listStyle = { display: "grid", gap: "6px", listStyle: "none", padding: "0", margin: "0" };
   return React.createElement(
     "ul",
@@ -153,7 +156,7 @@ function SearchResultsList({ results, handlers }: { results: any[]; handlers: an
   );
 }
 
-function SearchSection({ searchResults, isSearching, handlers }: { searchResults: any[]; isSearching: boolean; handlers: any }) {
+function SearchSection({ searchResults, isSearching, handlers }: { searchResults: ArtistSearchResult[]; isSearching: boolean; handlers: SavedArtistsHandlers }) {
   const styles = {
     section: { marginTop: "20px" },
     sectionTitle: { fontSize: "13px", fontWeight: "600", color: theme.textSecondary, marginBottom: "8px" },
@@ -188,9 +191,9 @@ function SearchSection({ searchResults, isSearching, handlers }: { searchResults
       "form",
       {
         style: styles.row,
-        onSubmit: (e: any) => {
+        onSubmit: (e: React.FormEvent<HTMLFormElement>) => {
           e.preventDefault();
-          const q = (e.target.elements["artist-search"] as any).value.trim();
+          const q = (e.currentTarget.elements.namedItem("artist-search") as HTMLInputElement).value.trim();
           if (q) handlers.onSearch?.(q);
         },
       },
@@ -215,7 +218,7 @@ function SearchSection({ searchResults, isSearching, handlers }: { searchResults
   );
 }
 
-function SelectionBar({ selectedCount, handlers }: { selectedCount: number; handlers: any }) {
+function SelectionBar({ selectedCount, handlers }: { selectedCount: number; handlers: SavedArtistsHandlers }) {
   const styles = {
     bar: {
       display: "flex",
@@ -256,7 +259,7 @@ function SelectionBar({ selectedCount, handlers }: { selectedCount: number; hand
   );
 }
 
-function GroupSection({ group, artists, handlers }: { group: any; artists: any[]; handlers: any }) {
+function GroupSection({ group, artists, handlers }: { group: ArtistGroup; artists: SavedArtistItemProps[]; handlers: SavedArtistsHandlers }) {
   const memberArtists = artists.filter((a) => group.memberIds.includes(a.id));
   const styles = {
     section: { marginTop: "20px" },
@@ -304,7 +307,7 @@ function GroupSection({ group, artists, handlers }: { group: any; artists: any[]
   );
 }
 
-function GroupsSection({ groups, artists, handlers }: { groups: any[]; artists: any[]; handlers: any }) {
+function GroupsSection({ groups, artists, handlers }: { groups: ArtistGroup[]; artists: SavedArtistItemProps[]; handlers: SavedArtistsHandlers }) {
   const styles = {
     section: { marginTop: "24px" },
     toolbar: { display: "flex", gap: "8px", alignItems: "center", marginBottom: "12px" },
@@ -355,9 +358,9 @@ function GroupsSection({ groups, artists, handlers }: { groups: any[]; artists: 
         "form",
         {
           style: { display: "flex", gap: "6px", flex: 1 },
-          onSubmit: (e: any) => {
+          onSubmit: (e: React.FormEvent<HTMLFormElement>) => {
             e.preventDefault();
-            const input = e.target.elements["create-group"] as any;
+            const input = e.currentTarget.elements.namedItem("create-group") as HTMLInputElement;
             const name = input.value.trim();
             if (name) {
               handlers.onCreateGroup?.(name);
@@ -385,7 +388,7 @@ function GroupsSection({ groups, artists, handlers }: { groups: any[]; artists: 
   );
 }
 
-export function SavedArtistsView({ viewProps, handlers }: { viewProps: any; handlers: any }) {
+export function SavedArtistsView({ viewProps, handlers }: { viewProps: SavedArtistsScreenState; handlers: SavedArtistsHandlers }) {
   const styles = {
     page: {
       backgroundColor: theme.pageBg,
@@ -462,7 +465,7 @@ export function SavedArtistsView({ viewProps, handlers }: { viewProps: any; hand
               type: "file",
               accept: ".json,application/json",
               style: { display: "none" },
-              onChange: (e: any) => {
+              onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
                 const file = e.target.files?.[0];
                 if (!file) return;
                 handlers.onImportFile?.(file);
@@ -494,7 +497,7 @@ export function SavedArtistsView({ viewProps, handlers }: { viewProps: any; hand
         : React.createElement(
             "ul",
             { style: { ...styles.list, listStyle: "none", padding: "0", margin: "0" } },
-            artists.map((artist: any) =>
+            artists.map((artist) =>
               React.createElement(SavedArtistItem, { key: artist.id, artist, handlers }),
             ),
           ),

--- a/apps/desktop/src/ui/WelcomeView.ts
+++ b/apps/desktop/src/ui/WelcomeView.ts
@@ -1,3 +1,4 @@
+import type { WelcomeHandlers } from "./viewTypes.js";
 import * as React from "react";
 
 const palette = {
@@ -15,7 +16,7 @@ const palette = {
 /**
  * First-run welcome: guides the user to add a Gemini API key (Settings) or skip for later.
  */
-export function WelcomeView({ viewProps, handlers }: { viewProps: any; handlers: any }) {
+export function WelcomeView({ viewProps, handlers }: { viewProps?: { title?: string }; handlers: WelcomeHandlers }) {
   void viewProps;
   return React.createElement(
     "main",

--- a/apps/desktop/src/ui/createDesktopReactShell.ts
+++ b/apps/desktop/src/ui/createDesktopReactShell.ts
@@ -1,29 +1,38 @@
+import type { ChatViewProps } from "../chatRenderAdapter.js";
+import type { DesktopChatUiStack } from "../desktopChatUiStack.js";
+import type { SavedArtistsScreenState } from "../savedArtistsModel.js";
+import type { ChatHandlers } from "./viewTypes.js";
 import * as React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { ChatAppView } from "./ChatAppView.js";
-import { ObscurityTargetPicker } from "./ObscurityTargetPicker.js";
 import { formatRecommendationQueryError } from "../apiErrorMessages.js";
 
 type ActionStatus = { type: "success" | "error"; message: string } | null;
 
+/** Node returns a Timeout, browsers and test fakes return a number. */
+type TimerHandle = ReturnType<typeof setTimeout> | number;
+
 interface CreateDesktopReactShellOptions {
   renderAdapter: {
-    onModeChange: (mode: string) => any;
-    onSubmitQuery: (query: string) => any;
-    onObscurityTargetChange?: (target: string | undefined) => any;
-    getViewProps: () => Record<string, any>;
+    onModeChange: (mode: string) => unknown;
+    onSubmitQuery: (query: string) => unknown;
+    onObscurityTargetChange?: (target: string | undefined) => unknown;
+    getViewProps: () => ChatViewProps;
   };
-  actionHandlers?: Record<string, any>;
+  actionHandlers?: Partial<ChatHandlers>;
   statusTimeoutMs?: number;
   errorStatusTimeoutMs?: number;
-  setTimeoutImpl?: typeof setTimeout;
+  // Only "schedule this callback, give me a handle I can cancel" is used, so
+  // the seam does not need the full setTimeout signature (which drags in
+  // __promisify__ and forces fakes to be Node Timeouts).
+  setTimeoutImpl?: (handler: () => void, timeout: number) => TimerHandle;
   getViewImpl?: () => string;
-  navigateImpl?: (view: string) => any;
+  navigateImpl?: (view: string) => unknown;
   searchArtistsImpl?: (query: string) => Promise<void>;
   toggleSelectionImpl?: (id: string) => void;
   deleteSavedArtistImpl?: (id: string) => Promise<void>;
   activateStyleRefImpl?: () => Promise<void>;
-  getSavedArtistsViewPropsImpl?: () => Record<string, any>;
+  getSavedArtistsViewPropsImpl?: () => SavedArtistsScreenState;
   cancelSearchImpl?: () => void;
   retryLastSearchImpl?: () => Promise<unknown> | void;
 }
@@ -47,12 +56,13 @@ export function createDesktopReactShell({
     selectedCount: 0,
     searchResults: [],
     isSearching: false,
+    groups: [],
   }),
   cancelSearchImpl,
   retryLastSearchImpl,
 }: CreateDesktopReactShellOptions) {
   let actionStatus: ActionStatus = null;
-  let clearStatusTimer: ReturnType<typeof setTimeout> | null = null;
+  let clearStatusTimer: TimerHandle | null = null;
 
   function scheduleStatusClear(customDelayMs?: number) {
     const delayMs = typeof customDelayMs === "number" ? customDelayMs : statusTimeoutMs;
@@ -73,8 +83,8 @@ export function createDesktopReactShell({
   };
 
   const shell = {
-    desktopUi: undefined as any,
-    getViewProps() {
+    desktopUi: undefined as DesktopChatUiStack | undefined,
+    getViewProps(): (ChatViewProps | SavedArtistsScreenState) & { actionStatus?: ActionStatus } {
       if (getViewImpl() === "saved-artists") {
         return getSavedArtistsViewPropsImpl();
       }
@@ -90,7 +100,7 @@ export function createDesktopReactShell({
       } catch (error) {
         actionStatus = { type: "error", message: formatRecommendationQueryError(error) };
         scheduleStatusClear(errorStatusTimeoutMs);
-        throw new Error("query failed");
+        throw new Error("query failed", { cause: error });
       }
     },
     async saveBand(artistName: string) {
@@ -149,7 +159,7 @@ export function createDesktopReactShell({
     },
     renderHtml() {
       const viewProps = renderAdapter.getViewProps();
-      return renderToStaticMarkup(React.createElement(ChatAppView as any, { viewProps, handlers }));
+      return renderToStaticMarkup(React.createElement(ChatAppView, { viewProps, handlers }));
     },
   };
   return shell;

--- a/apps/desktop/src/ui/mountDesktopReactApp.ts
+++ b/apps/desktop/src/ui/mountDesktopReactApp.ts
@@ -8,10 +8,46 @@ import { LoginView } from "./LoginView.js";
 import { RegisterView } from "./RegisterView.js";
 import { ResetPasswordView } from "./ResetPasswordView.js";
 
-type AnyShell = Record<string, any>;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyRouter = any;
-type AnySavedShell = Record<string, any> | null;
+/** The shell surface this mount drives; everything optional is guarded with `?.`. */
+type MountShell = {
+  getViewProps(): unknown;
+  getView?(): string;
+  updateMode(mode: string): Promise<unknown>;
+  submitQuery(query: string): Promise<unknown> | unknown;
+  saveBand?(artistName: string): Promise<unknown> | unknown;
+  rateBand?(artistName: string, rating?: number): Promise<unknown> | unknown;
+  deleteSavedArtist?(id: string): Promise<unknown>;
+  toggleSelection?(id: string): void;
+  activateStyleRef?(): Promise<unknown>;
+  searchArtists?(query: string): Promise<unknown>;
+  navigate?(view: string): Promise<unknown> | unknown;
+  cancelSearch?(): void;
+  retryLastSearch?(): Promise<unknown> | void;
+  desktopUi?: { setObscurityTarget?(target: string | undefined): void } | undefined;
+};
+
+// The mount dispatches to views with differing prop shapes, so prop types are
+// deliberately erased at this one seam rather than throughout.
+type ViewComponentLike = React.ComponentType<Record<string, unknown>>;
+
+type MountRouter = {
+  getRoute(): string;
+  navigate(route: string): void;
+  onRouteChange?(listener: () => void): unknown;
+};
+type MountSavedShell = {
+  getViewProps(): unknown;
+  toggleArtistSelection(id: string): void;
+  setSearchQuery(query: string): void;
+  searchArtists(): Promise<unknown>;
+  addArtist(artist: { id: string; name: string; disambiguation?: string }): Promise<unknown> | unknown;
+  deleteSavedArtist?(id: string): Promise<unknown>;
+  exportArtists?(): Promise<unknown[] | undefined>;
+  importArtists?(bands: unknown[]): Promise<unknown>;
+  createGroup?(name: string): Promise<unknown>;
+  deleteGroup?(id: string): Promise<unknown>;
+  autoGroup?(): Promise<unknown>;
+} | null;
 
 function defaultContainerResolver(): HTMLElement {
   const browserDocument = globalThis.document as Document | undefined;
@@ -26,10 +62,10 @@ function resolveViewComponent(viewName: string) {
 }
 
 export interface DesktopReactMountOptions {
-  shell: AnyShell;
-  router?: AnyRouter;
-  savedArtistsShell?: AnySavedShell;
-  getSettingsViewProps?: () => any;
+  shell: MountShell;
+  router?: MountRouter;
+  savedArtistsShell?: MountSavedShell;
+  getSettingsViewProps?: () => unknown;
   saveGeminiApiKey?: (apiKey: string) => Promise<void>;
   saveBraveApiKey?: (apiKey: string) => Promise<void>;
   saveTursoConfig?: (url: string, token: string) => Promise<void>;
@@ -73,23 +109,23 @@ export function createDesktopReactMount({
     const route = router ? router.getRoute() : "home";
 
     if (route === "login") {
-      root.render(React.createElement(LoginView as any, { viewProps: {}, handlers: loginHandlers }));
+      root.render(React.createElement(LoginView as unknown as ViewComponentLike, { viewProps: {}, handlers: loginHandlers }));
       return {};
     }
 
     if (route === "register") {
-      root.render(React.createElement(RegisterView as any, { viewProps: {}, handlers: registerHandlers }));
+      root.render(React.createElement(RegisterView as unknown as ViewComponentLike, { viewProps: {}, handlers: registerHandlers }));
       return {};
     }
 
     if (route === "reset-password") {
-      root.render(React.createElement(ResetPasswordView as any, { viewProps: {}, handlers: resetPasswordHandlers }));
+      root.render(React.createElement(ResetPasswordView as unknown as ViewComponentLike, { viewProps: {}, handlers: resetPasswordHandlers }));
       return {};
     }
 
     if (route === "welcome") {
       root.render(
-        React.createElement(WelcomeView as any, {
+        React.createElement(WelcomeView as unknown as ViewComponentLike, {
           viewProps: {},
           handlers: welcomeHandlers,
         }),
@@ -100,7 +136,7 @@ export function createDesktopReactMount({
     if (route === "saved" && savedArtistsShell) {
       const viewProps = savedArtistsShell.getViewProps();
       root.render(
-        React.createElement(SavedArtistsView as any, {
+        React.createElement(SavedArtistsView as unknown as ViewComponentLike, {
           viewProps,
           handlers: savedHandlers,
         }),
@@ -111,7 +147,7 @@ export function createDesktopReactMount({
     if (route === "settings") {
       const viewProps = await Promise.resolve(getSettingsViewProps());
       root.render(
-        React.createElement(SettingsView as any, {
+        React.createElement(SettingsView as unknown as ViewComponentLike, {
           viewProps,
           handlers: settingsHandlers,
         }),
@@ -122,7 +158,7 @@ export function createDesktopReactMount({
     const viewProps = shell.getViewProps();
     const currentView = shell.getView?.() ?? "chat";
     const ViewComponent = resolveViewComponent(currentView);
-    root.render(React.createElement(ViewComponent as any, { viewProps, handlers }));
+    root.render(React.createElement(ViewComponent as unknown as ViewComponentLike, { viewProps, handlers }));
     return viewProps;
   }
 
@@ -292,7 +328,7 @@ export function createDesktopReactMount({
       await savedArtistsShell?.searchArtists();
       renderCurrent();
     },
-    onAddArtist: (artist: any) => {
+    onAddArtist: (artist: { id: string; name: string; disambiguation?: string }) => {
       Promise.resolve(savedArtistsShell?.addArtist(artist)).then(() => renderCurrent());
     },
     onDelete: async (id: string) => {

--- a/apps/desktop/src/ui/viewTypes.ts
+++ b/apps/desktop/src/ui/viewTypes.ts
@@ -1,0 +1,41 @@
+// Callback surface the React views are handed.
+//
+// Required entries are always wired by createDesktopReactShell; the optional
+// ones are called with `?.` in the views because not every host provides them
+// (the browser shell wires fewer than the Tauri one).
+
+export type ChatHandlers = {
+  onModeChange(mode: string): unknown;
+  onQuerySubmit(query: string): unknown;
+  onSave(artistName: string): unknown;
+  onRate(artistName: string, rating?: number): unknown;
+  onMore(artistName: string): unknown;
+  onObscurityTargetChange?(target: string | undefined): unknown;
+  onCopyCard?(title: string, why: string): unknown;
+  onCopyAll?(text: string): unknown;
+  onFeedback?(feedbackType: string): unknown;
+  onFeedbackDismiss?(): unknown;
+  onNavigateSaved?(): unknown;
+  onNavigateSettings?(): unknown;
+  onStop?(): unknown;
+  onRetry?(): unknown;
+};
+
+export type SavedArtistsHandlers = {
+  onNavigate?(view: string): unknown;
+  onSearch?(query: string): unknown;
+  onAddArtist?(artist: { id: string; name: string; disambiguation?: string }): unknown;
+  onDelete?(id: string): unknown;
+  onToggleSelection?(id: string): unknown;
+  onActivateStyleRef?(): unknown;
+  onCreateGroup?(name: string): unknown;
+  onDeleteGroup?(id: string): unknown;
+  onAutoGroup?(): unknown;
+  onExport?(): unknown;
+  onImportFile?(file: File): unknown;
+};
+
+export type WelcomeHandlers = {
+  onGoToSettings?(): unknown;
+  onSkip?(): unknown;
+};

--- a/apps/desktop/test/app-navigation.test.js
+++ b/apps/desktop/test/app-navigation.test.js
@@ -1,10 +1,11 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 
+const { jsonResponse } = require("./helpers/fakeResponse");
 const { bootstrapDesktopApp } = require("../src");
 
 function makeApp() {
-  return bootstrapDesktopApp({ apiBaseUrl: "http://localhost:3001", fetchImpl: async () => ({}) });
+  return bootstrapDesktopApp({ apiBaseUrl: "http://localhost:3001", fetchImpl: async () => jsonResponse({}) });
 }
 
 test("bootstrapDesktopApp starts on chat view", () => {

--- a/apps/desktop/test/browser-entry.test.js
+++ b/apps/desktop/test/browser-entry.test.js
@@ -11,7 +11,7 @@ test("bootBrowserDesktopApp forwards options to browser starter", async () => {
     ...originalStarter,
     startDesktopBrowserApp: (options) => {
       calls.push(options);
-      return Promise.resolve({ ok: true });
+      return /** @type {any} */ (Promise.resolve({ ok: true }));
     },
   };
 
@@ -21,7 +21,7 @@ test("bootBrowserDesktopApp forwards options to browser starter", async () => {
 
   require.cache[starterPath].exports = originalStarter;
 
-  assert.equal(result.ok, true);
+  assert.equal(/** @type {any} */ (result).ok, true);
   assert.equal(calls.length, 1);
   assert.equal(calls[0].apiBaseUrl, "http://localhost:3001");
 });

--- a/apps/desktop/test/chat-client.test.js
+++ b/apps/desktop/test/chat-client.test.js
@@ -7,6 +7,7 @@ const {
   applyAssistantMessage,
   normalizeArtistId,
 } = require("../src/chatClient");
+const { jsonResponse } = require("./helpers/fakeResponse");
 
 test("chat client sends recommendation request and returns response payload", async () => {
   const calls = [];
@@ -14,15 +15,11 @@ test("chat client sends recommendation request and returns response payload", as
     apiBaseUrl: "http://localhost:3001",
     fetchImpl: async (url, init) => {
       calls.push({ url, init });
-      return {
-        ok: true,
-        status: 200,
-        json: async () => ({
+      return jsonResponse({
           recommendations: [{ artist: "Fen", why: "Atmospheric overlap", sourceSignals: ["musicbrainz_search"] }],
           assistantReply: "These lean atmospheric — want something heavier next?",
           meta: { modeUsed: "fresh", usedPreferenceContext: false },
-        }),
-      };
+        });
     },
   });
 
@@ -46,13 +43,13 @@ test("chat state appends assistant message from recommendation response", () => 
   assert.equal(next.messages.length, 1);
   assert.equal(next.messages[0].role, "assistant");
   assert.equal(next.messages[0].content.includes("shoegaze"), true);
-  assert.equal(next.messages[0].recommendations[0].artist, "Alcest");
+  assert.equal(/** @type {{ artist: string }} */ (next.messages[0].recommendations[0]).artist, "Alcest");
 });
 
 test("chat state synthesizes dialogue when API omits assistantReply", () => {
   const afterUser = {
     ...createInitialChatState(),
-    messages: [{ role: "user", content: "I like grunge" }],
+    messages: /** @type {{ role: "user", content: string }[]} */ ([{ role: "user", content: "I like grunge" }]),
   };
   const next = applyAssistantMessage(afterUser, {
     recommendations: [{ artist: "Mudhoney", why: "Proto-grunge", sourceSignals: ["agent_reasoning"] }],
@@ -71,11 +68,7 @@ test("chat client creates and updates preferences", async () => {
     apiBaseUrl: "http://localhost:3001",
     fetchImpl: async (url, init) => {
       calls.push({ url, init });
-      return {
-        ok: true,
-        status: 200,
-        json: async () => ({ savedBand: { id: "pref-1", name: "Fen", rating: 4 } }),
-      };
+      return jsonResponse({ savedBand: { id: "pref-1", name: "Fen", rating: 4 } });
     },
   });
 
@@ -100,13 +93,9 @@ test("chat client fetches saved bands from preferences endpoint", async () => {
     apiBaseUrl: "http://localhost:3001",
     fetchImpl: async (url, init) => {
       calls.push({ url, init });
-      return {
-        ok: true,
-        status: 200,
-        json: async () => ({
+      return jsonResponse({
           savedBands: [{ id: "pref-1", name: "Fen", rating: 4 }],
-        }),
-      };
+        });
     },
   });
 
@@ -125,13 +114,9 @@ test("chat client searches artists via artist search endpoint", async () => {
     apiBaseUrl: "http://localhost:3001",
     fetchImpl: async (url, init) => {
       calls.push({ url, init });
-      return {
-        ok: true,
-        status: 200,
-        json: async () => ({
+      return jsonResponse({
           artists: [{ id: "mb-1", name: "Fen", score: 100, disambiguation: "" }],
-        }),
-      };
+        });
     },
   });
 
@@ -149,13 +134,9 @@ test("chat client creates a new session", async () => {
     apiBaseUrl: "http://localhost:3001",
     fetchImpl: async (url, init) => {
       calls.push({ url, init });
-      return {
-        ok: true,
-        status: 201,
-        json: async () => ({
+      return jsonResponse({
           session: { id: "sess-1", title: "Post-black", createdAt: "2026-01-01T00:00:00Z" },
-        }),
-      };
+        }, { status: 201 });
     },
   });
 
@@ -168,10 +149,7 @@ test("chat client creates a new session", async () => {
 test("chat client lists sessions", async () => {
   const client = createChatClient({
     apiBaseUrl: "http://localhost:3001",
-    fetchImpl: async () => ({
-      ok: true,
-      json: async () => ({ sessions: [{ id: "sess-1", title: "Test" }] }),
-    }),
+    fetchImpl: async () => (jsonResponse({ sessions: [{ id: "sess-1", title: "Test" }] })),
   });
 
   const result = await client.listSessions();
@@ -184,10 +162,7 @@ test("chat client appends a message to a session", async () => {
     apiBaseUrl: "http://localhost:3001",
     fetchImpl: async (url, init) => {
       calls.push({ url, init });
-      return {
-        ok: true,
-        json: async () => ({ message: { id: "msg-1", role: "user", content: "I like Alcest" } }),
-      };
+      return jsonResponse({ message: { id: "msg-1", role: "user", content: "I like Alcest" } });
     },
   });
 
@@ -202,11 +177,7 @@ test("chat client sends selectedArtistIds when provided", async () => {
     apiBaseUrl: "http://localhost:3001",
     fetchImpl: async (url, init) => {
       calls.push({ url, init });
-      return {
-        ok: true,
-        status: 200,
-        json: async () => ({ recommendations: [], meta: { modeUsed: "preference-aware", usedPreferenceContext: true } }),
-      };
+      return jsonResponse({ recommendations: [], meta: { modeUsed: "preference-aware", usedPreferenceContext: true } });
     },
   });
 
@@ -221,14 +192,10 @@ test("chat client sends priorityContext in recommendations when provided", async
     apiBaseUrl: "http://localhost:3001",
     fetchImpl: async (url, init) => {
       calls.push({ url, init });
-      return {
-        ok: true,
-        status: 200,
-        json: async () => ({
+      return jsonResponse({
           recommendations: [],
           meta: { modeUsed: "fresh", usedPreferenceContext: true },
-        }),
-      };
+        });
     },
   });
 
@@ -244,11 +211,7 @@ test("chat client sends conversation messages in recommendations request", async
     apiBaseUrl: "http://localhost:3001",
     fetchImpl: async (url, init) => {
       calls.push({ url, init });
-      return {
-        ok: true,
-        status: 200,
-        json: async () => ({ recommendations: [], meta: { modeUsed: "fresh", usedPreferenceContext: false } }),
-      };
+      return jsonResponse({ recommendations: [], meta: { modeUsed: "fresh", usedPreferenceContext: false } });
     },
   });
 
@@ -271,14 +234,10 @@ test("chat client includes obscurityTarget in recommendations request body when 
     apiBaseUrl: "http://localhost:3001",
     fetchImpl: async (url, init) => {
       calls.push({ url, init });
-      return {
-        ok: true,
-        status: 200,
-        json: async () => ({
+      return jsonResponse({
           recommendations: [],
           meta: { modeUsed: "fresh", usedPreferenceContext: false, eventId: "evt-123" },
-        }),
-      };
+        });
     },
   });
 
@@ -293,11 +252,7 @@ test("chat client omits obscurityTarget from request body when not provided", as
     apiBaseUrl: "http://localhost:3001",
     fetchImpl: async (url, init) => {
       calls.push({ url, init });
-      return {
-        ok: true,
-        status: 200,
-        json: async () => ({ recommendations: [], meta: { modeUsed: "fresh" } }),
-      };
+      return jsonResponse({ recommendations: [], meta: { modeUsed: "fresh" } });
     },
   });
 
@@ -317,10 +272,7 @@ test("chat client fetches saved bands from GET /preferences", async () => {
     apiBaseUrl: "http://localhost:3001",
     fetchImpl: async (url, init) => {
       calls.push({ url, method: init?.method });
-      return {
-        ok: true,
-        json: async () => ({ savedBands: [{ id: "b1", name: "Fen", rating: 3 }] }),
-      };
+      return jsonResponse({ savedBands: [{ id: "b1", name: "Fen", rating: 3 }] });
     },
   });
 
@@ -329,7 +281,7 @@ test("chat client fetches saved bands from GET /preferences", async () => {
   assert.equal(calls[0].url, "http://localhost:3001/preferences");
   assert.equal(calls[0].method, "GET");
   assert.equal(bands.length, 1);
-  assert.equal(bands[0].name, "Fen");
+  assert.equal(/** @type {{ name: string }} */ (bands[0]).name, "Fen");
 });
 
 test("chat client deletes a preference via DELETE /preferences/:id", async () => {
@@ -338,7 +290,7 @@ test("chat client deletes a preference via DELETE /preferences/:id", async () =>
     apiBaseUrl: "http://localhost:3001",
     fetchImpl: async (url, init) => {
       calls.push({ url, method: init?.method });
-      return { ok: true, json: async () => ({ ok: true }) };
+      return jsonResponse({ ok: true });
     },
   });
 
@@ -354,11 +306,7 @@ test("fetchRecommendations forwards AbortSignal to fetch", async () => {
     apiBaseUrl: "http://localhost:3001",
     fetchImpl: async (url, init) => {
       capturedSignal = init?.signal;
-      return {
-        ok: true,
-        status: 200,
-        json: async () => ({ recommendations: [], meta: {} }),
-      };
+      return jsonResponse({ recommendations: [], meta: {} });
     },
   });
 

--- a/apps/desktop/test/chat-render-adapter.test.js
+++ b/apps/desktop/test/chat-render-adapter.test.js
@@ -23,8 +23,12 @@ function makeDesktopUi(overrides = {}) {
   let mode = "fresh";
   let obscurityTarget = "underground";
   let conversation = null;
+  let viewport = "desktop";
   return {
-    getViewport: () => "desktop",
+    setViewport: (v) => { viewport = v; },
+    getViewport: () => viewport,
+    cancelSearch: () => {},
+    retryLastSearch: async () => {},
     getMode: () => mode,
     isLoading: () => false,
     isShowFeedbackBar: () => false,

--- a/apps/desktop/test/chat-session-app.test.js
+++ b/apps/desktop/test/chat-session-app.test.js
@@ -2,36 +2,25 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 
 const { bootstrapDesktopApp } = require("../src/index");
+const { jsonResponse } = require("./helpers/fakeResponse");
 
 function createStubFetch({ sessionId = "sess-1", recommendations = [] } = {}) {
   return async (url, init) => {
     const method = init?.method || "GET";
     if (url.includes("/sessions") && method === "POST" && !url.match(/sessions\/[^/]+\/messages/)) {
-      return {
-        ok: true,
-        json: async () => ({ session: { id: sessionId, title: "Test", createdAt: "2026-01-01T00:00:00Z" } }),
-      };
+      return jsonResponse({ session: { id: sessionId, title: "Test", createdAt: "2026-01-01T00:00:00Z" } });
     }
     if (url.match(/sessions\/[^/]+\/messages/) && method === "POST") {
       const body = JSON.parse(init?.body || "{}");
-      return {
-        ok: true,
-        json: async () => ({ message: { id: `msg-${Date.now()}`, ...body } }),
-      };
+      return jsonResponse({ message: { id: `msg-${Date.now()}`, ...body } });
     }
     if (url.includes("/sessions") && method === "GET") {
-      return {
-        ok: true,
-        json: async () => ({ sessions: [{ id: sessionId, title: "Test" }] }),
-      };
+      return jsonResponse({ sessions: [{ id: sessionId, title: "Test" }] });
     }
     if (url.includes("/recommendations")) {
-      return {
-        ok: true,
-        json: async () => ({ recommendations, meta: { modeUsed: "fresh", usedPreferenceContext: false } }),
-      };
+      return jsonResponse({ recommendations, meta: { modeUsed: "fresh", usedPreferenceContext: false } });
     }
-    return { ok: true, json: async () => ({}) };
+    return jsonResponse({});
   };
 }
 

--- a/apps/desktop/test/chat-view-model.test.js
+++ b/apps/desktop/test/chat-view-model.test.js
@@ -3,6 +3,7 @@ const assert = require("node:assert/strict");
 
 const { createChatAppModel } = require("../src/chatAppModel");
 const { bootstrapDesktopApp } = require("../src/bootstrapDesktopApp");
+const { jsonResponse } = require("./helpers/fakeResponse");
 
 test("chat app model tracks mode and sends queries through app interface", async () => {
   const calls = [];
@@ -56,7 +57,9 @@ test("chat app model formats recommendation list for rendering", () => {
 
   const conversation = vm.getConversation();
   assert.ok(conversation, "conversation is non-null");
-  const cards = conversation[0].cards;
+  const first = conversation[0];
+  assert.ok(first.role === "assistant", "first conversation entry is the assistant reply");
+  const cards = first.cards;
   assert.equal(cards.length, 1);
   assert.equal(cards[0].title, "Fen");
   assert.ok(cards[0].why.includes("Post-metal"), "why field preserved");
@@ -183,7 +186,10 @@ test("chatAppModel.retryLastSearch is a no-op when lastQuery is empty", async ()
 });
 
 test("chatAppModel.submitQuery swallows AbortError and resets loadingState", async () => {
-  let rejectWithAbort;
+  /** @type {(reason?: unknown) => void} */
+  let rejectWithAbort = () => {
+    throw new Error("rejectWithAbort called before the search promise was created");
+  };
   const vm = createChatAppModel({
     app: {
       requestRecommendations: async () => {
@@ -203,7 +209,7 @@ test("chatAppModel.submitQuery swallows AbortError and resets loadingState", asy
 
 test("bootstrapDesktopApp.cancelSearch is a no-op when idle", () => {
   const app = bootstrapDesktopApp({
-    fetchImpl: async () => ({ ok: true, status: 200, json: async () => ({ recommendations: [], meta: {} }) }),
+    fetchImpl: async () => (jsonResponse({ recommendations: [], meta: {} })),
   });
   // Should not throw
   assert.doesNotThrow(() => app.cancelSearch());

--- a/apps/desktop/test/desktop-react-shell.test.js
+++ b/apps/desktop/test/desktop-react-shell.test.js
@@ -1,5 +1,7 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const { fakeDesktopApp } = require("./helpers/fakeApp");
+const { chatViewProps } = require("./helpers/fakeViewProps");
 
 const { BandsearchHttpError } = require("../src/chatClient");
 const { bootstrapDesktopReactShell } = require("../src");
@@ -8,7 +10,7 @@ const { createDesktopReactShell } = require("../src/ui/createDesktopReactShell")
 test("desktop react shell renders HTML with recommendation card and actions", async () => {
   const appState = { messages: [] };
   const shell = bootstrapDesktopReactShell({
-    app: {
+    app: fakeDesktopApp({
       requestRecommendations: async () => {
         appState.messages = [
           {
@@ -26,7 +28,7 @@ test("desktop react shell renders HTML with recommendation card and actions", as
         return { recommendations: appState.messages[0].recommendations, meta: appState.messages[0].meta };
       },
       getState: () => appState,
-    },
+    }),
   });
 
   await shell.submitQuery("I like post-black metal");
@@ -40,7 +42,7 @@ test("desktop react shell renders HTML with recommendation card and actions", as
 test("desktop react shell save and rate actions call app handlers", async () => {
   const calls = [];
   const shell = bootstrapDesktopReactShell({
-    app: {
+    app: fakeDesktopApp({
       requestRecommendations: async () => ({ recommendations: [], meta: { modeUsed: "fresh" } }),
       getState: () => ({ messages: [] }),
       saveBand: async (artistName) => {
@@ -49,7 +51,7 @@ test("desktop react shell save and rate actions call app handlers", async () => 
       rateBand: async (artistName, rating) => {
         calls.push({ type: "rate", artistName, rating });
       },
-    },
+    }),
   });
 
   await shell.saveBand("Fen");
@@ -68,7 +70,7 @@ test("desktop react shell save and rate actions call app handlers", async () => 
 test("desktop react shell maps BandsearchHttpError to a human recommendation error banner", async () => {
   const shell = createDesktopReactShell({
     renderAdapter: {
-      getViewProps: () => ({
+      getViewProps: () => chatViewProps({
         headerTitle: "Bandsearch",
         headerSubtitle: "Niche recommendations",
         viewport: "desktop",
@@ -77,7 +79,6 @@ test("desktop react shell maps BandsearchHttpError to a human recommendation err
         queryPlaceholder: "Describe bands...",
         queryDisabled: false,
         cards: [],
-        emptyText: "No recommendations yet.",
       }),
       onModeChange: () => ({}),
       onSubmitQuery: async () => {
@@ -96,10 +97,13 @@ test("desktop react shell maps BandsearchHttpError to a human recommendation err
 });
 
 test("desktop react shell clears action status after timeout", async () => {
-  let scheduled;
+  /** @type {() => void} */
+  let scheduled = () => {
+    throw new Error("scheduled callback invoked before setTimeoutImpl ran");
+  };
   const shell = createDesktopReactShell({
     renderAdapter: {
-      getViewProps: () => ({
+      getViewProps: () => chatViewProps({
         headerTitle: "Bandsearch",
         headerSubtitle: "Niche recommendations",
         viewport: "desktop",
@@ -108,7 +112,6 @@ test("desktop react shell clears action status after timeout", async () => {
         queryPlaceholder: "Describe bands...",
         queryDisabled: false,
         cards: [],
-        emptyText: "No recommendations yet.",
       }),
       onModeChange: () => ({}),
       onSubmitQuery: async () => ({}),
@@ -136,7 +139,7 @@ test("createDesktopReactShell exposes cancelSearch and retryLastSearch from prov
     renderAdapter: {
       onModeChange: () => {},
       onSubmitQuery: async () => {},
-      getViewProps: () => ({ modeValue: "fresh", modeOptions: [], isLoading: false, queryDisabled: false, queryPlaceholder: "", cards: [], actionStatus: null }),
+      getViewProps: () => chatViewProps({ modeValue: "fresh", modeOptions: [], isLoading: false, queryDisabled: false, queryPlaceholder: "", cards: [], actionStatus: null }),
     },
     cancelSearchImpl: () => { cancelled = true; },
     retryLastSearchImpl: () => { retried = true; },
@@ -157,7 +160,7 @@ test("desktop react shell renderHtml includes all three obscurity picker buttons
       onModeChange: () => {},
       onSubmitQuery: async () => {},
       onObscurityTargetChange: () => {},
-      getViewProps: () => ({
+      getViewProps: () => chatViewProps({
         headerTitle: "Bandsearch",
         viewport: "desktop",
         modeValue: "fresh",

--- a/apps/desktop/test/desktop-render-adapter-bootstrap.test.js
+++ b/apps/desktop/test/desktop-render-adapter-bootstrap.test.js
@@ -1,14 +1,15 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const { fakeDesktopApp } = require("./helpers/fakeApp");
 
 const { bootstrapDesktopRenderAdapter } = require("../src");
 
 test("desktop render adapter bootstrap exposes initial view props", () => {
   const adapter = bootstrapDesktopRenderAdapter({
-    app: {
+    app: fakeDesktopApp({
       requestRecommendations: async () => ({ recommendations: [], meta: { modeUsed: "fresh" } }),
       getState: () => ({ messages: [] }),
-    },
+    }),
   });
 
   const props = adapter.getViewProps();
@@ -18,10 +19,10 @@ test("desktop render adapter bootstrap exposes initial view props", () => {
 
 test("desktopUi.setViewport updates view props viewport", () => {
   const adapter = bootstrapDesktopRenderAdapter({
-    app: {
+    app: fakeDesktopApp({
       requestRecommendations: async () => ({ recommendations: [], meta: { modeUsed: "fresh" } }),
       getState: () => ({ messages: [] }),
-    },
+    }),
   });
 
   assert.equal(adapter.getViewProps().viewport, "desktop");

--- a/apps/desktop/test/desktop-ui-bootstrap.test.js
+++ b/apps/desktop/test/desktop-ui-bootstrap.test.js
@@ -1,15 +1,16 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const { fakeDesktopApp } = require("./helpers/fakeApp");
 
 const { bootstrapDesktopUi } = require("../src");
 const { createDesktopChatUiStack } = require("../src/desktopChatUiStack");
 
 test("desktop ui bootstrap exposes mode get/set", () => {
   const ui = bootstrapDesktopUi({
-    app: {
+    app: fakeDesktopApp({
       requestRecommendations: async () => ({ recommendations: [], meta: { modeUsed: "fresh" } }),
       getState: () => ({ messages: [], savedBands: [] }),
-    },
+    }),
   });
 
   assert.equal(ui.getMode(), "fresh");
@@ -20,7 +21,7 @@ test("desktop ui bootstrap exposes mode get/set", () => {
 test("desktop ui bootstrap refreshes conversation after query submission", async () => {
   const appState = { messages: [], savedBands: [] };
   const ui = bootstrapDesktopUi({
-    app: {
+    app: fakeDesktopApp({
       requestRecommendations: async () => {
         appState.messages = [
           {
@@ -39,7 +40,7 @@ test("desktop ui bootstrap refreshes conversation after query submission", async
         return { recommendations: appState.messages[0].recommendations, meta: appState.messages[0].meta };
       },
       getState: () => appState,
-    },
+    }),
   });
 
   await ui.submitQuery("I like blackgaze");
@@ -52,11 +53,11 @@ test("desktop ui bootstrap refreshes conversation after query submission", async
 test("desktopChatUiStack exposes cancelSearch that delegates to app.cancelSearch", () => {
   let cancelled = false;
   const stack = createDesktopChatUiStack({
-    app: {
+    app: fakeDesktopApp({
       requestRecommendations: async () => ({ recommendations: [], meta: {} }),
       cancelSearch: () => { cancelled = true; },
       getState: () => ({ messages: [], savedBands: [] }),
-    },
+    }),
   });
 
   stack.cancelSearch();
@@ -66,14 +67,14 @@ test("desktopChatUiStack exposes cancelSearch that delegates to app.cancelSearch
 test("desktopChatUiStack exposes retryLastSearch that delegates to appModel", async () => {
   const calls = [];
   const stack = createDesktopChatUiStack({
-    app: {
+    app: fakeDesktopApp({
       requestRecommendations: async (query) => {
         calls.push(query);
         return { recommendations: [], meta: {} };
       },
       cancelSearch: () => {},
       getState: () => ({ messages: [], savedBands: [] }),
-    },
+    }),
   });
 
   await stack.submitQuery("jazz fusion");

--- a/apps/desktop/test/helpers/fakeApp.ts
+++ b/apps/desktop/test/helpers/fakeApp.ts
@@ -20,8 +20,6 @@ export function fakeDesktopApp(overrides: Partial<DesktopApp> = {}): DesktopApp 
     listSavedBands: async () => [],
     deleteSavedBand: async () => undefined,
     searchArtists: async () => [],
-    listGroups: async () => [],
-    createGroup: async () => undefined,
     ...overrides,
   };
 }

--- a/apps/desktop/test/helpers/fakeApp.ts
+++ b/apps/desktop/test/helpers/fakeApp.ts
@@ -1,0 +1,27 @@
+import type { SavedArtistsCollaborator } from "../../src/savedArtistsModel.js";
+import type { ChatAppCollaborator } from "../../src/chatAppModel.js";
+
+type DesktopApp = ChatAppCollaborator &
+  SavedArtistsCollaborator & {
+    getView?(): string;
+    navigate?(view: string): unknown;
+    saveBand?(artistName: string): unknown;
+    rateBand?(artistName: string, rating?: number): unknown;
+    setPendingStyleRef?(ids: string[]): void;
+  };
+
+// A complete app double, so each test only states the collaborator calls it
+// actually exercises instead of restating the whole surface.
+export function fakeDesktopApp(overrides: Partial<DesktopApp> = {}): DesktopApp {
+  return {
+    requestRecommendations: async () => ({ meta: {} }),
+    sendFeedback: async () => undefined,
+    getState: () => ({ messages: [], savedBands: [] }),
+    listSavedBands: async () => [],
+    deleteSavedBand: async () => undefined,
+    searchArtists: async () => [],
+    listGroups: async () => [],
+    createGroup: async () => undefined,
+    ...overrides,
+  };
+}

--- a/apps/desktop/test/helpers/fakeDom.ts
+++ b/apps/desktop/test/helpers/fakeDom.ts
@@ -1,0 +1,19 @@
+// Stand-ins for the few DOM objects the desktop shell takes as collaborators.
+//
+// The production code only stores these and hands them to React or reads one or
+// two fields, so a full DOM implementation would be noise. These helpers keep
+// the narrowing in one place instead of casting at every call site.
+
+/** A mount container. React roots are faked in these tests, so nothing reads it. */
+export function fakeContainer(props: Partial<HTMLElement> = {}): HTMLElement {
+  return props as unknown as HTMLElement;
+}
+
+/** A matchMedia result; only `matches` and the listener hooks are exercised. */
+export function fakeMediaQueryList(matches: boolean): MediaQueryList {
+  return {
+    matches,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  } as unknown as MediaQueryList;
+}

--- a/apps/desktop/test/helpers/fakeResponse.ts
+++ b/apps/desktop/test/helpers/fakeResponse.ts
@@ -1,0 +1,19 @@
+// Test doubles for fetch.
+//
+// Tests used to hand production code object literals like `{ ok, status, json }`.
+// Those satisfy the few properties the code touches but are not a Response, so
+// none of it type-checked and a double could drift from what fetch really
+// returns. Building a real Response keeps the doubles honest and the types quiet.
+
+export function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+    ...init,
+  });
+}
+
+/** A Response with a non-2xx status, for exercising error paths. */
+export function errorResponse(status: number, body: unknown = {}): Response {
+  return jsonResponse(body, { status });
+}

--- a/apps/desktop/test/helpers/fakeViewProps.ts
+++ b/apps/desktop/test/helpers/fakeViewProps.ts
@@ -1,0 +1,23 @@
+import type { ChatViewProps } from "../../src/chatRenderAdapter.js";
+
+// A complete ChatViewProps so each test only states the fields it asserts on.
+// Without this the shell's getViewProps seam would have to be typed loosely,
+// which is what let the views drift from the adapter in the first place.
+const BASE: ChatViewProps = {
+  headerTitle: "Bandsearch",
+  headerSubtitle: "Niche music recommendations",
+  viewport: "desktop",
+  modeValue: "fresh",
+  modeOptions: [],
+  isLoading: false,
+  queryPlaceholder: "Describe bands you like...",
+  queryDisabled: false,
+  obscurityTarget: undefined,
+  showFeedbackBar: false,
+  cards: [],
+  messages: undefined,
+};
+
+export function chatViewProps(overrides: Partial<ChatViewProps> = {}): ChatViewProps {
+  return { ...BASE, ...overrides };
+}

--- a/apps/desktop/test/mount-desktop-react-app.test.js
+++ b/apps/desktop/test/mount-desktop-react-app.test.js
@@ -2,6 +2,7 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 
 const { createDesktopReactMount } = require("../src/ui/mountDesktopReactApp");
+const { fakeContainer } = require("./helpers/fakeDom");
 
 test("desktop react mount renders and wires interaction callbacks", async () => {
   const calls = [];
@@ -11,7 +12,7 @@ test("desktop react mount renders and wires interaction callbacks", async () => 
     },
   };
   const fakeCreateRoot = () => fakeRoot;
-  const fakeContainer = {};
+  const container = fakeContainer();
 
   const shell = {
     getViewProps: () => ({
@@ -33,7 +34,7 @@ test("desktop react mount renders and wires interaction callbacks", async () => 
   const mount = createDesktopReactMount({
     shell,
     createRootImpl: fakeCreateRoot,
-    resolveContainer: () => fakeContainer,
+    resolveContainer: () => container,
   });
 
   mount.mount();
@@ -62,7 +63,7 @@ test("createDesktopReactMount exposes onStop handler that calls shell.cancelSear
       retryLastSearch: async () => {},
     },
     createRootImpl: () => ({ render: () => {} }),
-    resolveContainer: () => ({ id: "root" }),
+    resolveContainer: () => fakeContainer({ id: "root" }),
   });
 
   await mountApi.handlers.onStop?.();
@@ -81,7 +82,7 @@ test("createDesktopReactMount exposes onRetry handler that calls shell.retryLast
       retryLastSearch: async () => { retried = true; },
     },
     createRootImpl: () => ({ render: () => {} }),
-    resolveContainer: () => ({ id: "root" }),
+    resolveContainer: () => fakeContainer({ id: "root" }),
   });
 
   await mountApi.handlers.onRetry?.();

--- a/apps/desktop/test/routed-mount.test.js
+++ b/apps/desktop/test/routed-mount.test.js
@@ -2,6 +2,7 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 
 const { createDesktopReactMount } = require("../src/ui/mountDesktopReactApp");
+const { fakeContainer } = require("./helpers/fakeDom");
 
 function makeShell(overrides = {}) {
   return {
@@ -72,7 +73,7 @@ test("routed mount calls render with SavedArtistsView when route is saved", asyn
     router,
     savedArtistsShell: savedShell,
     createRootImpl: () => fakeRoot,
-    resolveContainer: () => ({}),
+    resolveContainer: () => fakeContainer(),
   });
 
   await mount.mount();
@@ -94,7 +95,7 @@ test("routed mount calls render with ChatAppView when route is home", async () =
     router,
     savedArtistsShell: savedShell,
     createRootImpl: () => fakeRoot,
-    resolveContainer: () => ({}),
+    resolveContainer: () => fakeContainer(),
   });
 
   await mount.mount();
@@ -116,7 +117,7 @@ test("routed mount calls render with WelcomeView when route is welcome", async (
     router,
     savedArtistsShell: savedShell,
     createRootImpl: () => fakeRoot,
-    resolveContainer: () => ({}),
+    resolveContainer: () => fakeContainer(),
   });
 
   await mount.mount();
@@ -143,7 +144,7 @@ test("routed mount calls render with SettingsView when route is settings", async
       statusMessage: null,
     }),
     createRootImpl: () => fakeRoot,
-    resolveContainer: () => ({}),
+    resolveContainer: () => fakeContainer(),
   });
 
   await mount.mount();
@@ -163,7 +164,7 @@ test("routed mount settingsHandlers.onSaveTursoConfig calls provided saveTursoCo
     getSettingsViewProps: () => ({ headerTitle: "Settings", hasStoredKey: false }),
     saveTursoConfig: async (url, token) => { calls.push({ url, token }); },
     createRootImpl: () => ({ render: () => {} }),
-    resolveContainer: () => ({}),
+    resolveContainer: () => fakeContainer(),
   });
 
   await mount.handlers.onSaveTursoConfig("libsql://test.turso.io", "mytoken");

--- a/apps/desktop/test/saved-artists-app.test.js
+++ b/apps/desktop/test/saved-artists-app.test.js
@@ -2,25 +2,23 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 
 const { bootstrapDesktopApp } = require("../src/index");
+const { jsonResponse } = require("./helpers/fakeResponse");
 
 function createStubFetch({ savedBands = [], artists = [], recommendations = [] } = {}) {
   return async (url, init) => {
     if (url.includes("/preferences") && (!init || init.method === "GET")) {
-      return { ok: true, json: async () => ({ savedBands }) };
+      return jsonResponse({ savedBands });
     }
     if (url.includes("/artists/search")) {
-      return { ok: true, json: async () => ({ artists }) };
+      return jsonResponse({ artists });
     }
     if (url.includes("/recommendations")) {
-      return {
-        ok: true,
-        json: async () => ({
+      return jsonResponse({
           recommendations,
           meta: { modeUsed: "fresh", usedPreferenceContext: false },
-        }),
-      };
+        });
     }
-    return { ok: true, json: async () => ({}) };
+    return jsonResponse({});
   };
 }
 
@@ -33,7 +31,7 @@ test("app.listSavedBands fetches and returns saved bands", async () => {
 
   const bands = await app.listSavedBands();
   assert.equal(bands.length, 1);
-  assert.equal(bands[0].name, "Fen");
+  assert.equal(/** @type {{ name: string }} */ (bands[0]).name, "Fen");
 });
 
 test("app.searchArtists returns MusicBrainz artist results", async () => {
@@ -69,12 +67,9 @@ test("app.requestRecommendations sends priorityContext when artists are selected
   const fetchImpl = async (url, init) => {
     if (url.includes("/recommendations")) {
       requestBodies.push(JSON.parse(init.body));
-      return {
-        ok: true,
-        json: async () => ({ recommendations: [], meta: { modeUsed: "fresh", usedPreferenceContext: false } }),
-      };
+      return jsonResponse({ recommendations: [], meta: { modeUsed: "fresh", usedPreferenceContext: false } });
     }
-    return { ok: true, json: async () => ({}) };
+    return jsonResponse({});
   };
 
   const app = bootstrapDesktopApp({ fetchImpl });

--- a/apps/desktop/test/saved-artists-model.test.js
+++ b/apps/desktop/test/saved-artists-model.test.js
@@ -8,12 +8,8 @@ function makeApp(savedBands = []) {
   return {
     listSavedBands: async () => bands,
     deleteSavedBand: async (id) => { const i = bands.findIndex((b) => b.id === id); if (i >= 0) bands.splice(i, 1); },
-    // Defaults so each test only states the collaborator calls it cares about.
+    // Default so each test only states the collaborator calls it cares about.
     searchArtists: async () => [],
-    importArtists: async () => ({ imported: 0, skipped: 0, failed: 0 }),
-    listGroups: async () => [],
-    createGroup: async () => ({}),
-    autoGroupByGenre: async () => ({}),
   };
 }
 
@@ -198,93 +194,4 @@ test("saved artists model clears search results for empty query", async () => {
   assert.equal(model.getScreenState().searchResults.length, 1);
   await model.searchArtists("");
   assert.equal(model.getScreenState().searchResults.length, 0);
-});
-
-test("saved artists model exportArtists returns raw saved bands from app", async () => {
-  const bands = [{ id: "b1", name: "Fen", rating: 4, categories: ["post-metal"], note: "" }];
-  const model = createSavedArtistsModel({ app: makeApp(bands) });
-  await model.loadSavedArtists();
-
-  const exported = await model.exportArtists();
-
-  assert.equal(Array.isArray(exported), true);
-  assert.equal(exported.length, 1);
-  assert.equal(exported[0].name, "Fen");
-});
-
-test("saved artists model loadGroups stores groups in screen state", async () => {
-  const model = createSavedArtistsModel({
-    app: {
-      ...makeApp(),
-      listGroups: async () => [{ id: "g1", name: "Blackgaze", memberIds: [] }],
-    },
-  });
-
-  await model.loadGroups();
-
-  const state = model.getScreenState();
-  assert.equal(Array.isArray(state.groups), true);
-  assert.equal(state.groups.length, 1);
-  assert.equal(state.groups[0].name, "Blackgaze");
-});
-
-test("saved artists model createGroup calls app and reloads groups", async () => {
-  const created = [];
-  const model = createSavedArtistsModel({
-    app: {
-      ...makeApp(),
-      listGroups: async () => created.map((n, i) => ({ id: `g${i}`, name: n, memberIds: [] })),
-      createGroup: async (name) => { created.push(name); return { ok: true, group: { id: "g0", name, memberIds: [] } }; },
-    },
-  });
-
-  await model.createGroup("Post-metal");
-
-  const state = model.getScreenState();
-  assert.equal(state.groups.length, 1);
-  assert.equal(state.groups[0].name, "Post-metal");
-});
-
-test("saved artists model autoGroupByGenre calls app and reloads groups", async () => {
-  let autoCalled = false;
-  const model = createSavedArtistsModel({
-    app: {
-      ...makeApp(),
-      listGroups: async () => autoCalled ? [{ id: "g1", name: "blackgaze", memberIds: [] }] : [],
-      autoGroupByGenre: async () => { autoCalled = true; return { groups: [] }; },
-    },
-  });
-
-  await model.autoGroupByGenre();
-
-  assert.equal(autoCalled, true);
-  const state = model.getScreenState();
-  assert.equal(Array.isArray(state.groups), true);
-});
-
-test("saved artists model importArtists calls app importArtists and reloads", async () => {
-  let importCalled = false;
-  let importedBands = null;
-  const store = [];
-  const app = {
-    ...makeApp(),
-    listSavedBands: async () => [...store],
-    deleteSavedBand: async (id) => { const i = store.findIndex((b) => b.id === id); if (i >= 0) store.splice(i, 1); },
-    importArtists: async (toImport) => {
-      importCalled = true;
-      importedBands = toImport;
-      store.push(...toImport.map((b, i) => ({ ...b, id: `imported-${i}` })));
-      return { imported: toImport.length, skipped: 0 };
-    },
-  };
-
-  const model = createSavedArtistsModel({ app });
-  const payload = [{ musicbrainzArtistId: "x1", name: "Alcest", rating: 5, categories: [], note: "" }];
-  const result = await model.importArtists(payload);
-
-  assert.equal(importCalled, true);
-  assert.deepEqual(importedBands, payload);
-  assert.equal(result.imported, 1);
-  assert.equal(result.skipped, 0);
-  assert.equal(model.getScreenState().artists.length, 1);
 });

--- a/apps/desktop/test/saved-artists-model.test.js
+++ b/apps/desktop/test/saved-artists-model.test.js
@@ -8,6 +8,12 @@ function makeApp(savedBands = []) {
   return {
     listSavedBands: async () => bands,
     deleteSavedBand: async (id) => { const i = bands.findIndex((b) => b.id === id); if (i >= 0) bands.splice(i, 1); },
+    // Defaults so each test only states the collaborator calls it cares about.
+    searchArtists: async () => [],
+    importArtists: async () => ({ imported: 0, skipped: 0, failed: 0 }),
+    listGroups: async () => [],
+    createGroup: async () => ({}),
+    autoGroupByGenre: async () => ({}),
   };
 }
 
@@ -39,6 +45,7 @@ test("saved artists model maps saved bands to UI items after load", async () => 
 test("saved artists model sets isLoading true during load", async () => {
   let observedDuringLoad = null;
   const app = {
+    ...makeApp(),
     listSavedBands: async () => {
       observedDuringLoad = model.getScreenState().isLoading;
       return [];
@@ -75,7 +82,10 @@ test("saved artists model tracks search results after searchArtists call", async
 });
 
 test("saved artists model isSearching is true during search", async () => {
-  let resolveSearch;
+  /** @type {(value?: unknown) => void} */
+  let resolveSearch = () => {
+    throw new Error("resolveSearch called before the search promise was created");
+  };
   const model = createSavedArtistsModel({
     app: {
       ...makeApp(),
@@ -257,6 +267,7 @@ test("saved artists model importArtists calls app importArtists and reloads", as
   let importedBands = null;
   const store = [];
   const app = {
+    ...makeApp(),
     listSavedBands: async () => [...store],
     deleteSavedBand: async (id) => { const i = store.findIndex((b) => b.id === id); if (i >= 0) store.splice(i, 1); },
     importArtists: async (toImport) => {

--- a/apps/desktop/test/start-desktop-browser-app.test.js
+++ b/apps/desktop/test/start-desktop-browser-app.test.js
@@ -1,5 +1,7 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const { jsonResponse } = require("./helpers/fakeResponse");
+const { fakeMediaQueryList } = require("./helpers/fakeDom");
 
 test("startDesktopBrowserApp mounts bootstrapped react app", async () => {
   const modulePath = require.resolve("../src/index");
@@ -56,13 +58,7 @@ test("startDesktopBrowserApp uses the configured remote endpoint as the API base
     },
   };
 
-  const fakeFetch = async () => ({
-    ok: true,
-    status: 200,
-    json: async () => ({ enabled: false, userCount: 0 }),
-    clone() { return this; },
-    text: async () => "",
-  });
+  const fakeFetch = async () => (jsonResponse({ enabled: false, userCount: 0 }));
 
   delete require.cache[require.resolve("../src/startDesktopBrowserApp")];
   const { startDesktopBrowserApp } = require("../src/startDesktopBrowserApp");
@@ -106,12 +102,9 @@ test("startDesktopBrowserApp picks mobile viewport when matchMedia matches narro
   };
 
   const prevWindow = globalThis.window;
-  globalThis.window = {
-    matchMedia: (query) => ({
-      matches: query.includes("max-width"),
-      addEventListener: () => {},
-    }),
-  };
+  globalThis.window = /** @type {typeof globalThis.window} */ ({
+    matchMedia: (query) => fakeMediaQueryList(query.includes("max-width")),
+  });
 
   delete require.cache[require.resolve("../src/startDesktopBrowserApp")];
   const { startDesktopBrowserApp } = require("../src/startDesktopBrowserApp");

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -12,5 +12,11 @@
     "types": ["node"],
     "noEmit": true
   },
-  "include": ["src/**/*.js", "src/**/*.ts", "test/**/*.ts"]
+  "include": [
+    "src/**/*.js",
+    "src/**/*.ts",
+    "test/**/*.js",
+    "test/**/*.ts",
+    "scripts/**/*.js"
+  ]
 }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -264,3 +264,20 @@ Resolved — `fetchWithTimeoutAndRetry` now lives in `services/api/src/integrati
 `authAwareFetch` injects `Authorization: Bearer <token>` on every request. Once a user overrides the API endpoint in Settings, all requests — including auth API calls — go to the user-supplied URL carrying the JWT. In a self-hosted scenario with a trusted operator-supplied URL this is correct behaviour; if the URL were somehow corrupted (e.g. a stored config tampered on disk) the token could be sent to an unintended host.
 
 **Note (low priority, no immediate action):** The desktop is a local trust boundary, so this risk is low. Document the invariant in `authAwareFetch.ts`: tokens are sent to `apiBaseUrl` only, and `apiBaseUrl` originates from either the default localhost or the URL the user explicitly saved in Settings. Revisit if the app ever accepts the endpoint from a non-user source (e.g. a deep-link or QR code).
+
+---
+
+### 7. Saved artists: one screen served by two competing implementations ← **next up**
+
+**Files:** `apps/desktop/src/savedArtistsModel.ts`, `apps/desktop/src/createSavedArtistsShell.ts`, `apps/desktop/src/ui/mountDesktopReactApp.ts`, `apps/desktop/src/index.ts`, `apps/desktop/src/ui/createDesktopReactShell.ts`
+
+Two modules hold saved-artists state and talk to the same app object, and which one serves the screen depends on how the app was assembled:
+
+- **Live path:** `startDesktopBrowserApp.ts:108` builds `createSavedArtistsShell({ app })` and hands it to the mount; `mountDesktopReactApp` renders `SavedArtistsView` from `savedArtistsShell.getViewProps()`.
+- **Second path:** `index.ts` wires `savedArtistsModel.getScreenState()` into `createDesktopReactShell` as `getSavedArtistsViewPropsImpl`, which serves the same screen when `shell.getView() === "saved-artists"` and no `savedArtistsShell` was supplied.
+
+The duplication had already rotted. Five `savedArtistsModel` methods (`exportArtists`, `importArtists`, `loadGroups`, `createGroup`, `autoGroupByGenre`) were unreachable from production code, and two of them called `app.importArtists` / `app.autoGroupByGenre` — which `bootstrapDesktopApp` never implemented; it exposes `importPreferences` / `autoGroup`. They would have thrown on first use. **The tests kept them alive** by supplying fakes that implemented the non-existent methods, so a green suite was asserting a contract the real app never fulfilled. Those five methods and their tests were deleted together with this entry; the two implementations themselves remain.
+
+Leftover symptom to expect: `savedArtistsModel`'s state still declares a `groups` field that nothing writes, because grouping lives only in the shell. It is kept deliberately so that `SavedArtistsScreenState` — the type `SavedArtistsView` renders against — stays whole. That is the thread to pull.
+
+**Action:** Give the screen a single owner. `createSavedArtistsShell` is the better candidate: it is the path the running app uses, it owns grouping, and it reloads after mutations. Move over the two things only the model still has — selection state (`toggleSelection` / `clearSelection` / `getSelectedIds`, consumed by `activateStyleRefImpl` in `index.ts`) and the `isLoading` / `isSearching` flags — then delete `savedArtistsModel.ts` along with the `getSavedArtistsViewPropsImpl` seam in `createDesktopReactShell`. Give `SavedArtistsView` an explicit props type rather than one derived from whichever module survives, so the view stops being coupled to the winner. Verify by driving the screen end to end — search, add, select, activate style ref, create/auto group, import, export — since the two paths differ precisely in the mutation-and-reload behaviour that unit tests with fakes do not exercise.


### PR DESCRIPTION
## Why

`apps/desktop` lints `src/**/*.js`. That directory contains **0 `.js` files and 29 `.ts` files** — the glob has matched nothing since the TypeScript conversion, so every "All checks passed" from this workspace was a no-op. `tsconfig.json` had the mirror problem: it included `test/**/*.ts` but not `test/**/*.js`, leaving 25 test files unchecked.

Widening both surfaced **130 lint errors and 55 type errors** that had accumulated unseen.

## What changed

**The two config lines** (`apps/desktop/package.json`, `apps/desktop/tsconfig.json`) now cover `src`, `test` and `scripts`, matching what `services/api` and `shared/schemas` already do.

**Typed, not suppressed.** Rather than 128 `eslint-disable` comments, the fix goes at the root:

- `src/domain.ts` names the API payloads. `chatClient` returns them instead of untyped `response.json()`, which removes the `as any` cascade that had spread upward from there.
- View props are derived from their producer (`CardViewProps`, `ChatViewProps` via `ReturnType` of the render adapter), so a view can no longer drift from the module that builds its props.
- Each model/shell declares the slice of the app it drives instead of taking `app: any`.
- Test doubles gained typed helpers under `test/helpers/`: real `Response` objects instead of `{ ok, status, json }` literals, plus complete app/view-props fakes so a test states only what it exercises.

## Bugs this surfaced

1. **Dead code that tests kept alive.** Five `savedArtistsModel` methods had no production caller — `createSavedArtistsShell` serves the saved-artists screen and does that work itself. Two of them called `app.importArtists` / `app.autoGroupByGenre`, which `bootstrapDesktopApp` never implemented (it has `importPreferences` / `autoGroup`); they would have thrown on first use. The tests supplied fakes implementing those non-existent methods, so a green suite was asserting a contract the real app never fulfilled. Removed in da41018.

2. **Two over-wide types.** `setTimeoutImpl` was declared `typeof setTimeout` though the seam only needs "schedule a callback, give me a cancellable handle" — which forced test fakes to be Node `Timeout`s. `applyAssistantMessage` demanded a full `ChatState` but only reads `messages`, so it rejected the output of its own sibling `createInitialChatState()`.

3. Smaller: a test asserted on an `emptyText` prop that exists in no view, and one test file had a local variable shadowing an import.

## Follow-up

The remaining duplication between `savedArtistsModel` and `createSavedArtistsShell` is recorded as **item 7, marked next up**, in ROADMAP → *Architecture — Pending Deepening*, with both call paths, file:line evidence, and why the test suite stayed green. Deliberately not fixed here — it changes which module owns the screen.

Note for whoever picks it up: `savedArtistsModel`'s `groups` field is now written by nothing. It is kept so `SavedArtistsScreenState` (the type `SavedArtistsView` renders against) stays whole. That is the thread to pull.

## Verification

`lint`, `typecheck` and the full suite green across all workspaces; desktop bundle builds. Verified standalone on this branch, independent of #100.

Scope note: this was split out of #100 (release pipeline) so that PR stays reviewable. The only file both touch is `apps/desktop/package.json`, on different lines — the cherry-pick auto-merged.
