### PR TITLE
chore: weekly maintenance 2026-08-12 - dependency updates + security audit

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -4,6 +4,121 @@ Weekly dependency and health checks for the Bandsearch application.
 
 ---
 
+## 2026-08-12
+
+### Checks performed
+- `git fetch origin`, then compared the working branch (`claude/eloquent-volta-l94b2x`) against
+  `origin/staging`: 0 commits behind, but 1 commit "ahead" (`383ce9a`, PR #102 "Update for Main").
+  Investigated before touching anything, per this cycle's instructions — that commit turned out to
+  be the merge of `staging` into `main` (already on `origin/main`'s tip, confirmed via
+  `git merge-base --is-ancestor`), so it was not unique/unpushed work, just the branch having been
+  seeded from `origin/main`'s tip instead of `origin/staging`'s. Reset to `origin/staging`
+  (`ff80c78`, merge of #101) — same underlying "seeded from the wrong ref" pattern as the
+  2026-07-15 and 2026-08-05 cycles, this time pointing at `main` rather than being stale.
+- Confirmed `npm ci` + `cache: npm` in `.github/workflows/ci.yml` and `package-lock.json` (not
+  `pnpm-lock.yaml`) is what CI actually installs from — npm/`package-lock.json` is authoritative.
+- Baseline: `npm ci`, `npm run lint`, `npm run typecheck`, `npm run test`,
+  `npm --workspace @bandsearch/desktop run build` — all green before any changes.
+- `npm outdated` / `npm audit` across all workspaces (root, `apps/desktop`, `services/api`,
+  `services/eval`, `shared/schemas`).
+- Confirmed root `pyproject.toml` still declares `dependencies = []` — nothing to audit on the
+  Python side, reconfirmed rather than assumed.
+- Installed `cargo-audit` 0.22.2 (not cached in this sandbox) via `cargo install cargo-audit
+  --locked`, then ran `cargo audit --no-yanked` in `apps/desktop/src-tauri` (yanked-crate checks
+  hit `503` from the registry through the sandbox's outbound proxy; the vulnerability/warning scan
+  itself is unaffected by that flag).
+- Cross-referenced `npm outdated` against the 10 open Dependabot npm/cargo PRs (via `git fetch`
+  branch list and `list_pull_requests`) to avoid duplicating any in-flight bump.
+- Checked recent CI runs on `staging` via the GitHub Actions API.
+- Re-ran the full baseline suite after applying updates.
+
+### CI health (staging)
+Most recent `CI` run against `staging`'s current tip (`ff80c78`, run `31590463407`) is
+`completed`/`success`. No red runs found in recent history.
+
+### Fixes applied
+
+- **npm — no new security vulnerabilities this cycle.** Baseline `npm audit`: **0 vulnerabilities**
+  (workspace-wide). Nothing to fix.
+
+- **Safe npm updates** — applied only where not already covered by an open Dependabot PR
+  (`npm update` targeted at specific packages; no `package.json` range changes):
+
+  | Workspace | Package | Before | After |
+  |---|---|---|---|
+  | root | `typescript-eslint` (+ `@typescript-eslint/*` sub-packages) | 8.66.0 | 8.67.0 |
+  | root | `globals` | 17.9.0 | 17.11.0 |
+  | `services/api` | `pg` (+ transitive `pg-protocol`) | 8.22.0 → n/a | 8.23.0 / 1.16.0 |
+
+  Only `package-lock.json` changed (142 lines: 71 insertions / 71 deletions). `better-sqlite3`,
+  `esbuild`, `eslint`, `tsx` were left untouched despite being outdated — each already has an open
+  Dependabot PR (#111, #108, #109, #112) targeting the same or a newer version; bumping them here
+  would either duplicate or conflict with those PRs. Note: the open `tsx` PR (#112) targets
+  4.23.11, one patch behind the true latest (4.23.12) — left as-is rather than superseding an
+  in-flight PR; worth a glance by the owner when merging #112.
+
+- **Rust — no fix needed/applied this cycle.** `cargo audit --no-yanked`: **0 vulnerabilities**,
+  19 informational unmaintained/unsound warnings — identical set and count to the 2026-08-05
+  cycle (no new advisories this week). `Cargo.lock` still resolves `plist 1.10.0` / `quick-xml
+  0.41.0` (RUSTSEC-2026-0194/0195 fix unregressed). `cargo update --dry-run` shows the same
+  category of non-security patch/minor bumps across the `tauri` 2.x family as prior cycles (plus
+  churn already covered by the open cargo Dependabot PRs #105/#107/#110) — none applied, consistent
+  with "keep security-driven PRs minimal" precedent.
+
+### Majors — flagged, NOT applied
+
+| Package | Current | Latest | Why held back |
+|---|---|---|---|
+| `typescript` (root) | 6.0.3 | 7.0.2 | Major rewrite, flagged every cycle since 07-08; still needs a dedicated compatibility pass across all 4 npm workspaces + `typescript-eslint`. Note: open PR #113 ("complete TypeScript migration with strict mode") may be adjacent to this — worth the owner checking whether #113 also lands the v7 bump before a future cycle attempts it separately. |
+| `@types/node` (root) | 25.9.5 | 26.2.0 | Type-defs major ahead of `engines: ">=22"` / CI's pinned Node 22 — low risk but flagged per policy, unchanged from prior cycles. |
+| `better-sqlite3` (`services/api`) | 12.11.1 | 13.0.3 | Native-addon major; already has an open Dependabot PR (#111) — not duplicated here, needs its own rebuild/verification pass per prior cycles' notes. |
+
+### Security audit results
+
+| Ecosystem | Tool | Result |
+|---|---|---|
+| npm (all workspaces) | `npm audit` | **0 vulnerabilities** (baseline and after updates) |
+| Python | manual (`dependencies = []` in `pyproject.toml`) | Nothing to audit, reconfirmed |
+| Rust | `cargo audit` 0.22.2 (535 crate deps scanned) | **0 vulnerabilities**. 19 informational unmaintained/unsound warnings, unchanged from 2026-08-05 (GTK3 `gtk-rs` bindings ×5, `proc-macro-error`, `unic-char-*`/`unic-common`/`unic-ucd-*` ×6, `anyhow` `Error::downcast_mut()` unsoundness, `event-listener` `!Send` unsoundness, `glib` iterator unsoundness) — no independent fix available. |
+| GitHub | `security-audit`-labeled issues | 0 open issues (repo-wide) — reverified fresh rather than assumed from last week. |
+
+### Open-PR backlog — flag for owner
+
+**11 PRs are currently open against `staging`** (#103–#112 Dependabot bumps across npm/cargo/
+github-actions, plus #113 a large manual "complete TypeScript migration with strict mode" PR) with
+none merged since at least the 2026-08-05 cycle. This is a sizeable, growing backlog — prior
+cycles' logs have flagged pileups like this before, and it's worth the owner's attention: either a
+batch-review/merge session for the low-risk Dependabot PRs, or an explicit decision to let them
+keep queuing. Per this cycle's constraints, none of the 11 were merged, closed, or edited — only
+this cycle's own PR was opened.
+
+### Notes
+
+- **Lock file drift (pre-existing, not fixed this cycle, call for repo owner)** —
+  `package-lock.json` and `pnpm-lock.yaml` (+ `pnpm-workspace.yaml`) still coexist at the root.
+  Reconfirmed this cycle that CI (`.github/workflows/ci.yml`) only ever runs `npm ci` (with
+  `cache: npm`) and every `package.json` script in this repo invokes `npm`/`npx` — so
+  `package-lock.json` is the ecosystem CI and this maintenance routine actually depend on, and
+  `pnpm-lock.yaml`/`pnpm-workspace.yaml` look like unintentional drift (an abandoned pnpm
+  experiment, or a stale artifact from before the repo settled on npm workspaces) rather than a
+  second supported install path. Still not independently resolved this cycle — remains the repo
+  owner's call whether to delete the pnpm files or adopt pnpm properly — but flagged more pointedly
+  this time since it's now been observed across multiple consecutive cycles without action.
+- Local branch was seeded from `origin/main`'s tip rather than `origin/staging`'s this cycle (see
+  Checks performed) — third consecutive cycle with a branch-seeding issue (07-15: seeded from
+  `main`; 08-05: 76 commits stale; 08-12: seeded from `main`'s post-merge tip). Worth a look at
+  whatever automation seeds these session branches.
+- Re-ran `npm run lint`, `npm run typecheck`, `npm run test` (all workspaces), and
+  `apps/desktop`'s `npm --workspace @bandsearch/desktop run build` after the dependency updates —
+  all still green, identical pass counts to baseline: **685/686 tests** (desktop 221/222 pass + 1
+  pre-existing skip, api 423/423, eval 16/16, schemas 25/25); lint and typecheck clean.
+- `cargo audit`'s yanked-crate check failed with `503 Service Unavailable` through this sandbox's
+  outbound proxy (unrelated to the advisory-database scan, which completed normally) — ran with
+  `--no-yanked` to get a clean result; worth re-running the yanked check outside this sandbox if a
+  yanked-crate concern ever comes up specifically.
+
+---
+
 ## 2026-08-05
 
 ### Correction / backlog note — please read first

--- a/package-lock.json
+++ b/package-lock.json
@@ -1365,17 +1365,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.66.0.tgz",
-      "integrity": "sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.67.0.tgz",
+      "integrity": "sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.66.0",
-        "@typescript-eslint/type-utils": "8.66.0",
-        "@typescript-eslint/utils": "8.66.0",
-        "@typescript-eslint/visitor-keys": "8.66.0",
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/type-utils": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -1388,7 +1388,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.66.0",
+        "@typescript-eslint/parser": "^8.67.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -1404,16 +1404,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.66.0.tgz",
-      "integrity": "sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.67.0.tgz",
+      "integrity": "sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.66.0",
-        "@typescript-eslint/types": "8.66.0",
-        "@typescript-eslint/typescript-estree": "8.66.0",
-        "@typescript-eslint/visitor-keys": "8.66.0",
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1429,14 +1429,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.66.0.tgz",
-      "integrity": "sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.67.0.tgz",
+      "integrity": "sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.66.0",
-        "@typescript-eslint/types": "^8.66.0",
+        "@typescript-eslint/tsconfig-utils": "^8.67.0",
+        "@typescript-eslint/types": "^8.67.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1451,14 +1451,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.66.0.tgz",
-      "integrity": "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.67.0.tgz",
+      "integrity": "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.66.0",
-        "@typescript-eslint/visitor-keys": "8.66.0"
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1469,9 +1469,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.66.0.tgz",
-      "integrity": "sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.67.0.tgz",
+      "integrity": "sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1486,15 +1486,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.66.0.tgz",
-      "integrity": "sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.67.0.tgz",
+      "integrity": "sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.66.0",
-        "@typescript-eslint/typescript-estree": "8.66.0",
-        "@typescript-eslint/utils": "8.66.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -1511,9 +1511,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.66.0.tgz",
-      "integrity": "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.67.0.tgz",
+      "integrity": "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1525,16 +1525,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.66.0.tgz",
-      "integrity": "sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.67.0.tgz",
+      "integrity": "sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.66.0",
-        "@typescript-eslint/tsconfig-utils": "8.66.0",
-        "@typescript-eslint/types": "8.66.0",
-        "@typescript-eslint/visitor-keys": "8.66.0",
+        "@typescript-eslint/project-service": "8.67.0",
+        "@typescript-eslint/tsconfig-utils": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -1553,16 +1553,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.66.0.tgz",
-      "integrity": "sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.67.0.tgz",
+      "integrity": "sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.66.0",
-        "@typescript-eslint/types": "8.66.0",
-        "@typescript-eslint/typescript-estree": "8.66.0"
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1577,13 +1577,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.66.0.tgz",
-      "integrity": "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.67.0.tgz",
+      "integrity": "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/types": "8.67.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -2595,9 +2595,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.9.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.9.0.tgz",
-      "integrity": "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==",
+      "version": "17.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.11.0.tgz",
+      "integrity": "sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3388,14 +3388,14 @@
       }
     },
     "node_modules/pg": {
-      "version": "8.22.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
-      "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
+      "version": "8.23.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.23.0.tgz",
+      "integrity": "sha512-Ip2EQCngowJLGOfCwkFhPXU7/ljlhn6Rxlmy4XYfL2Y+vyRM59+8uR2xqRWKdYmbXmxCFOAmKxBuSUCdF34qLg==",
       "license": "MIT",
       "dependencies": {
         "pg-connection-string": "^2.14.0",
         "pg-pool": "^3.14.0",
-        "pg-protocol": "^1.15.0",
+        "pg-protocol": "^1.16.0",
         "pg-types": "2.2.0",
         "pgpass": "1.0.5"
       },
@@ -3446,9 +3446,9 @@
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
-      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.16.0.tgz",
+      "integrity": "sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg==",
       "license": "MIT"
     },
     "node_modules/pg-types": {
@@ -4187,16 +4187,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.66.0.tgz",
-      "integrity": "sha512-QlEbBPz/RuJ1XUHj29nm3t0F/O/cSlEnntozqPOYHnnTGAXFamnMBu5i9Vn6vhUPHGAjR+Vl+5J8vPN/BMUrJw==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.67.0.tgz",
+      "integrity": "sha512-S2udFs8tCKEKffuJ4TB1idGUZiXdCPGi3IPBGWXarbLQ5UPXORV8QEVzJ4gCRduURMb5EkpNCdjbk0eDIuI8Yg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.66.0",
-        "@typescript-eslint/parser": "8.66.0",
-        "@typescript-eslint/typescript-estree": "8.66.0",
-        "@typescript-eslint/utils": "8.66.0"
+        "@typescript-eslint/eslint-plugin": "8.67.0",
+        "@typescript-eslint/parser": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"


### PR DESCRIPTION
## Summary

Weekly maintenance cycle. No PR template found in the repo, so this follows the structure of prior weekly-maintenance PRs / `docs/maintenance.md` entries.

### Branch state
- Local branch had been seeded from `origin/main`'s post-merge tip (`383ce9a`, PR #102 "Update for Main") rather than `origin/staging`'s. Investigated before touching anything: that commit is already on `origin/main` (confirmed via `git merge-base --is-ancestor`), so it wasn't unique/unpushed work — just the wrong seed ref. Reset to `origin/staging`'s current tip (`ff80c78`, merge of #101).

### Checks performed
- Confirmed `npm ci` (`cache: npm` in `.github/workflows/ci.yml`) + `package-lock.json` is what CI actually installs from — npm is authoritative, not pnpm.
- Baseline (before any change): `npm ci`, `npm run lint`, `npm run typecheck`, `npm run test`, `npm --workspace @bandsearch/desktop run build` — **all green**. `npm run ci` was green before pushing.
- `npm audit` / `npm outdated` across all workspaces.
- Confirmed root `pyproject.toml` still declares `dependencies = []` — nothing to audit on the Python side.
- Installed `cargo-audit` 0.22.2 and ran `cargo audit --no-yanked` in `apps/desktop/src-tauri` (yanked-crate lookups hit `503` through the sandbox's outbound proxy; the advisory/vulnerability scan itself is unaffected).
- Cross-referenced `npm outdated` and `cargo update --dry-run` against the 10 open Dependabot PRs to avoid duplicating any in-flight bump.

### Security findings & remediation
- **npm**: 0 vulnerabilities, baseline and after updates.
- **Python**: nothing to audit (no declared dependencies).
- **Rust**: 0 vulnerabilities via `cargo audit`; 19 informational unmaintained/unsound warnings, identical set to the 2026-08-05 cycle (no new advisories this week).
- **GitHub**: 0 open issues labeled `security-audit` (reverified fresh, not assumed).

### Changes in this PR
Safe minor bumps **not** already covered by an open Dependabot PR (package-lock.json only, no `package.json` range changes):

| Workspace | Package | Before | After |
|---|---|---|---|
| root | `typescript-eslint` (+ sub-packages) | 8.66.0 | 8.67.0 |
| root | `globals` | 17.9.0 | 17.11.0 |
| `services/api` | `pg` (+ transitive `pg-protocol`) | 8.22.0 | 8.23.0 |

`better-sqlite3`, `esbuild`, `eslint`, `tsx` were left untouched — each already has an open Dependabot PR (#111, #108, #109, #112 respectively); bumping them here would duplicate/conflict with those. Re-ran the full baseline suite after applying updates — still green, identical pass counts to baseline (685/686 tests: desktop 221/222 + 1 pre-existing skip, api 423/423, eval 16/16, schemas 25/25).

### Deferred major-version items (not applied, with rationale)
| Package | Current → Latest | Why deferred |
|---|---|---|
| `typescript` (root) | 6.0.3 → 7.0.2 | Major rewrite, flagged every cycle since 07-08; needs a dedicated compatibility pass across all 4 npm workspaces + `typescript-eslint`. Possibly adjacent to open PR #113 ("complete TypeScript migration with strict mode") — worth checking whether #113 also lands this bump. |
| `@types/node` (root) | 25.9.5 → 26.2.0 | Type-defs major ahead of `engines: ">=22"` / CI's pinned Node 22 — low risk but held per standing policy. |
| `better-sqlite3` (`services/api`) | 12.11.1 → 13.0.3 | Native-addon major; already has an open Dependabot PR (#111) — not duplicated, needs its own rebuild/verification. |
| Rust (`tauri` 2.x family etc.) | various patch/minor | `cargo update --dry-run` shows non-security churn only; none correspond to a `cargo audit` finding, so none applied — consistent with "keep security-driven PRs minimal" precedent. Partially covered already by Dependabot cargo PRs #105/#107/#110. |

### Heads-up for reviewer: open-PR backlog
**11 PRs are currently open against `staging`** (#103–#112 Dependabot bumps, plus #113 a large manual TypeScript-migration PR), none merged since at least the 2026-08-05 cycle. This is a sizeable backlog worth attention — either a batch review/merge pass for the low-risk Dependabot PRs, or an explicit decision to keep letting them queue. Per this cycle's constraints, none of the 11 were merged, closed, or edited — only this PR was opened.

### Other findings (see `docs/maintenance.md` "Notes" for detail)
- **Dual lockfile drift** — `package-lock.json` and `pnpm-lock.yaml`/`pnpm-workspace.yaml` still coexist at the root, but only `package-lock.json` is exercised by CI or any `package.json` script. This looks like unintentional drift (abandoned pnpm experiment or stale artifact) rather than a supported second install path, and has now been observed across multiple consecutive cycles without action — flagged more pointedly this time for an explicit owner decision (delete the pnpm files, or adopt pnpm properly).
- **Branch-seeding pattern** — third consecutive cycle with a branch-seeding issue (07-15: seeded from `main`; 08-05: 76 commits stale; 08-12: seeded from `main`'s post-merge tip). Worth a look at whatever seeds these session branches.

## Test plan
- [x] `npm ci`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` (685/686 pass, 1 pre-existing skip, 0 fail)
- [x] `npm --workspace @bandsearch/desktop run build`
- [x] `npm audit` (0 vulnerabilities)
- [x] `cargo audit` (0 vulnerabilities)
- [x] Full baseline re-verified green after dependency updates
- [x] husky pre-commit hook ran (not bypassed) and passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FHsRwbGcQB39aqNFCkP2vQ)_