### PR TITLE
test(e2e): cover the saved-artists screen in a browser

### DIFF
--- a/tests/e2e/saved-artists.spec.ts
+++ b/tests/e2e/saved-artists.spec.ts
@@ -1,0 +1,83 @@
+import { expect, test, type APIRequestContext, type Page } from "@playwright/test";
+import { AUTH_TOKEN_STORAGE_KEY, E2E_API_BASE_URL } from "./constants.js";
+
+/**
+ * Browser coverage for the saved-artists screen.
+ *
+ * The unit suite drives this screen through the real shell and the real view, but
+ * it cannot catch a screen that is unreachable — which is what happened: `#/saved`
+ * threw on render while the chat "Saved" button quietly served a second, less
+ * capable implementation. These specs assert the screen is reachable and that its
+ * controls reach the API.
+ *
+ * Artists are seeded over HTTP rather than added through the in-app MusicBrainz
+ * search, so a run never depends on MusicBrainz being responsive — it throttles at
+ * roughly one request per second, and the `@live` specs already pay that cost.
+ */
+async function seedArtist(page: Page, request: APIRequestContext, name: string) {
+  await page.goto("/");
+  const token = await page.evaluate((key) => localStorage.getItem(key), AUTH_TOKEN_STORAGE_KEY);
+  const response = await request.post(`${E2E_API_BASE_URL}/preferences`, {
+    headers: { authorization: `Bearer ${token}` },
+    data: { musicbrainzArtistId: `seed-${name}`, name, rating: 4, categories: [], note: "seeded" },
+  });
+  expect(response.status(), `seeding ${name} failed`).toBe(201);
+}
+
+test("navigates from chat to the saved screen", async ({ page, request }) => {
+  await seedArtist(page, request, "Codeine");
+  await page.goto("/");
+  await page.click("text=Saved");
+  await expect(page.locator("h1")).toContainText("Saved Artists");
+  expect(await page.evaluate(() => location.hash)).toBe("#/saved");
+  await expect(page.locator("li", { hasText: "Codeine" }).first()).toBeVisible({ timeout: 15000 });
+});
+
+test("loads data on a direct reload of the saved route", async ({ page, request }) => {
+  await seedArtist(page, request, "Duster");
+  await page.goto("/#/saved");
+  await page.reload();
+  await expect(page.locator("li", { hasText: "Duster" }).first()).toBeVisible({ timeout: 15000 });
+});
+
+test("selects an artist and activates it as a style reference", async ({ page, request }) => {
+  await seedArtist(page, request, "Bedhead");
+  await page.goto("/#/saved");
+  await page.locator("button.tick-btn").first().click();
+  await expect(page.locator("text=/\\d+ selected/")).toBeVisible();
+  await page.click("button:has-text('Use as style reference')");
+  await expect(page.locator("input[name=query]")).toBeVisible();
+});
+
+test("creates and deletes a group", async ({ page, request }) => {
+  await seedArtist(page, request, "Low");
+  await page.goto("/#/saved");
+  await page.fill("input[name=create-group]", "Slowcore");
+  await page.click("button:has-text('Create')");
+  await expect(page.locator("p", { hasText: "Slowcore" }).first()).toBeVisible({ timeout: 15000 });
+  // The outer GroupsSection also contains this text, so target the group's own
+  // header delete button (×) rather than the first button in any matching section.
+  await page.locator("section").filter({ hasText: "Slowcore" }).last().locator("button", { hasText: "×" }).first().click();
+  await expect(page.locator("p", { hasText: "Slowcore" })).toHaveCount(0, { timeout: 15000 });
+});
+
+test("exports the saved artists", async ({ page, request }) => {
+  await seedArtist(page, request, "Bark Psychosis");
+  await page.goto("/#/saved");
+  const download = page.waitForEvent("download", { timeout: 15000 });
+  await page.click("button:has-text('Export')");
+  expect((await download).suggestedFilename()).toBe("bandsearch-artists.json");
+});
+
+test("deletes a saved artist", async ({ page, request }) => {
+  // A name no other spec seeds, so the count assertion below cannot see a duplicate.
+  await seedArtist(page, request, "Slint");
+  await page.goto("/#/saved");
+  const row = page.locator("li", { hasText: "Slint" }).first();
+  await expect(row).toBeVisible({ timeout: 15000 });
+
+  // Each row renders the style-reference tick first and the delete control last.
+  await row.locator("button").last().click();
+
+  await expect(page.locator("li", { hasText: "Slint" })).toHaveCount(0, { timeout: 15000 });
+});


### PR DESCRIPTION
## What & why

Adds `tests/e2e/saved-artists.spec.ts` — browser coverage for the screen consolidated in #123.

The unit suite added there drives the real shell through the real view, which catches prop-shape drift. What it cannot catch is a screen that is *unreachable*, and that is precisely what had gone wrong: `#/saved` threw on render, while the chat "Saved" button quietly served a second implementation whose Export / Import / Group-by-genre / Create buttons did nothing. Both are the kind of defect only a browser sees.

Six specs:

| spec | covers |
|---|---|
| navigates from chat to the saved screen | the Saved button now moves the router; hash becomes `#/saved` |
| loads data on a direct reload of the saved route | deep link / reload path, fixed in `fc9bd0a` |
| selects an artist and activates it as a style reference | selection → `setPendingStyleRef` → back on chat |
| creates and deletes a group | grouping handlers, previously inert on the reachable path |
| exports the saved artists | download handler fires with the right filename |
| deletes a saved artist | delete → reload |

## Why this is stacked on #123

It needs both halves and is red without either:

- **#123** — the screen throws on `#/saved` without it, so every spec fails.
- **#122** (already merged) — supplies `E2E_API_BASE_URL`, the auth setup project, and the isolated E2E database. Without those the app never leaves the login/welcome screen.

Based on `feature/saved-artists-single-owner` rather than `staging` so it is green in CI. GitHub will retarget it to `staging` once #123 merges. Fold it into #123 instead if you would rather review them together — it is a single file.

## Key decisions

- **Artists are seeded over HTTP, not added through the in-app MusicBrainz search.** MusicBrainz throttles at ~1 request/second and was intermittently returning nothing while this was written; the `@live` specs in #122 already pay that cost and these should not. The seeded path exercises the same load, render and mutation code — only candidate discovery is skipped.
- Each spec seeds its own artist under a distinct name, so no assertion depends on another spec's leftovers or on database state from a previous run.

## Testing

- `npm run ci` green
- `npm run test:e2e` — **7 passed in ~8 s** (6 specs + the auth setup), verified across three consecutive runs, cold and warm database

## Known gaps

- Import is not covered — it needs a real file input, and the export/import pair is better tested as a round trip once there is a fixture to import.
- CI still does not run any Playwright suite; that decision is unchanged from #122 and needs a call on API keys in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)