### PR TITLE
ci: run the end-to-end suite on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,52 @@ jobs:
 
       - name: Test
         run: npm run test
+
+  # Separate job, ubuntu only: Playwright needs a browser download and a built
+  # desktop bundle, neither of which the checks job wants, and doubling that onto
+  # the Windows runner buys little for a browser-rendering suite.
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 26
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # tests/e2e/serve-frontend.ts serves apps/desktop/dist, which is gitignored.
+      - name: Build desktop bundle
+        run: npm run build --workspace @bandsearch/desktop
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: End-to-end tests
+        # The API refuses to boot without these, but the default suite never
+        # reaches the recommendation pipeline — it exercises rendering, routing,
+        # auth and preference CRUD. Dummy values keep this runnable on forked
+        # PRs, which cannot read secrets, and spend no Gemini or Brave quota.
+        # The `@live` specs, which do call the pipeline, are excluded by the
+        # script and are not run in CI at all.
+        env:
+          GEMINI_API_KEY: ci-dummy-key
+          BRAVE_API_KEY: ci-dummy-key
+        run: npm run test:e2e
+
+      # test-results/ holds the failure context, screenshots and traces. There is
+      # no playwright-report/ — the config sets no reporter, so nothing HTML is
+      # produced.
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-failures
+          path: test-results/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,8 @@ Thanks for contributing to Bandsearch.
    - `npm run test:e2e` — Playwright end-to-end smoke tests, if you touched user-facing flows.
      Needs browsers once (`npx playwright install chromium`). Runs against its own
      `e2e-bandsearch.db` and signs itself in, so it does not touch your dev database.
+     CI runs this on every pull request, with dummy API keys — these specs never reach
+     the recommendation pipeline, so no real credentials are involved and forked PRs work.
    - `npm run test:e2e:live` — additionally runs the `@live` specs, which drive the real
      Gemini + Brave + MusicBrainz pipeline. Excluded from the default run: MusicBrainz
      throttles at roughly one request per second, so the same query has taken anywhere


### PR DESCRIPTION
## What & why

The Playwright suite was never wired into CI. That is how it came to sit red through an entire auth feature without anyone noticing — the fix for that is in #122, and this closes the loop so it cannot happen again silently.

Adds a separate `e2e` job to `.github/workflows/ci.yml`.

## Key decisions

**No secrets.** `GEMINI_API_KEY` and `BRAVE_API_KEY` are set to literal dummy values. The API refuses to boot without them, but the default suite never reaches the recommendation pipeline — it exercises rendering, routing, auth and preference CRUD. I verified the dummies genuinely take effect: with them set, a real `POST /recommendations` returns `recommendation_unavailable`, while all the default specs still pass.

That buys two things worth having: forked pull requests work (they cannot read repository secrets, so a secrets-based job would be permanently red for outside contributors), and no Gemini or Brave quota is spent per PR.

Nothing else is required — `JWT_SECRET` self-generates, and the preference store defaults to SQLite at the path the Playwright config supplies.

**Separate job, ubuntu only.** It needs a browser download and a built desktop bundle, neither of which the `checks` job wants. Running a browser-rendering suite a second time on the Windows runner costs several minutes for little added signal.

**`@live` excluded.** `npm run test:e2e` already filters them out. They call the real pipeline, and their wall time is set by MusicBrainz throttling (26 s to 150 s+ for the same query), so they have no place in a gate.

## Testing

Validated in a fresh `git clone` with no `.env` present — the same starting state as the runner:

```
npm ci                                    ✓
npm run build --workspace @bandsearch/desktop  ✓
GEMINI_API_KEY=ci-dummy-key BRAVE_API_KEY=ci-dummy-key npm run test:e2e
  4 passed (7.1s)
```

`npm run ci` green. The job adds roughly a minute, mostly the Chromium download.

## Notes

- `test-results/` is uploaded on failure (failure context, screenshots, traces). There is deliberately no `playwright-report/` — the config sets no reporter, so nothing HTML is produced; `if-no-files-found: ignore` keeps that from warning.
- Independent of #123 and #124: this only runs the specs already on `staging`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)