### PR TITLE
test(e2e): land the saved-artists browser specs on staging

### DIFF
--- a/tests/e2e/saved-artists.spec.ts
+++ b/tests/e2e/saved-artists.spec.ts
@@ -1,0 +1,83 @@
+import { expect, test, type APIRequestContext, type Page } from "@playwright/test";
+import { AUTH_TOKEN_STORAGE_KEY, E2E_API_BASE_URL } from "./constants.js";
+
+/**
+ * Browser coverage for the saved-artists screen.
+ *
+ * The unit suite drives this screen through the real shell and the real view, but
+ * it cannot catch a screen that is unreachable — which is what happened: `#/saved`
+ * threw on render while the chat "Saved" button quietly served a second, less
+ * capable implementation. These specs assert the screen is reachable and that its
+ * controls reach the API.
+ *
+ * Artists are seeded over HTTP rather than added through the in-app MusicBrainz
+ * search, so a run never depends on MusicBrainz being responsive — it throttles at
+ * roughly one request per second, and the `@live` specs already pay that cost.
+ */
+async function seedArtist(page: Page, request: APIRequestContext, name: string) {
+  await page.goto("/");
+  const token = await page.evaluate((key) => localStorage.getItem(key), AUTH_TOKEN_STORAGE_KEY);
+  const response = await request.post(`${E2E_API_BASE_URL}/preferences`, {
+    headers: { authorization: `Bearer ${token}` },
+    data: { musicbrainzArtistId: `seed-${name}`, name, rating: 4, categories: [], note: "seeded" },
+  });
+  expect(response.status(), `seeding ${name} failed`).toBe(201);
+}
+
+test("navigates from chat to the saved screen", async ({ page, request }) => {
+  await seedArtist(page, request, "Codeine");
+  await page.goto("/");
+  await page.click("text=Saved");
+  await expect(page.locator("h1")).toContainText("Saved Artists");
+  expect(await page.evaluate(() => location.hash)).toBe("#/saved");
+  await expect(page.locator("li", { hasText: "Codeine" }).first()).toBeVisible({ timeout: 15000 });
+});
+
+test("loads data on a direct reload of the saved route", async ({ page, request }) => {
+  await seedArtist(page, request, "Duster");
+  await page.goto("/#/saved");
+  await page.reload();
+  await expect(page.locator("li", { hasText: "Duster" }).first()).toBeVisible({ timeout: 15000 });
+});
+
+test("selects an artist and activates it as a style reference", async ({ page, request }) => {
+  await seedArtist(page, request, "Bedhead");
+  await page.goto("/#/saved");
+  await page.locator("button.tick-btn").first().click();
+  await expect(page.locator("text=/\\d+ selected/")).toBeVisible();
+  await page.click("button:has-text('Use as style reference')");
+  await expect(page.locator("input[name=query]")).toBeVisible();
+});
+
+test("creates and deletes a group", async ({ page, request }) => {
+  await seedArtist(page, request, "Low");
+  await page.goto("/#/saved");
+  await page.fill("input[name=create-group]", "Slowcore");
+  await page.click("button:has-text('Create')");
+  await expect(page.locator("p", { hasText: "Slowcore" }).first()).toBeVisible({ timeout: 15000 });
+  // The outer GroupsSection also contains this text, so target the group's own
+  // header delete button (×) rather than the first button in any matching section.
+  await page.locator("section").filter({ hasText: "Slowcore" }).last().locator("button", { hasText: "×" }).first().click();
+  await expect(page.locator("p", { hasText: "Slowcore" })).toHaveCount(0, { timeout: 15000 });
+});
+
+test("exports the saved artists", async ({ page, request }) => {
+  await seedArtist(page, request, "Bark Psychosis");
+  await page.goto("/#/saved");
+  const download = page.waitForEvent("download", { timeout: 15000 });
+  await page.click("button:has-text('Export')");
+  expect((await download).suggestedFilename()).toBe("bandsearch-artists.json");
+});
+
+test("deletes a saved artist", async ({ page, request }) => {
+  // A name no other spec seeds, so the count assertion below cannot see a duplicate.
+  await seedArtist(page, request, "Slint");
+  await page.goto("/#/saved");
+  const row = page.locator("li", { hasText: "Slint" }).first();
+  await expect(row).toBeVisible({ timeout: 15000 });
+
+  // Each row renders the style-reference tick first and the delete control last.
+  await row.locator("button").last().click();
+
+  await expect(page.locator("li", { hasText: "Slint" })).toHaveCount(0, { timeout: 15000 });
+});

--- a/tests/e2e/saved-artists.spec.ts
+++ b/tests/e2e/saved-artists.spec.ts
@@ -81,3 +81,29 @@ test("deletes a saved artist", async ({ page, request }) => {
 
   await expect(page.locator("li", { hasText: "Slint" })).toHaveCount(0, { timeout: 15000 });
 });
+
+test("exported artists can be imported back", async ({ page, request }) => {
+  // Unique per run: importing re-adds the artist under a fresh id, so a fixed
+  // name would accumulate duplicates and make the delete assertion below fail on
+  // the second run against the same database.
+  const artist = `Codeine ${Date.now()}`;
+  const rows = page.locator("li", { hasText: artist });
+
+  await seedArtist(page, request, artist);
+  await page.goto("/#/saved");
+  await expect(rows.first()).toBeVisible({ timeout: 15000 });
+
+  // Export, then delete, then import the exported file: a round trip proves the
+  // two halves agree on a format, which a hand-written fixture would not.
+  const download = page.waitForEvent("download", { timeout: 15000 });
+  await page.click("button:has-text('Export')");
+  const exported = await (await download).path();
+  expect(exported, "export produced no file").toBeTruthy();
+
+  await rows.first().locator("button").last().click();
+  await expect(rows).toHaveCount(0, { timeout: 15000 });
+
+  await page.locator("input[type=file]").setInputFiles(exported as string);
+
+  await expect(rows.first()).toBeVisible({ timeout: 15000 });
+});


### PR DESCRIPTION
## What & why

Recovers the specs from #124, which were merged but never reached `staging`.

**What happened:** #124 targeted `feature/saved-artists-single-owner` (stacked, so it would be green before #123 landed). The two merges then happened 22 seconds apart, in the wrong order:

| time | event |
|---|---|
| 08:52:03 | #123 merged `feature/saved-artists-single-owner` → `staging` |
| 08:52:25 | #124 merged `test/saved-artists-e2e` → `feature/saved-artists-single-owner` |

By the time the spec landed on the feature branch, that branch had already been merged into `staging`. Both PRs show as merged, `tests/e2e/saved-artists.spec.ts` exists on the feature branch — and is absent from `staging`.

This cherry-picks the two original commits (`f466502`, `5c31a07`) onto `staging`. No content changes.

## What it restores

Seven specs covering the screen consolidated in #123, in a real browser: navigation from chat, direct reload of `#/saved`, select → activate style reference, create/delete group, export, delete artist, and export→import round trip.

## Testing

Against current `staging`:

- `npm run ci` green
- `npm run test:e2e` — **11 passed in ~11 s** (4 recommendation + 7 saved-artists including auth setup)

The `e2e` job added in #125 will now run these on this PR, which is the first time that gate covers them.

## Note for next time

This is a hazard of stacked PRs: merging the base PR first strands anything merged into the head branch afterwards. Merging #124 before #123 — or retargeting #124 to `staging` once #123 landed — would have avoided it. Worth remembering rather than fixing structurally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)