### PR TITLE
fix(desktop): restore browser config fallback and repair the E2E suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ coverage/
 .env
 .env.*
 test-results/
+
+# Playwright cached auth state
+playwright/.auth/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,14 @@ Thanks for contributing to Bandsearch.
 2. Keep changes scoped to one phase or concern.
 3. Run checks locally before committing (the same checks also run automatically via a husky pre-commit hook):
    - `npm run ci` — lint + typecheck + test in one command
-   - `npm run test:e2e` — Playwright end-to-end smoke tests, if you touched user-facing flows
+   - `npm run test:e2e` — Playwright end-to-end smoke tests, if you touched user-facing flows.
+     Needs browsers once (`npx playwright install chromium`). Runs against its own
+     `e2e-bandsearch.db` and signs itself in, so it does not touch your dev database.
+   - `npm run test:e2e:live` — additionally runs the `@live` specs, which drive the real
+     Gemini + Brave + MusicBrainz pipeline. Excluded from the default run: MusicBrainz
+     throttles at roughly one request per second, so the same query has taken anywhere
+     from 26 s to over 150 s depending on recent usage. Expect minutes, and occasional
+     upstream timeouts that are not your change.
 4. Open a pull request against `staging` with:
    - clear summary
    - test evidence

--- a/apps/desktop/src/geminiDesktopSettings.ts
+++ b/apps/desktop/src/geminiDesktopSettings.ts
@@ -55,7 +55,13 @@ export function createGeminiSettingsController(options: GeminiSettingsController
           apiEndpointUrl?: string;
         };
       } catch {
-        return {};
+        // A failed invoke means there is no Tauri host answering — the browser
+        // build bundles @tauri-apps/api, so the import succeeds even in a plain
+        // browser and only the IPC call fails. Returning `null` (not `{}`) is
+        // what routes callers to their localStorage fallback; `{}` reads as
+        // "Tauri answered, nothing configured" and stranded browser dev on the
+        // welcome screen no matter what was stored.
+        return null;
       }
     }
     return null;

--- a/apps/desktop/test/gemini-desktop-settings.test.ts
+++ b/apps/desktop/test/gemini-desktop-settings.test.ts
@@ -350,3 +350,49 @@ test("gemini_config_status is invoked exactly once per getBootstrapGate call", a
   await ctrl.getBootstrapGate();
   assert.equal(callCount, 1, "invokeTauri should be called exactly once");
 });
+
+// The browser build bundles @tauri-apps/api, so `invokeTauri` is a function even
+// in a plain browser — the call is what fails, not the import. Treating a failed
+// invoke as "no config" instead of "not Tauri" left the documented browser-dev
+// localStorage fallback unreachable, and the app stuck on the welcome screen.
+function withStubbedLocalStorage<T>(entries: Record<string, string>, run: () => Promise<T>): Promise<T> {
+  const globals = globalThis as { localStorage?: Storage };
+  const previous = globals.localStorage;
+  globals.localStorage = {
+    getItem: (key: string) => entries[key] ?? null,
+    setItem: () => {},
+    removeItem: () => {},
+  } as unknown as Storage;
+  return run().finally(() => {
+    if (previous === undefined) delete globals.localStorage;
+    else globals.localStorage = previous;
+  });
+}
+
+test("bootstrap gate falls back to browser storage when the Tauri invoke fails", async () => {
+  const ctrl = createGeminiSettingsController({
+    invokeTauri: async () => { throw new Error("not running in Tauri"); },
+  });
+
+  const gate = await withStubbedLocalStorage(
+    { bandsearch_onboarding_complete: "1", bandsearch_gemini_api_key: "key-123" },
+    () => ctrl.getBootstrapGate(),
+  );
+
+  assert.equal(gate.onboardingComplete, true);
+  assert.equal(gate.hasStoredKey, true);
+});
+
+test("settings view falls back to browser storage when the Tauri invoke fails", async () => {
+  const ctrl = createGeminiSettingsController({
+    invokeTauri: async () => { throw new Error("not running in Tauri"); },
+  });
+
+  const props = await withStubbedLocalStorage(
+    { bandsearch_gemini_api_key: "key-123", bandsearch_brave_api_key: "brave-456" },
+    () => ctrl.getSettingsViewProps(),
+  );
+
+  assert.equal(props.hasStoredKey, true);
+  assert.equal(props.hasBraveKey, true);
+});

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "lint": "npm run lint:root && npm run lint:js && npm run lint:py",
     "typecheck": "tsc -p tsconfig.json && npm run typecheck --workspaces --if-present",
     "test": "npm run test --workspaces --if-present",
-    "test:e2e": "playwright test",
+    "test:e2e": "playwright test --grep-invert @live",
+    "test:e2e:live": "playwright test",
     "ci": "npm run lint && npm run typecheck && npm run test",
     "prepare": "husky"
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,20 +1,41 @@
 import { defineConfig } from "@playwright/test";
-import { E2E_FRONTEND_PORT } from "./tests/e2e/constants.js";
+import {
+  E2E_API_PORT,
+  E2E_DATABASE_PATH,
+  E2E_FRONTEND_PORT,
+  E2E_STORAGE_STATE,
+} from "./tests/e2e/constants.js";
 
 export default defineConfig({
   testDir: "./tests/e2e",
-  timeout: 40000,
+  // Generous because the opt-in `@live` specs wait on the real research pipeline;
+  // the default suite finishes each test in well under a second. See
+  // LIVE_PIPELINE_TIMEOUT_MS in recommendation.spec.ts.
+  timeout: 200_000,
   use: {
     baseURL: `http://localhost:${E2E_FRONTEND_PORT}`,
     headless: true,
   },
+  projects: [
+    // Signs in once and caches the browser state; see auth.setup.ts.
+    { name: "setup", testMatch: /.*\.setup\.ts/ },
+    {
+      name: "chromium",
+      testMatch: /.*\.spec\.ts/,
+      use: { storageState: E2E_STORAGE_STATE },
+      dependencies: ["setup"],
+    },
+  ],
   webServer: [
     {
       command: "node --import tsx services/api/src/server.ts",
-      port: 3001,
+      port: E2E_API_PORT,
       reuseExistingServer: false,
       timeout: 15000,
-      env: { PORT: "3001" },
+      // Its own database: the suite registers a user, and that must not land in
+      // the developer's bandsearch.db (where it would also change the auth-status
+      // user count the desktop client routes on).
+      env: { PORT: String(E2E_API_PORT), DATABASE_PATH: E2E_DATABASE_PATH },
     },
     {
       command: "npx tsx tests/e2e/serve-frontend.ts",

--- a/tests/e2e/auth.setup.ts
+++ b/tests/e2e/auth.setup.ts
@@ -1,0 +1,50 @@
+import { expect, test as setup } from "@playwright/test";
+import {
+  AUTH_TOKEN_STORAGE_KEY,
+  E2E_API_BASE_URL,
+  E2E_STORAGE_STATE,
+  E2E_USER,
+  ONBOARDING_STORAGE_KEY,
+} from "./constants.js";
+
+/**
+ * Signs the suite in before any spec runs.
+ *
+ * `startDesktopBrowserApp` gates startup on two things before it will show the
+ * chat screen: onboarding must be finished, and — once the API reports any
+ * registered user — a token must be present. Without this the specs land on
+ * `#/login` or `#/welcome`, where none of the chat locators exist.
+ */
+setup("authenticate", async ({ page, request }) => {
+  const registered = await request.post(`${E2E_API_BASE_URL}/auth/register`, { data: E2E_USER });
+
+  // A warm database already has this account, so registration is expected to
+  // fail on every run after the first. Fall back to logging the same user in.
+  let token: string;
+  if (registered.ok()) {
+    token = (await registered.json()).token;
+  } else {
+    const loggedIn = await request.post(`${E2E_API_BASE_URL}/auth/login`, {
+      data: { email: E2E_USER.email, password: E2E_USER.password },
+    });
+    expect(
+      loggedIn.ok(),
+      `could not register or log in the E2E user (register: ${registered.status()}, login: ${loggedIn.status()})`,
+    ).toBeTruthy();
+    token = (await loggedIn.json()).token;
+  }
+  expect(token, "auth endpoint returned no token").toBeTruthy();
+
+  // The token lives in localStorage, which is per-origin, so it has to be written
+  // from a page on the app's origin rather than from the API request context.
+  await page.goto("/");
+  await page.evaluate(
+    ([tokenKey, tokenValue, onboardingKey]) => {
+      localStorage.setItem(tokenKey, tokenValue);
+      localStorage.setItem(onboardingKey, "1");
+    },
+    [AUTH_TOKEN_STORAGE_KEY, token, ONBOARDING_STORAGE_KEY] as const,
+  );
+
+  await page.context().storageState({ path: E2E_STORAGE_STATE });
+});

--- a/tests/e2e/constants.ts
+++ b/tests/e2e/constants.ts
@@ -1,2 +1,30 @@
 /** Shared E2E static server port — keep in sync across Playwright and the local file server. */
 export const E2E_FRONTEND_PORT = 4000;
+
+/** The API the desktop bundle talks to; `startDesktopBrowserApp` defaults to this. */
+export const E2E_API_PORT = 3001;
+export const E2E_API_BASE_URL = `http://localhost:${E2E_API_PORT}`;
+
+/**
+ * A SQLite file used only by E2E runs, so the suite never registers its user into
+ * the developer's `bandsearch.db`. Gitignored via the `*.db` rule.
+ */
+export const E2E_DATABASE_PATH = "e2e-bandsearch.db";
+
+/** Where the authenticated browser state is cached between the setup project and the specs. */
+export const E2E_STORAGE_STATE = "playwright/.auth/user.json";
+
+/**
+ * The account the setup project signs in as. Reused across runs: the first run
+ * registers it, later runs log in, so the suite is green on a fresh checkout and
+ * on a warm database alike.
+ */
+export const E2E_USER = {
+  email: "e2e@bandsearch.test",
+  displayName: "E2E Runner",
+  password: "e2e-password-not-secret",
+};
+
+/** localStorage keys the desktop client gates its startup routing on. */
+export const AUTH_TOKEN_STORAGE_KEY = "bandsearch_auth_token";
+export const ONBOARDING_STORAGE_KEY = "bandsearch_onboarding_complete";

--- a/tests/e2e/recommendation.spec.ts
+++ b/tests/e2e/recommendation.spec.ts
@@ -7,6 +7,21 @@ type RecommendationApiResponse = {
   }>;
 };
 
+/**
+ * Tests tagged `@live` drive the real research pipeline: Gemini plans the search,
+ * Brave runs it, MusicBrainz verifies each candidate. They are excluded from
+ * `npm run test:e2e` and run by `npm run test:e2e:live`.
+ *
+ * They are opt-in because their wall time is not ours to control. MusicBrainz
+ * allows roughly one request per second, so verifying ~25 candidates dominates
+ * the run and degrades sharply once it starts throttling: the same query has
+ * measured 26 s on a cold client and over 150 s after a handful of consecutive
+ * runs. That is a property of the upstream service, not a regression, and no
+ * timeout value makes it deterministic — so it does not belong in the suite
+ * people run before committing.
+ */
+const LIVE_PIPELINE_TIMEOUT_MS = 180_000;
+
 test.describe("Bandsearch UI", () => {
   test("renders the app with mode toggle and input", async ({ page }) => {
     await page.goto("/");
@@ -23,17 +38,17 @@ test.describe("Bandsearch UI", () => {
     await expect(page.locator("main")).toContainText("Start with 1");
   });
 
-  test("submits a query and renders recommendation cards", async ({ page }) => {
+  test("submits a query and renders recommendation cards @live", async ({ page }) => {
     await page.goto("/");
     await page.fill("input[name=query]", "bands like Alcest");
     await page.click("button[type=submit]");
 
     const card = page.locator("article").first();
-    await expect(card).toBeVisible({ timeout: 25000 });
+    await expect(card).toBeVisible({ timeout: LIVE_PIPELINE_TIMEOUT_MS });
     await expect(card.locator("h2")).not.toBeEmpty();
   });
 
-  test("recommendations come from Gemini, not deterministic fallback", async ({ page }) => {
+  test("recommendations come from Gemini, not deterministic fallback @live", async ({ page }) => {
     const apiResponses: RecommendationApiResponse[] = [];
 
     await page.route("**/recommendations", async (route) => {
@@ -47,7 +62,7 @@ test.describe("Bandsearch UI", () => {
     await page.fill("input[name=query]", "bands like Alcest");
     await page.click("button[type=submit]");
 
-    await page.locator("article").first().waitFor({ timeout: 25000 });
+    await page.locator("article").first().waitFor({ timeout: LIVE_PIPELINE_TIMEOUT_MS });
 
     expect(apiResponses.length).toBeGreaterThan(0);
     const signals = apiResponses[0].recommendations.flatMap((r) => r.sourceSignals);


### PR DESCRIPTION
## What & why

`npm run test:e2e` failed 5/5 on `staging`. The cause turned out to be an application bug, not stale tests.

### The app bug

`readStatus()` in `apps/desktop/src/geminiDesktopSettings.ts` returned `{}` when the Tauri invoke threw. Both callers branch on `r !== null` to choose between the Tauri config and the localStorage fallback — so `{}` read as *"Tauri answered, nothing is configured"*, and the fallback beneath it was unreachable.

The invoke always throws in a browser because `@tauri-apps/api/core` **is bundled into the browser build** (`__TAURI_INTERNALS__` appears in `bundle.js`): the import succeeds, only the IPC call fails. So the `typeof invokeTauri === "function"` guard doesn't send browser dev down the fallback path either.

**Effect:** in a browser the app showed the welcome screen on every load regardless of what was stored, and could never reach the chat screen. ROADMAP Phase 3.5 has documented this fallback since it was written; this is the first time it works. Fix is `return null` instead of `return {}`, plus two regression tests.

### The test infrastructure

- **Auth setup project.** The specs predate Phase 6 auth. Once any user exists, `startDesktopBrowserApp` redirects to `#/login`, where no chat locator exists. A setup project now registers — or logs in, on a warm database — a dedicated account and caches the token into `storageState`.
- **Isolated database.** The API webServer gets `DATABASE_PATH=e2e-bandsearch.db`, so the E2E account never lands in a developer's `bandsearch.db`, where it would also change the `userCount` the client routes on.

### Live specs split out

Two specs drive the real Gemini + Brave + MusicBrainz pipeline. Their wall time is set by MusicBrainz, which allows ~1 request/second and throttles hard. Measured from `research_verification_done` in the API log, verifying ~25 candidates took **26 s cold, then 129.6 s and 97.9 s** on later runs; one request returned `502 recommendation_unavailable` after 120 s. No timeout value makes that deterministic, so they are tagged `@live` and excluded from the default run. The old 25 s budget predates the research pipeline — it was written when the classic pipeline still existed.

## Testing

| command | result |
|---|---|
| `npm run ci` | green |
| `npm run test:e2e` | **4 passed, ~5 s** — verified 3×, on both the cold-register and warm-login paths |
| `npm run test:e2e:live` | adds the 2 live specs; minutes, upstream-dependent |

## Key decisions

- Returning `null` rather than special-casing the browser keeps one code path: a failed invoke means no Tauri host is answering, whatever the reason.
- The E2E account is reused across runs (register once, log in thereafter) rather than resetting the database, so the suite is green on a fresh checkout and a warm one alike without depending on Playwright's setup/webServer ordering.

## Known gaps

- CI still does not run this suite, which is how it rotted unnoticed. Wiring it up is deliberately left out of this PR — the `@live` split makes it viable now, but it needs a decision about API keys in CI.
- The `@live` specs remain upstream-dependent by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)