### PR TITLE
feat(desktop): in-app update notification (Phase 10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ One-time signing setup (required before the first tag):
    - `TAURI_SIGNING_PRIVATE_KEY` — contents of `~/.tauri/bandsearch.key`
    - `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` — password used at generation (empty string if none)
 
-In-app update UI is still Phase 10; this pipeline already produces signed updater artifacts (`createUpdaterArtifacts`) and `latest.json` for that work.
+**In-app update notification (Windows/Linux):** on every launch the app checks `latest.json` in the background; if a newer version is available, a dismissible banner appears with a one-click Install (`install_update` downloads, verifies the signature, and installs). Dismissing is per-version — a later release shows the banner again even if an earlier one was dismissed. **macOS is not covered**: without a signed macOS build there is no macOS entry in `latest.json`, so macOS testers never see the banner and must download releases manually from the GitHub Releases page.
 
 ---
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bandsearch/desktop",
-  "version": "0.4.0-alpha.0",
+  "version": "0.4.0",
   "private": true,
   "description": "Tauri + React desktop client",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -224,7 +224,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bandsearch"
-version = "0.2.0"
+version = "0.4.0"
 dependencies = [
  "dirs",
  "serde",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bandsearch"
-version = "0.2.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.77"
 

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -418,23 +418,25 @@ fn reconcile_sidecar(api: &ApiProcess, workspace_root: &Path) {
     }
 }
 
+/// Whether this build can install an update in place. macOS ships no signed
+/// updater artifact (see the auto-update plan's deviations), so its banner is
+/// informational only. Single source of truth for the payload and its test.
+fn can_auto_install() -> bool {
+    cfg!(not(target_os = "macos"))
+}
+
 /// Checks the configured updater endpoint once and, on a hit, emits `update-available`
-/// with the new version and whether this platform can auto-install it. macOS has no
-/// signed updater artifact (see the auto-update plan's deviations), so it never gets
-/// `canAutoInstall: true` here even though the frontend banner is Windows/Linux only.
+/// with the new version and whether this platform can auto-install it.
 async fn check_for_update_and_notify(app: tauri::AppHandle) {
-    let updater = match app.updater() {
-        Ok(u) => u,
-        Err(e) => {
-            eprintln!("[bandsearch] updater unavailable: {e}");
-            return;
-        }
+    let Ok(updater) = app.updater() else {
+        eprintln!("[bandsearch] updater unavailable");
+        return;
     };
     match updater.check().await {
         Ok(Some(update)) => {
             let payload = UpdateAvailablePayload {
-                version: update.version.clone(),
-                can_auto_install: cfg!(not(target_os = "macos")),
+                version: update.version,
+                can_auto_install: can_auto_install(),
             };
             if let Err(e) = app.emit("update-available", payload) {
                 eprintln!("[bandsearch] failed to emit update-available: {e}");
@@ -573,14 +575,15 @@ fn complete_onboarding() -> Result<(), String> {
 #[tauri::command]
 async fn install_update(app: tauri::AppHandle) -> Result<(), String> {
     let updater = app.updater().map_err(|e| e.to_string())?;
-    let update = updater.check().await.map_err(|e| e.to_string())?;
-    match update {
-        Some(update) => update
-            .download_and_install(|_, _| {}, || {})
-            .await
-            .map_err(|e| e.to_string()),
-        None => Err("no update available".to_string()),
-    }
+    let update = updater
+        .check()
+        .await
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| "no update available".to_string())?;
+    update
+        .download_and_install(|_, _| {}, || {})
+        .await
+        .map_err(|e| e.to_string())
 }
 
 fn main() {
@@ -600,20 +603,21 @@ fn main() {
                 absolute_bandsearch_db_path(&workspace_root)
             );
 
+            // Spawned before reconcile_sidecar, which blocks this thread in
+            // wait_for_api_tcp for as long as the Node sidecar takes to listen.
+            // The check needs no managed state, so starting it first lets the
+            // network round trip overlap that wait instead of queueing behind it.
+            // Event-driven, not polled: one check per launch is enough for a
+            // tester-facing notification, and it keeps the untestable surface
+            // (the actual network round trip) to a single spawned task.
+            tauri::async_runtime::spawn(check_for_update_and_notify(app.handle().clone()));
+
             let api = ApiProcess(Mutex::new(None));
             // Start the local sidecar only when no remote endpoint is configured.
             reconcile_sidecar(&api, &workspace_root);
 
             app.manage(api);
             app.manage(WorkspaceRoot(workspace_root));
-
-            // Event-driven, not polled: one check per app launch is enough for a
-            // tester-facing notification, and it keeps the untestable surface (the
-            // actual network round trip) to a single spawned task.
-            let update_handle = app.handle().clone();
-            tauri::async_runtime::spawn(async move {
-                check_for_update_and_notify(update_handle).await;
-            });
 
             Ok(())
         })
@@ -850,13 +854,16 @@ mod tests {
     }
 
     #[test]
-    fn can_auto_install_is_false_on_macos_true_elsewhere() {
-        let can_auto_install = cfg!(not(target_os = "macos"));
-        if cfg!(target_os = "macos") {
-            assert!(!can_auto_install, "macOS must not offer auto-install");
-        } else {
-            assert!(can_auto_install, "Windows/Linux must offer auto-install");
-        }
+    fn update_payload_carries_the_platform_auto_install_flag() {
+        // Goes through the real can_auto_install() rather than recomputing the
+        // cfg!, so hardcoding the flag in the payload would fail this.
+        let payload = UpdateAvailablePayload {
+            version: "0.5.0".to_string(),
+            can_auto_install: can_auto_install(),
+        };
+        let value = serde_json::to_value(&payload).expect("payload must serialize");
+        assert_eq!(value["canAutoInstall"], cfg!(not(target_os = "macos")));
+        assert_eq!(value["canAutoInstall"].as_bool(), Some(!cfg!(target_os = "macos")));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -7,7 +7,8 @@ use std::process::{Child, Command};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 use tauri::menu::{Menu, PredefinedMenuItem, Submenu};
-use tauri::{Manager, State, WindowEvent};
+use tauri::{Emitter, Manager, State, WindowEvent};
+use tauri_plugin_updater::UpdaterExt;
 
 struct ApiProcess(Mutex<Option<Child>>);
 
@@ -30,6 +31,13 @@ struct BandsearchConfig {
     jwt_secret: String,
     #[serde(default)]
     api_endpoint_url: String,
+}
+
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct UpdateAvailablePayload {
+    version: String,
+    can_auto_install: bool,
 }
 
 #[derive(Serialize)]
@@ -410,6 +418,33 @@ fn reconcile_sidecar(api: &ApiProcess, workspace_root: &Path) {
     }
 }
 
+/// Checks the configured updater endpoint once and, on a hit, emits `update-available`
+/// with the new version and whether this platform can auto-install it. macOS has no
+/// signed updater artifact (see the auto-update plan's deviations), so it never gets
+/// `canAutoInstall: true` here even though the frontend banner is Windows/Linux only.
+async fn check_for_update_and_notify(app: tauri::AppHandle) {
+    let updater = match app.updater() {
+        Ok(u) => u,
+        Err(e) => {
+            eprintln!("[bandsearch] updater unavailable: {e}");
+            return;
+        }
+    };
+    match updater.check().await {
+        Ok(Some(update)) => {
+            let payload = UpdateAvailablePayload {
+                version: update.version.clone(),
+                can_auto_install: cfg!(not(target_os = "macos")),
+            };
+            if let Err(e) = app.emit("update-available", payload) {
+                eprintln!("[bandsearch] failed to emit update-available: {e}");
+            }
+        }
+        Ok(None) => {}
+        Err(e) => eprintln!("[bandsearch] update check failed: {e}"),
+    }
+}
+
 fn build_app_menu(app: &tauri::AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
     let quit = PredefinedMenuItem::quit(app, Some("Quit Bandsearch"))?;
     let about = PredefinedMenuItem::about(app, Some("About Bandsearch"), None)?;
@@ -533,11 +568,26 @@ fn complete_onboarding() -> Result<(), String> {
     persist_config(&cfg)
 }
 
+/// Re-checks for an update (rather than trusting the earlier `update-available` event)
+/// so install always acts on a fresh, signature-verified release.
+#[tauri::command]
+async fn install_update(app: tauri::AppHandle) -> Result<(), String> {
+    let updater = app.updater().map_err(|e| e.to_string())?;
+    let update = updater.check().await.map_err(|e| e.to_string())?;
+    match update {
+        Some(update) => update
+            .download_and_install(|_, _| {}, || {})
+            .await
+            .map_err(|e| e.to_string()),
+        None => Err("no update available".to_string()),
+    }
+}
+
 fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
-        .invoke_handler(tauri::generate_handler![gemini_config_status, save_gemini_api_key, save_brave_api_key, save_turso_config, clear_turso_config, save_api_endpoint_url, complete_onboarding])
+        .invoke_handler(tauri::generate_handler![gemini_config_status, save_gemini_api_key, save_brave_api_key, save_turso_config, clear_turso_config, save_api_endpoint_url, complete_onboarding, install_update])
         .setup(|app| {
             let menu = build_app_menu(&app.handle())?;
             app.set_menu(menu)?;
@@ -556,6 +606,14 @@ fn main() {
 
             app.manage(api);
             app.manage(WorkspaceRoot(workspace_root));
+
+            // Event-driven, not polled: one check per app launch is enough for a
+            // tester-facing notification, and it keeps the untestable surface (the
+            // actual network round trip) to a single spawned task.
+            let update_handle = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                check_for_update_and_notify(update_handle).await;
+            });
 
             Ok(())
         })
@@ -778,6 +836,27 @@ mod tests {
                 .expect("config with api_endpoint_url must parse");
         assert_eq!(cfg.api_endpoint_url, "https://remote.example");
         assert!(!should_run_local_sidecar(&cfg.api_endpoint_url));
+    }
+
+    #[test]
+    fn update_available_payload_serializes_camel_case() {
+        let payload = UpdateAvailablePayload {
+            version: "0.5.0".to_string(),
+            can_auto_install: true,
+        };
+        let value = serde_json::to_value(&payload).expect("payload must serialize");
+        assert_eq!(value["version"], "0.5.0");
+        assert_eq!(value["canAutoInstall"], true);
+    }
+
+    #[test]
+    fn can_auto_install_is_false_on_macos_true_elsewhere() {
+        let can_auto_install = cfg!(not(target_os = "macos"));
+        if cfg!(target_os = "macos") {
+            assert!(!can_auto_install, "macOS must not offer auto-install");
+        } else {
+            assert!(can_auto_install, "Windows/Linux must offer auto-install");
+        }
     }
 
     #[test]

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Bandsearch",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "identifier": "app.bandsearch",
   "build": {
     "frontendDist": "../dist",

--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -3,7 +3,7 @@ import { createDesktopReactShell } from "./ui/createDesktopReactShell.js";
 import { createDesktopReactMount } from "./ui/mountDesktopReactApp.js";
 import type { DesktopReactMountOptions } from "./ui/mountDesktopReactApp.js";
 import type { ChatAppCollaborator } from "./chatAppModel.js";
-import type { ChatHandlers } from "./ui/viewTypes.js";
+import type { ChatHandlers, UpdateBannerHandlers } from "./ui/viewTypes.js";
 import { createDesktopChatUiStack } from "./desktopChatUiStack.js";
 import { bootstrapDesktopApp } from "./bootstrapDesktopApp.js";
 
@@ -70,6 +70,7 @@ export type BootstrapDesktopReactAppOptions = {
   onLogin?: (email: string, password: string) => Promise<void>;
   onRegister?: (email: string, displayName: string, password: string) => Promise<{ recoveryCode: string }>;
   onResetPassword?: (email: string, recoveryCode: string, newPassword: string) => Promise<{ newRecoveryCode: string }>;
+  updateBannerHandlers?: UpdateBannerHandlers;
 };
 
 function bootstrapDesktopReactApp(options: BootstrapDesktopReactAppOptions) {
@@ -89,6 +90,7 @@ function bootstrapDesktopReactApp(options: BootstrapDesktopReactAppOptions) {
     onLogin,
     onRegister,
     onResetPassword,
+    updateBannerHandlers,
   } = options;
   const shell = bootstrapDesktopReactShell({ app, viewport, actionHandlers });
   const mountApi = createDesktopReactMount({
@@ -105,6 +107,7 @@ function bootstrapDesktopReactApp(options: BootstrapDesktopReactAppOptions) {
     onLogin,
     onRegister,
     onResetPassword,
+    updateBannerHandlers,
   });
   return {
     ...mountApi,

--- a/apps/desktop/src/startDesktopBrowserApp.ts
+++ b/apps/desktop/src/startDesktopBrowserApp.ts
@@ -6,6 +6,13 @@ import { shouldOfferWelcomeScreen } from "./firstRunOnboarding.js";
 import { getAuthToken, setAuthToken, clearAuthToken } from "./authTokenStore.js";
 import { createAuthApiClient, type LoginResult, type RegisterResult, type ResetPasswordResult } from "./authApiClient.js";
 import { createAuthAwareFetch } from "./authAwareFetch.js";
+import {
+  shouldShowUpdateBanner,
+  getDismissedUpdateVersion,
+  dismissUpdateVersion,
+  type UpdateAvailablePayload,
+  type UpdateDismissalStorage,
+} from "./updateNotification.js";
 
 const VIEWPORT_BREAKPOINT_MAX_PX = 767;
 
@@ -48,6 +55,43 @@ function createDefaultTauriInvoke(): ((cmd: string, args?: Record<string, string
   }
 }
 
+/** Production default: subscribe to main.rs's `update-available` event. Absent (returns
+ * undefined) outside a Tauri host, same fallback shape as createDefaultTauriInvoke. */
+function createDefaultUpdateListener(): ((handler: (payload: UpdateAvailablePayload) => void) => void) | undefined {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { listen } = require("@tauri-apps/api/event") as {
+      listen: (event: string, handler: (event: { payload: UpdateAvailablePayload }) => void) => Promise<unknown>;
+    };
+    return (handler: (payload: UpdateAvailablePayload) => void) => {
+      // No Tauri host answering (browser dev, tests) rejects asynchronously;
+      // there is nothing to subscribe to, so the rejection is not surfaced.
+      listen("update-available", (event) => handler(event.payload)).catch(() => {});
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function createDefaultUpdateDismissalStorage(): UpdateDismissalStorage {
+  return {
+    getItem: (key: string) => {
+      try {
+        return globalThis.localStorage?.getItem(key) ?? null;
+      } catch {
+        return null;
+      }
+    },
+    setItem: (key: string, value: string) => {
+      try {
+        globalThis.localStorage?.setItem(key, value);
+      } catch {
+        /* ignore */
+      }
+    },
+  };
+}
+
 export type ActionHandlers = {
   onSave?: (artistName: string) => void;
   onRate?: (artistName: string) => void;
@@ -70,6 +114,8 @@ export type StartDesktopBrowserAppOptions = {
   viewport?: string;
   actionHandlers?: ActionHandlers;
   invokeTauri?: (cmd: string, args?: Record<string, string>) => Promise<unknown>;
+  listenUpdateAvailable?: (handler: (payload: UpdateAvailablePayload) => void) => void;
+  updateDismissalStorage?: UpdateDismissalStorage;
   deps?: StartDesktopBrowserAppDeps;
 };
 
@@ -79,6 +125,8 @@ export async function startDesktopBrowserApp({
   viewport = "desktop",
   actionHandlers = {},
   invokeTauri,
+  listenUpdateAvailable,
+  updateDismissalStorage,
   deps = {},
 }: StartDesktopBrowserAppOptions = {}): Promise<ReturnType<typeof bootstrapDesktopReactApp>> {
   const {
@@ -86,6 +134,8 @@ export async function startDesktopBrowserApp({
     bootstrapDesktopReactApp: bootstrapReactApp = bootstrapDesktopReactApp,
   } = deps;
   const resolvedInvoke = typeof invokeTauri === "function" ? invokeTauri : createDefaultTauriInvoke();
+  const resolvedListenUpdateAvailable = listenUpdateAvailable ?? createDefaultUpdateListener();
+  const updateStorage = updateDismissalStorage ?? createDefaultUpdateDismissalStorage();
   const resolvedFetch = fetchImpl ?? fetch;
   const router = createHashRouter();
   const authAwareFetch = createAuthAwareFetch(resolvedFetch, () => {
@@ -163,6 +213,23 @@ export async function startDesktopBrowserApp({
     return { newRecoveryCode: result.newRecoveryCode };
   }
 
+  // Set when update-available fires; onDismiss needs the version to persist it.
+  // Declared before reactApp so the handlers below can close over it — both are
+  // only invoked later, after reactApp is assigned, once mount() has resolved.
+  let currentUpdatePayload: UpdateAvailablePayload | undefined;
+  const updateBannerHandlers = {
+    onDismiss: () => {
+      if (currentUpdatePayload) dismissUpdateVersion(updateStorage, currentUpdatePayload.version);
+      currentUpdatePayload = undefined;
+      reactApp.showUpdateBanner?.(null);
+    },
+    onInstall: async () => {
+      if (typeof resolvedInvoke === "function") {
+        await resolvedInvoke("install_update");
+      }
+    },
+  };
+
   const reactApp = bootstrapReactApp({
     app,
     viewport: initialViewport,
@@ -179,10 +246,21 @@ export async function startDesktopBrowserApp({
     onLogin,
     onRegister,
     onResetPassword,
+    updateBannerHandlers,
   });
   await reactApp.mount();
   if (reactApp.desktopUi) {
     subscribeViewportChanges(reactApp.desktopUi, () => void reactApp.mount());
   }
+
+  if (resolvedListenUpdateAvailable) {
+    resolvedListenUpdateAvailable((payload) => {
+      const dismissedVersion = getDismissedUpdateVersion(updateStorage);
+      if (!shouldShowUpdateBanner({ availableVersion: payload.version, dismissedVersion })) return;
+      currentUpdatePayload = payload;
+      reactApp.showUpdateBanner?.(payload);
+    });
+  }
+
   return reactApp;
 }

--- a/apps/desktop/src/startDesktopBrowserApp.ts
+++ b/apps/desktop/src/startDesktopBrowserApp.ts
@@ -7,9 +7,7 @@ import { getAuthToken, setAuthToken, clearAuthToken } from "./authTokenStore.js"
 import { createAuthApiClient, type LoginResult, type RegisterResult, type ResetPasswordResult } from "./authApiClient.js";
 import { createAuthAwareFetch } from "./authAwareFetch.js";
 import {
-  shouldShowUpdateBanner,
-  getDismissedUpdateVersion,
-  dismissUpdateVersion,
+  createUpdateNotificationController,
   type UpdateAvailablePayload,
   type UpdateDismissalStorage,
 } from "./updateNotification.js";
@@ -137,6 +135,19 @@ export async function startDesktopBrowserApp({
   const resolvedListenUpdateAvailable = listenUpdateAvailable ?? createDefaultUpdateListener();
   const updateStorage = updateDismissalStorage ?? createDefaultUpdateDismissalStorage();
   const resolvedFetch = fetchImpl ?? fetch;
+
+  // Subscribed before any await below. The backend check is spawned from Rust's
+  // .setup() and Tauri's emit has no replay buffer, so subscribing after the
+  // bootstrap/auth round trips would silently drop an update that arrived
+  // first. The controller buffers until the UI attaches after mount.
+  const updateNotifications = createUpdateNotificationController({
+    storage: updateStorage,
+    installUpdate: async () => { await resolvedInvoke?.("install_update"); },
+    onInstallError: (error) => {
+      console.error("[bandsearch] update install failed", error);
+    },
+  });
+  resolvedListenUpdateAvailable?.((payload) => updateNotifications.updateAvailable(payload));
   const router = createHashRouter();
   const authAwareFetch = createAuthAwareFetch(resolvedFetch, () => {
     clearAuthToken();
@@ -213,23 +224,6 @@ export async function startDesktopBrowserApp({
     return { newRecoveryCode: result.newRecoveryCode };
   }
 
-  // Set when update-available fires; onDismiss needs the version to persist it.
-  // Declared before reactApp so the handlers below can close over it — both are
-  // only invoked later, after reactApp is assigned, once mount() has resolved.
-  let currentUpdatePayload: UpdateAvailablePayload | undefined;
-  const updateBannerHandlers = {
-    onDismiss: () => {
-      if (currentUpdatePayload) dismissUpdateVersion(updateStorage, currentUpdatePayload.version);
-      currentUpdatePayload = undefined;
-      reactApp.showUpdateBanner?.(null);
-    },
-    onInstall: async () => {
-      if (typeof resolvedInvoke === "function") {
-        await resolvedInvoke("install_update");
-      }
-    },
-  };
-
   const reactApp = bootstrapReactApp({
     app,
     viewport: initialViewport,
@@ -246,21 +240,15 @@ export async function startDesktopBrowserApp({
     onLogin,
     onRegister,
     onResetPassword,
-    updateBannerHandlers,
+    updateBannerHandlers: updateNotifications.handlers,
   });
   await reactApp.mount();
   if (reactApp.desktopUi) {
     subscribeViewportChanges(reactApp.desktopUi, () => void reactApp.mount());
   }
 
-  if (resolvedListenUpdateAvailable) {
-    resolvedListenUpdateAvailable((payload) => {
-      const dismissedVersion = getDismissedUpdateVersion(updateStorage);
-      if (!shouldShowUpdateBanner({ availableVersion: payload.version, dismissedVersion })) return;
-      currentUpdatePayload = payload;
-      reactApp.showUpdateBanner?.(payload);
-    });
-  }
+  // The UI can paint now; flushes an update that was reported during bootstrap.
+  updateNotifications.attach((viewProps) => reactApp.showUpdateBanner(viewProps));
 
   return reactApp;
 }

--- a/apps/desktop/src/ui/UpdateBanner.ts
+++ b/apps/desktop/src/ui/UpdateBanner.ts
@@ -1,0 +1,91 @@
+import type { UpdateBannerHandlers } from "./viewTypes.js";
+import * as React from "react";
+
+const palette = {
+  bg: "#16233b",
+  border: "#2c3e5c",
+  text: "#f0f4f8",
+  accent: "#7aa7d9",
+  installText: "#0a0d14",
+  laterText: "#c8d4e8",
+};
+
+export type UpdateBannerViewProps = {
+  version: string;
+  canAutoInstall: boolean;
+};
+
+/**
+ * Dismissible, `position: fixed` banner shown above every screen when a newer
+ * version is available. On Windows/Linux it offers a one-click Install;
+ * macOS testers (no signed updater artifact yet) only see the version note.
+ */
+export function UpdateBanner({
+  viewProps,
+  handlers,
+}: {
+  viewProps: UpdateBannerViewProps;
+  handlers: UpdateBannerHandlers;
+}) {
+  const { version, canAutoInstall } = viewProps;
+  return React.createElement(
+    "div",
+    {
+      className: "update-banner",
+      style: {
+        position: "fixed",
+        top: 0,
+        left: 0,
+        right: 0,
+        zIndex: 9999,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: "16px",
+        padding: "10px 16px",
+        backgroundColor: palette.bg,
+        borderBottom: `1px solid ${palette.border}`,
+        color: palette.text,
+        fontSize: "13px",
+      },
+    },
+    React.createElement("span", null, `Bandsearch ${version} is available.`),
+    canAutoInstall &&
+      React.createElement(
+        "button",
+        {
+          type: "button",
+          className: "update-banner-install-btn",
+          onClick: () => handlers.onInstall?.(),
+          style: {
+            backgroundColor: palette.accent,
+            color: palette.installText,
+            border: "none",
+            borderRadius: "6px",
+            padding: "6px 14px",
+            fontWeight: "600",
+            fontSize: "13px",
+            cursor: "pointer",
+          },
+        },
+        "Install",
+      ),
+    React.createElement(
+      "button",
+      {
+        type: "button",
+        className: "update-banner-dismiss-btn",
+        onClick: () => handlers.onDismiss?.(),
+        style: {
+          background: "none",
+          border: "none",
+          color: palette.laterText,
+          fontSize: "13px",
+          cursor: "pointer",
+          padding: 0,
+        },
+      },
+      "Later",
+    ),
+  );
+}

--- a/apps/desktop/src/ui/mountDesktopReactApp.ts
+++ b/apps/desktop/src/ui/mountDesktopReactApp.ts
@@ -109,23 +109,32 @@ export function createDesktopReactMount({
   let savedArtistsLoaded = false;
   // Set by showUpdateBanner; null means no banner is showing.
   let updateBannerViewProps: UpdateBannerViewProps | null = null;
+  // The last routed element, so the banner can be toggled on top of it without
+  // re-running the route — re-rendering `settings` would repeat its
+  // gemini_config_status IPC just to paint an overlay.
+  let routedView: React.ReactNode = null;
 
-  // Every route branch renders through here so the banner — when present —
-  // stays layered above whichever view is routed, instead of each branch
-  // needing to know about it.
-  function renderRoot(routedView: React.ReactNode) {
-    if (!updateBannerViewProps) {
-      root.render(routedView);
-      return;
-    }
+  // Always the same Fragment shape, banner or not: rendering the bare view when
+  // no banner is present would change the root element's shape the moment one
+  // appears, and React would unmount and remount the whole routed view.
+  function paint() {
     root.render(
       React.createElement(
         React.Fragment,
         null,
-        React.createElement(UpdateBanner, { viewProps: updateBannerViewProps, handlers: updateBannerHandlers }),
+        updateBannerViewProps &&
+          React.createElement(UpdateBanner, { viewProps: updateBannerViewProps, handlers: updateBannerHandlers }),
         routedView,
       ),
     );
+  }
+
+  // Every route branch renders through here so the banner — when present —
+  // stays layered above whichever view is routed, instead of each branch
+  // needing to know about it.
+  function renderRoot(nextRoutedView: React.ReactNode) {
+    routedView = nextRoutedView;
+    paint();
   }
 
   async function renderCurrent() {
@@ -430,7 +439,7 @@ export function createDesktopReactMount({
     },
     showUpdateBanner(viewProps: UpdateBannerViewProps | null) {
       updateBannerViewProps = viewProps;
-      return renderCurrent();
+      paint();
     },
   };
 }

--- a/apps/desktop/src/ui/mountDesktopReactApp.ts
+++ b/apps/desktop/src/ui/mountDesktopReactApp.ts
@@ -8,6 +8,8 @@ import { WelcomeView } from "./WelcomeView.js";
 import { LoginView } from "./LoginView.js";
 import { RegisterView } from "./RegisterView.js";
 import { ResetPasswordView } from "./ResetPasswordView.js";
+import { UpdateBanner, type UpdateBannerViewProps } from "./UpdateBanner.js";
+import type { UpdateBannerHandlers } from "./viewTypes.js";
 
 /** The shell surface this mount drives; everything optional is guarded with `?.`. */
 export type MountShell = {
@@ -69,6 +71,7 @@ export interface DesktopReactMountOptions {
   onResetPassword?: (email: string, recoveryCode: string, newPassword: string) => Promise<{ newRecoveryCode: string }>;
   onExportAccountData?: () => Promise<Record<string, unknown>>;
   onDeleteAccount?: (password: string) => Promise<{ ok: boolean; error?: string }>;
+  updateBannerHandlers?: UpdateBannerHandlers;
   createRootImpl?: typeof createRoot;
   resolveContainer?: () => HTMLElement;
 }
@@ -95,6 +98,7 @@ export function createDesktopReactMount({
   onLogin,
   onRegister,
   onResetPassword,
+  updateBannerHandlers = {},
   createRootImpl = createRoot,
   resolveContainer = defaultContainerResolver,
 }: DesktopReactMountOptions) {
@@ -103,28 +107,48 @@ export function createDesktopReactMount({
 
   // Whether the saved screen has fetched since the route was last entered.
   let savedArtistsLoaded = false;
+  // Set by showUpdateBanner; null means no banner is showing.
+  let updateBannerViewProps: UpdateBannerViewProps | null = null;
+
+  // Every route branch renders through here so the banner — when present —
+  // stays layered above whichever view is routed, instead of each branch
+  // needing to know about it.
+  function renderRoot(routedView: React.ReactNode) {
+    if (!updateBannerViewProps) {
+      root.render(routedView);
+      return;
+    }
+    root.render(
+      React.createElement(
+        React.Fragment,
+        null,
+        React.createElement(UpdateBanner, { viewProps: updateBannerViewProps, handlers: updateBannerHandlers }),
+        routedView,
+      ),
+    );
+  }
 
   async function renderCurrent() {
     const route = router ? router.getRoute() : "home";
     if (route !== "saved") savedArtistsLoaded = false;
 
     if (route === "login") {
-      root.render(React.createElement(LoginView as unknown as ViewComponentLike, { viewProps: {}, handlers: loginHandlers }));
+      renderRoot(React.createElement(LoginView as unknown as ViewComponentLike, { viewProps: {}, handlers: loginHandlers }));
       return {};
     }
 
     if (route === "register") {
-      root.render(React.createElement(RegisterView as unknown as ViewComponentLike, { viewProps: {}, handlers: registerHandlers }));
+      renderRoot(React.createElement(RegisterView as unknown as ViewComponentLike, { viewProps: {}, handlers: registerHandlers }));
       return {};
     }
 
     if (route === "reset-password") {
-      root.render(React.createElement(ResetPasswordView as unknown as ViewComponentLike, { viewProps: {}, handlers: resetPasswordHandlers }));
+      renderRoot(React.createElement(ResetPasswordView as unknown as ViewComponentLike, { viewProps: {}, handlers: resetPasswordHandlers }));
       return {};
     }
 
     if (route === "welcome") {
-      root.render(
+      renderRoot(
         React.createElement(WelcomeView as unknown as ViewComponentLike, {
           viewProps: {},
           handlers: welcomeHandlers,
@@ -143,7 +167,7 @@ export function createDesktopReactMount({
         await savedArtistsShell.loadSavedArtists?.();
       }
       const viewProps = savedArtistsShell.getViewProps();
-      root.render(
+      renderRoot(
         React.createElement(SavedArtistsView as unknown as ViewComponentLike, {
           viewProps,
           handlers: savedHandlers,
@@ -153,7 +177,7 @@ export function createDesktopReactMount({
     }
 
     if (route === "privacy") {
-      root.render(
+      renderRoot(
         React.createElement(PrivacyPolicyView as unknown as ViewComponentLike, {
           viewProps: {},
           handlers: privacyHandlers,
@@ -164,7 +188,7 @@ export function createDesktopReactMount({
 
     if (route === "settings") {
       const viewProps = await Promise.resolve(getSettingsViewProps());
-      root.render(
+      renderRoot(
         React.createElement(SettingsView as unknown as ViewComponentLike, {
           viewProps,
           handlers: settingsHandlers,
@@ -174,7 +198,7 @@ export function createDesktopReactMount({
     }
 
     const viewProps = shell.getViewProps();
-    root.render(React.createElement(ChatAppView as unknown as ViewComponentLike, { viewProps, handlers }));
+    renderRoot(React.createElement(ChatAppView as unknown as ViewComponentLike, { viewProps, handlers }));
     return viewProps;
   }
 
@@ -402,6 +426,10 @@ export function createDesktopReactMount({
   return {
     handlers,
     mount() {
+      return renderCurrent();
+    },
+    showUpdateBanner(viewProps: UpdateBannerViewProps | null) {
+      updateBannerViewProps = viewProps;
       return renderCurrent();
     },
   };

--- a/apps/desktop/src/ui/viewTypes.ts
+++ b/apps/desktop/src/ui/viewTypes.ts
@@ -70,3 +70,8 @@ export type WelcomeHandlers = {
   onGoToSettings?(): unknown;
   onSkip?(): unknown;
 };
+
+export type UpdateBannerHandlers = {
+  onInstall?(): unknown;
+  onDismiss?(): unknown;
+};

--- a/apps/desktop/src/updateNotification.ts
+++ b/apps/desktop/src/updateNotification.ts
@@ -1,0 +1,28 @@
+/** localStorage key: version string the user last dismissed the update banner for. */
+export const UPDATE_DISMISSED_VERSION_STORAGE_KEY = "bandsearch_update_dismissed_version";
+
+export interface UpdateDismissalStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+/**
+ * Show the banner when an update was reported and its version was not the
+ * one the user last dismissed. Dismissal is per-version, so a later update
+ * shows again even if an earlier one was dismissed.
+ */
+export function shouldShowUpdateBanner(input: {
+  availableVersion: string | undefined;
+  dismissedVersion: string | undefined;
+}): boolean {
+  if (!input.availableVersion) return false;
+  return input.availableVersion !== input.dismissedVersion;
+}
+
+export function getDismissedUpdateVersion(storage: UpdateDismissalStorage): string | undefined {
+  return storage.getItem(UPDATE_DISMISSED_VERSION_STORAGE_KEY) ?? undefined;
+}
+
+export function dismissUpdateVersion(storage: UpdateDismissalStorage, version: string): void {
+  storage.setItem(UPDATE_DISMISSED_VERSION_STORAGE_KEY, version);
+}

--- a/apps/desktop/src/updateNotification.ts
+++ b/apps/desktop/src/updateNotification.ts
@@ -32,3 +32,70 @@ export function getDismissedUpdateVersion(storage: UpdateDismissalStorage): stri
 export function dismissUpdateVersion(storage: UpdateDismissalStorage, version: string): void {
   storage.setItem(UPDATE_DISMISSED_VERSION_STORAGE_KEY, version);
 }
+
+export interface UpdateNotificationControllerOptions {
+  storage: UpdateDismissalStorage;
+  /** Invokes the backend install command. Injected so tests need no Tauri host. */
+  installUpdate: () => Promise<void>;
+  onInstallError?: (error: unknown) => void;
+}
+
+/**
+ * Owns "an update is available" for the lifetime of the app: the decision, the
+ * per-version dismissal, and the banner's handlers — so no caller has to
+ * sequence those correctly by hand.
+ *
+ * Crucially it decouples *when the update is reported* from *when the UI can
+ * render it*. The Rust check runs from `.setup()` and can emit before the
+ * webview has booted; Tauri's `emit` has no replay buffer, so a payload that
+ * arrives before `attach()` is held and flushed on attach rather than lost for
+ * that launch.
+ */
+export function createUpdateNotificationController({
+  storage,
+  installUpdate,
+  onInstallError,
+}: UpdateNotificationControllerOptions) {
+  let showBanner: ((viewProps: UpdateAvailablePayload | null) => void) | undefined;
+  /** Reported while no renderer was attached yet; flushed by attach(). */
+  let buffered: UpdateAvailablePayload | undefined;
+  /** The update currently on display, needed to persist the right dismissal. */
+  let current: UpdateAvailablePayload | undefined;
+
+  return {
+    /** Feed in an `update-available` payload. Safe to call before attach(). */
+    updateAvailable(payload: UpdateAvailablePayload): void {
+      const dismissedVersion = getDismissedUpdateVersion(storage);
+      if (!shouldShowUpdateBanner({ availableVersion: payload.version, dismissedVersion })) return;
+      current = payload;
+      if (showBanner) showBanner(payload);
+      else buffered = payload;
+    },
+
+    /** Connect the renderer once the UI can paint, flushing anything buffered. */
+    attach(show: (viewProps: UpdateAvailablePayload | null) => void): void {
+      showBanner = show;
+      if (buffered) {
+        show(buffered);
+        buffered = undefined;
+      }
+    },
+
+    handlers: {
+      onDismiss(): void {
+        if (current) dismissUpdateVersion(storage, current.version);
+        current = undefined;
+        showBanner?.(null);
+      },
+      async onInstall(): Promise<void> {
+        // A rejection here would land in a click handler with nobody to catch
+        // it; the controller owns install failure so the caller cannot forget.
+        try {
+          await installUpdate();
+        } catch (error) {
+          onInstallError?.(error);
+        }
+      },
+    },
+  };
+}

--- a/apps/desktop/src/updateNotification.ts
+++ b/apps/desktop/src/updateNotification.ts
@@ -6,6 +6,12 @@ export interface UpdateDismissalStorage {
   setItem(key: string, value: string): void;
 }
 
+/** The `update-available` Tauri event payload emitted from main.rs's setup hook. */
+export type UpdateAvailablePayload = {
+  version: string;
+  canAutoInstall: boolean;
+};
+
 /**
  * Show the banner when an update was reported and its version was not the
  * one the user last dismissed. Dismissal is per-version, so a later update

--- a/apps/desktop/test/app-version.test.ts
+++ b/apps/desktop/test/app-version.test.ts
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const root = path.resolve(path.dirname(process.argv[1]), "../../..");
+
+function readJsonVersion(relativePath: string): string {
+  const filePath = path.join(root, relativePath);
+  const parsed: unknown = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  assert.ok(
+    typeof parsed === "object" && parsed !== null && "version" in parsed,
+    `${relativePath} must have a "version" field`,
+  );
+  const version = (parsed as { version: unknown }).version;
+  assert.equal(typeof version, "string", `${relativePath} version must be a string`);
+  return version as string;
+}
+
+function readCargoVersion(relativePath: string): string {
+  const filePath = path.join(root, relativePath);
+  const contents = fs.readFileSync(filePath, "utf8");
+  const match = contents.match(/^version\s*=\s*"([^"]+)"/m);
+  assert.ok(match, `${relativePath} must have a top-level version field`);
+  return match![1];
+}
+
+test("the app version is the same string across npm, Cargo and Tauri", () => {
+  const versions: Record<string, string> = {
+    "package.json": readJsonVersion("package.json"),
+    "apps/desktop/package.json": readJsonVersion("apps/desktop/package.json"),
+    "services/api/package.json": readJsonVersion("services/api/package.json"),
+    "services/eval/package.json": readJsonVersion("services/eval/package.json"),
+    "shared/schemas/package.json": readJsonVersion("shared/schemas/package.json"),
+    "apps/desktop/src-tauri/Cargo.toml": readCargoVersion("apps/desktop/src-tauri/Cargo.toml"),
+    "apps/desktop/src-tauri/tauri.conf.json": readJsonVersion(
+      "apps/desktop/src-tauri/tauri.conf.json",
+    ),
+  };
+
+  const distinct = new Set(Object.values(versions));
+  assert.equal(
+    distinct.size,
+    1,
+    `Expected one version everywhere, found: ${JSON.stringify(versions, null, 2)}`,
+  );
+});

--- a/apps/desktop/test/helpers/fakeDom.ts
+++ b/apps/desktop/test/helpers/fakeDom.ts
@@ -4,7 +4,7 @@
 // two fields, so a full DOM implementation would be noise. These helpers keep
 // the narrowing in one place instead of casting at every call site.
 
-import type { ReactNode } from "react";
+import { Fragment, type ReactElement, type ReactNode } from "react";
 import type { Root } from "react-dom/client";
 
 /** A mount container. React roots are faked in these tests, so nothing reads it. */
@@ -23,6 +23,20 @@ export function fakeReactRoot(onRender: (element: ReactNode) => void = () => {})
     render: onRender,
     unmount: () => {},
   };
+}
+
+/**
+ * The mount always renders `<Fragment>[banner?, routedView]</Fragment>` — a
+ * fixed shape, so the routed view keeps its React identity (and its DOM state)
+ * when the update banner appears or is dismissed. Tests assert on the routed
+ * view, so unwrap it from that envelope.
+ */
+export function routedViewOf(rendered: ReactNode): ReactElement {
+  const element = rendered as ReactElement<{ children?: ReactNode }>;
+  if (element?.type !== Fragment) return element;
+  const children = element.props.children;
+  const list = Array.isArray(children) ? children : [children];
+  return list[list.length - 1] as ReactElement;
 }
 
 /** A matchMedia result; only `matches` and the listener hooks are exercised. */

--- a/apps/desktop/test/helpers/fakeStorage.ts
+++ b/apps/desktop/test/helpers/fakeStorage.ts
@@ -1,0 +1,12 @@
+import type { UpdateDismissalStorage } from "../../src/updateNotification.js";
+
+/** In-memory stand-in for the one-key dismissal store, so tests need no localStorage. */
+export function fakeUpdateStorage(initial: Record<string, string> = {}): UpdateDismissalStorage {
+  const data = new Map(Object.entries(initial));
+  return {
+    getItem: (key: string) => data.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      data.set(key, value);
+    },
+  };
+}

--- a/apps/desktop/test/routed-mount.test.ts
+++ b/apps/desktop/test/routed-mount.test.ts
@@ -6,7 +6,7 @@ import {
   createDesktopReactMount,
   type DesktopReactMountOptions,
 } from "../src/ui/mountDesktopReactApp.js";
-import { fakeContainer, fakeReactRoot } from "./helpers/fakeDom.js";
+import { fakeContainer, fakeReactRoot, routedViewOf } from "./helpers/fakeDom.js";
 
 type MountShell = DesktopReactMountOptions["shell"];
 type MountRouter = NonNullable<DesktopReactMountOptions["router"]>;
@@ -21,7 +21,8 @@ function recordingRoot(renders: ReactElement[]): Root {
 
 // The mount picks a view component per route; these tests assert on that choice.
 function renderedComponentName(element: ReactElement): string | undefined {
-  return typeof element.type === "function" ? element.type.name : undefined;
+  const view = routedViewOf(element);
+  return typeof view.type === "function" ? view.type.name : undefined;
 }
 
 function makeShell(overrides: Partial<MountShell> = {}): MountShell {

--- a/apps/desktop/test/saved-artists-screen.test.ts
+++ b/apps/desktop/test/saved-artists-screen.test.ts
@@ -8,7 +8,7 @@ import { createDesktopReactMount } from "../src/ui/mountDesktopReactApp.js";
 import { SavedArtistsView } from "../src/ui/SavedArtistsView.js";
 import type { SavedArtistsHandlers } from "../src/ui/viewTypes.js";
 import type { ArtistGroup, ArtistSearchResult, SavedBand } from "../src/domain.js";
-import { fakeContainer, fakeReactRoot } from "./helpers/fakeDom.js";
+import { fakeContainer, fakeReactRoot, routedViewOf } from "./helpers/fakeDom.js";
 
 // These tests pair the real shell with the real view. Every other saved-artists
 // test feeds the view a hand-written prop object, which is how the shell's
@@ -156,7 +156,7 @@ function mountSavedScreen(app: SavedArtistsShellCollaborator) {
       onRouteChange: () => {},
     },
     savedArtistsShell: shell,
-    createRootImpl: () => fakeReactRoot((element) => { lastRender = element as RenderedScreen; }),
+    createRootImpl: () => fakeReactRoot((element) => { lastRender = routedViewOf(element) as RenderedScreen; }),
     resolveContainer: () => fakeContainer(),
   });
   return {

--- a/apps/desktop/test/start-desktop-browser-app.test.ts
+++ b/apps/desktop/test/start-desktop-browser-app.test.ts
@@ -4,7 +4,9 @@ import { startDesktopBrowserApp } from "../src/startDesktopBrowserApp.js";
 import { bootstrapDesktopApp, bootstrapDesktopReactApp } from "../src/index.js";
 import { jsonResponse } from "./helpers/fakeResponse.js";
 import { fakeMediaQueryList, fakeWindow } from "./helpers/fakeDom.js";
+import { fakeUpdateStorage } from "./helpers/fakeStorage.js";
 import type { UpdateAvailablePayload, UpdateDismissalStorage } from "../src/updateNotification.js";
+import type { UpdateBannerHandlers } from "../src/ui/viewTypes.js";
 
 // One flat record instead of a discriminated union: the assertions read a single
 // field per call and stay free of narrowing noise.
@@ -130,102 +132,90 @@ test("startDesktopBrowserApp picks mobile viewport when matchMedia matches narro
   assert.equal(calls[0].viewport, "mobile");
 });
 
-function fakeUpdateStorage(initial: Record<string, string> = {}): UpdateDismissalStorage {
-  const data = new Map(Object.entries(initial));
-  return {
-    getItem: (key: string) => data.get(key) ?? null,
-    setItem: (key: string, value: string) => {
-      data.set(key, value);
-    },
-  };
-}
-
-/** Captures the subscription so a test can fire the event itself. */
-function capturingUpdateListener() {
-  let handler: ((payload: UpdateAvailablePayload) => void) | undefined;
-  return {
-    listenUpdateAvailable: (h: (payload: UpdateAvailablePayload) => void) => { handler = h; },
-    fire: (payload: UpdateAvailablePayload) => handler?.(payload),
-  };
-}
-
-async function startWithUpdateDeps(overrides: {
-  listenUpdateAvailable: (handler: (payload: UpdateAvailablePayload) => void) => void;
-  updateDismissalStorage: UpdateDismissalStorage;
-  invokeTauri?: (cmd: string, args?: Record<string, string>) => Promise<unknown>;
-}) {
-  let capturedUpdateBannerHandlers: { onInstall?: () => void; onDismiss?: () => void } | undefined;
+/**
+ * Boots the app with the update collaborators injected, and hands back the
+ * banner calls, the banner handlers, and a `fire` that plays an
+ * `update-available` event through whatever listener the app subscribed.
+ */
+async function startWithUpdateDeps(
+  overrides: {
+    updateDismissalStorage?: UpdateDismissalStorage;
+    invokeTauri?: (cmd: string, args?: Record<string, string>) => Promise<unknown>;
+  } = {},
+) {
+  let listener: ((payload: UpdateAvailablePayload) => void) | undefined;
+  let updateBannerHandlers: UpdateBannerHandlers | undefined;
   const showUpdateBannerCalls: Array<UpdateAvailablePayload | null> = [];
 
   await startDesktopBrowserApp({
-    listenUpdateAvailable: overrides.listenUpdateAvailable,
-    updateDismissalStorage: overrides.updateDismissalStorage,
+    listenUpdateAvailable: (handler) => { listener = handler; },
+    updateDismissalStorage: overrides.updateDismissalStorage ?? fakeUpdateStorage(),
     invokeTauri: overrides.invokeTauri ?? (async () => ({})),
     deps: {
       bootstrapDesktopApp: (options) => bootstrapDesktopApp(options),
       bootstrapDesktopReactApp: (options) => {
-        capturedUpdateBannerHandlers = (options as { updateBannerHandlers?: typeof capturedUpdateBannerHandlers }).updateBannerHandlers;
-        return {
+        updateBannerHandlers = options.updateBannerHandlers;
+        return fakeReactApp({
           mount: async () => ({}),
-          showUpdateBanner: (payload: UpdateAvailablePayload | null) => {
-            showUpdateBannerCalls.push(payload);
-          },
-        } as unknown as ReturnType<typeof bootstrapDesktopReactApp>;
+          showUpdateBanner: (payload) => { showUpdateBannerCalls.push(payload); },
+        });
       },
     },
   });
 
-  return { showUpdateBannerCalls, updateBannerHandlers: capturedUpdateBannerHandlers };
+  return {
+    showUpdateBannerCalls,
+    updateBannerHandlers,
+    fire: (payload: UpdateAvailablePayload) => listener?.(payload),
+  };
 }
 
+const AN_UPDATE: UpdateAvailablePayload = { version: "0.5.0", canAutoInstall: true };
+
 test("an update-available payload makes the banner appear", async () => {
-  const listener = capturingUpdateListener();
-  const { showUpdateBannerCalls } = await startWithUpdateDeps({
-    listenUpdateAvailable: listener.listenUpdateAvailable,
-    updateDismissalStorage: fakeUpdateStorage(),
-  });
+  const app = await startWithUpdateDeps();
 
-  listener.fire({ version: "0.5.0", canAutoInstall: true });
+  app.fire(AN_UPDATE);
 
-  assert.deepEqual(showUpdateBannerCalls, [{ version: "0.5.0", canAutoInstall: true }]);
+  assert.deepEqual(app.showUpdateBannerCalls, [AN_UPDATE]);
+});
+
+test("the app subscribes before bootstrap finishes, so no update is dropped", async () => {
+  // Regression guard: the Rust check is spawned from .setup() and Tauri's emit
+  // has no replay buffer. Subscribing only after the bootstrap/auth awaits used
+  // to mean an update that arrived first was lost for that whole launch.
+  const app = await startWithUpdateDeps();
+  assert.equal(typeof app.fire, "function", "a listener must be registered by the time start resolves");
+
+  app.fire(AN_UPDATE);
+  assert.deepEqual(app.showUpdateBannerCalls, [AN_UPDATE], "the update still reaches the banner");
 });
 
 test("dismissing the banner persists and it does not reappear on the next start", async () => {
   const storage = fakeUpdateStorage();
 
-  const listenerA = capturingUpdateListener();
-  const first = await startWithUpdateDeps({
-    listenUpdateAvailable: listenerA.listenUpdateAvailable,
-    updateDismissalStorage: storage,
-  });
-  listenerA.fire({ version: "0.5.0", canAutoInstall: true });
+  const first = await startWithUpdateDeps({ updateDismissalStorage: storage });
+  first.fire(AN_UPDATE);
   assert.equal(first.showUpdateBannerCalls.length, 1, "banner should appear on first start");
   first.updateBannerHandlers?.onDismiss?.();
 
-  const listenerB = capturingUpdateListener();
-  const second = await startWithUpdateDeps({
-    listenUpdateAvailable: listenerB.listenUpdateAvailable,
-    updateDismissalStorage: storage,
-  });
-  listenerB.fire({ version: "0.5.0", canAutoInstall: true });
+  const second = await startWithUpdateDeps({ updateDismissalStorage: storage });
+  second.fire(AN_UPDATE);
 
   assert.equal(second.showUpdateBannerCalls.length, 0, "dismissed version should not reappear");
 });
 
 test("clicking Install invokes the install_update command", async () => {
   const invokedCommands: string[] = [];
-  const listener = capturingUpdateListener();
-  const { updateBannerHandlers } = await startWithUpdateDeps({
-    listenUpdateAvailable: listener.listenUpdateAvailable,
-    updateDismissalStorage: fakeUpdateStorage(),
+  const app = await startWithUpdateDeps({
     invokeTauri: async (cmd) => {
       invokedCommands.push(cmd);
       return {};
     },
   });
-  listener.fire({ version: "0.5.0", canAutoInstall: true });
+  app.fire(AN_UPDATE);
 
-  await updateBannerHandlers?.onInstall?.();
+  await app.updateBannerHandlers?.onInstall?.();
 
   assert.ok(invokedCommands.includes("install_update"), "expected install_update to be invoked");
 });

--- a/apps/desktop/test/start-desktop-browser-app.test.ts
+++ b/apps/desktop/test/start-desktop-browser-app.test.ts
@@ -4,6 +4,7 @@ import { startDesktopBrowserApp } from "../src/startDesktopBrowserApp.js";
 import { bootstrapDesktopApp, bootstrapDesktopReactApp } from "../src/index.js";
 import { jsonResponse } from "./helpers/fakeResponse.js";
 import { fakeMediaQueryList, fakeWindow } from "./helpers/fakeDom.js";
+import type { UpdateAvailablePayload, UpdateDismissalStorage } from "../src/updateNotification.js";
 
 // One flat record instead of a discriminated union: the assertions read a single
 // field per call and stay free of narrowing noise.
@@ -127,4 +128,104 @@ test("startDesktopBrowserApp picks mobile viewport when matchMedia matches narro
 
   assert.equal(calls[0].type, "bootstrapReact");
   assert.equal(calls[0].viewport, "mobile");
+});
+
+function fakeUpdateStorage(initial: Record<string, string> = {}): UpdateDismissalStorage {
+  const data = new Map(Object.entries(initial));
+  return {
+    getItem: (key: string) => data.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      data.set(key, value);
+    },
+  };
+}
+
+/** Captures the subscription so a test can fire the event itself. */
+function capturingUpdateListener() {
+  let handler: ((payload: UpdateAvailablePayload) => void) | undefined;
+  return {
+    listenUpdateAvailable: (h: (payload: UpdateAvailablePayload) => void) => { handler = h; },
+    fire: (payload: UpdateAvailablePayload) => handler?.(payload),
+  };
+}
+
+async function startWithUpdateDeps(overrides: {
+  listenUpdateAvailable: (handler: (payload: UpdateAvailablePayload) => void) => void;
+  updateDismissalStorage: UpdateDismissalStorage;
+  invokeTauri?: (cmd: string, args?: Record<string, string>) => Promise<unknown>;
+}) {
+  let capturedUpdateBannerHandlers: { onInstall?: () => void; onDismiss?: () => void } | undefined;
+  const showUpdateBannerCalls: Array<UpdateAvailablePayload | null> = [];
+
+  await startDesktopBrowserApp({
+    listenUpdateAvailable: overrides.listenUpdateAvailable,
+    updateDismissalStorage: overrides.updateDismissalStorage,
+    invokeTauri: overrides.invokeTauri ?? (async () => ({})),
+    deps: {
+      bootstrapDesktopApp: (options) => bootstrapDesktopApp(options),
+      bootstrapDesktopReactApp: (options) => {
+        capturedUpdateBannerHandlers = (options as { updateBannerHandlers?: typeof capturedUpdateBannerHandlers }).updateBannerHandlers;
+        return {
+          mount: async () => ({}),
+          showUpdateBanner: (payload: UpdateAvailablePayload | null) => {
+            showUpdateBannerCalls.push(payload);
+          },
+        } as unknown as ReturnType<typeof bootstrapDesktopReactApp>;
+      },
+    },
+  });
+
+  return { showUpdateBannerCalls, updateBannerHandlers: capturedUpdateBannerHandlers };
+}
+
+test("an update-available payload makes the banner appear", async () => {
+  const listener = capturingUpdateListener();
+  const { showUpdateBannerCalls } = await startWithUpdateDeps({
+    listenUpdateAvailable: listener.listenUpdateAvailable,
+    updateDismissalStorage: fakeUpdateStorage(),
+  });
+
+  listener.fire({ version: "0.5.0", canAutoInstall: true });
+
+  assert.deepEqual(showUpdateBannerCalls, [{ version: "0.5.0", canAutoInstall: true }]);
+});
+
+test("dismissing the banner persists and it does not reappear on the next start", async () => {
+  const storage = fakeUpdateStorage();
+
+  const listenerA = capturingUpdateListener();
+  const first = await startWithUpdateDeps({
+    listenUpdateAvailable: listenerA.listenUpdateAvailable,
+    updateDismissalStorage: storage,
+  });
+  listenerA.fire({ version: "0.5.0", canAutoInstall: true });
+  assert.equal(first.showUpdateBannerCalls.length, 1, "banner should appear on first start");
+  first.updateBannerHandlers?.onDismiss?.();
+
+  const listenerB = capturingUpdateListener();
+  const second = await startWithUpdateDeps({
+    listenUpdateAvailable: listenerB.listenUpdateAvailable,
+    updateDismissalStorage: storage,
+  });
+  listenerB.fire({ version: "0.5.0", canAutoInstall: true });
+
+  assert.equal(second.showUpdateBannerCalls.length, 0, "dismissed version should not reappear");
+});
+
+test("clicking Install invokes the install_update command", async () => {
+  const invokedCommands: string[] = [];
+  const listener = capturingUpdateListener();
+  const { updateBannerHandlers } = await startWithUpdateDeps({
+    listenUpdateAvailable: listener.listenUpdateAvailable,
+    updateDismissalStorage: fakeUpdateStorage(),
+    invokeTauri: async (cmd) => {
+      invokedCommands.push(cmd);
+      return {};
+    },
+  });
+  listener.fire({ version: "0.5.0", canAutoInstall: true });
+
+  await updateBannerHandlers?.onInstall?.();
+
+  assert.ok(invokedCommands.includes("install_update"), "expected install_update to be invoked");
 });

--- a/apps/desktop/test/update-banner.test.ts
+++ b/apps/desktop/test/update-banner.test.ts
@@ -1,0 +1,87 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { UpdateBanner } from "../src/ui/UpdateBanner.js";
+
+type ButtonElement = React.ReactElement<{
+  className?: string;
+  children?: React.ReactNode;
+  onClick?: () => void;
+}>;
+
+/**
+ * UpdateBanner has no internal state, so it is called directly (not mounted)
+ * and its returned element tree is walked to find the button to click — the
+ * only way to exercise a click handler without a DOM/testing-library setup,
+ * which this codebase does not have.
+ */
+function findByClassName(node: unknown, className: string): ButtonElement | null {
+  if (!node || typeof node !== "object") return null;
+  const el = node as ButtonElement;
+  if (el.props?.className === className) return el;
+  const children = el.props?.children;
+  if (Array.isArray(children)) {
+    for (const child of children) {
+      const found = findByClassName(child, className);
+      if (found) return found;
+    }
+  } else if (children) {
+    return findByClassName(children, className);
+  }
+  return null;
+}
+
+test("UpdateBanner renders the available version", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(UpdateBanner, {
+      viewProps: { version: "0.5.0", canAutoInstall: true },
+      handlers: {},
+    }),
+  );
+  assert.ok(html.includes("0.5.0"), "expected the version string in the banner");
+});
+
+test("UpdateBanner shows an Install button when canAutoInstall is true", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(UpdateBanner, {
+      viewProps: { version: "0.5.0", canAutoInstall: true },
+      handlers: {},
+    }),
+  );
+  assert.ok(html.includes("Install"), "expected an Install button");
+});
+
+test("UpdateBanner hides the Install button when canAutoInstall is false", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(UpdateBanner, {
+      viewProps: { version: "0.5.0", canAutoInstall: false },
+      handlers: {},
+    }),
+  );
+  assert.ok(!html.includes("Install"), "did not expect an Install button");
+});
+
+test("UpdateBanner calls the dismiss handler when Later is clicked", () => {
+  let dismissed = false;
+  const element = UpdateBanner({
+    viewProps: { version: "0.5.0", canAutoInstall: true },
+    handlers: { onDismiss: () => { dismissed = true; } },
+  });
+  const laterBtn = findByClassName(element, "update-banner-dismiss-btn");
+  assert.ok(laterBtn, "expected a Later button");
+  laterBtn!.props.onClick?.();
+  assert.equal(dismissed, true);
+});
+
+test("UpdateBanner calls the install handler when Install is clicked", () => {
+  let installed = false;
+  const element = UpdateBanner({
+    viewProps: { version: "0.5.0", canAutoInstall: true },
+    handlers: { onInstall: () => { installed = true; } },
+  });
+  const installBtn = findByClassName(element, "update-banner-install-btn");
+  assert.ok(installBtn, "expected an Install button");
+  installBtn!.props.onClick?.();
+  assert.equal(installed, true);
+});

--- a/apps/desktop/test/update-notification.test.ts
+++ b/apps/desktop/test/update-notification.test.ts
@@ -6,18 +6,10 @@ import {
   shouldShowUpdateBanner,
   getDismissedUpdateVersion,
   dismissUpdateVersion,
-  type UpdateDismissalStorage,
+  createUpdateNotificationController,
+  type UpdateAvailablePayload,
 } from "../src/updateNotification.js";
-
-function createFakeStorage(initial: Record<string, string> = {}): UpdateDismissalStorage {
-  const data = new Map(Object.entries(initial));
-  return {
-    getItem: (key: string) => data.get(key) ?? null,
-    setItem: (key: string, value: string) => {
-      data.set(key, value);
-    },
-  };
-}
+import { fakeUpdateStorage } from "./helpers/fakeStorage.js";
 
 test("shows the banner for a newer version that was never dismissed", () => {
   assert.equal(
@@ -48,17 +40,108 @@ test("stays hidden when no update was reported", () => {
 });
 
 test("getDismissedUpdateVersion reads the dismissal key from storage", () => {
-  const storage = createFakeStorage({ [UPDATE_DISMISSED_VERSION_STORAGE_KEY]: "0.5.0" });
+  const storage = fakeUpdateStorage({ [UPDATE_DISMISSED_VERSION_STORAGE_KEY]: "0.5.0" });
   assert.equal(getDismissedUpdateVersion(storage), "0.5.0");
 });
 
 test("getDismissedUpdateVersion is undefined when nothing was dismissed", () => {
-  const storage = createFakeStorage();
-  assert.equal(getDismissedUpdateVersion(storage), undefined);
+  assert.equal(getDismissedUpdateVersion(fakeUpdateStorage()), undefined);
 });
 
 test("dismissUpdateVersion persists the version so it reads back", () => {
-  const storage = createFakeStorage();
+  const storage = fakeUpdateStorage();
   dismissUpdateVersion(storage, "0.5.0");
   assert.equal(getDismissedUpdateVersion(storage), "0.5.0");
+});
+
+// ── controller ──────────────────────────────────────────────────────────────
+
+const AN_UPDATE: UpdateAvailablePayload = { version: "0.5.0", canAutoInstall: true };
+
+function controllerWithSpies(storage = fakeUpdateStorage()) {
+  const shown: Array<UpdateAvailablePayload | null> = [];
+  const installs: number[] = [];
+  const errors: unknown[] = [];
+  const controller = createUpdateNotificationController({
+    storage,
+    installUpdate: async () => { installs.push(1); },
+    onInstallError: (e) => errors.push(e),
+  });
+  return { controller, shown, installs, errors, attach: () => controller.attach((p) => shown.push(p)) };
+}
+
+test("an update reported after the UI is ready shows the banner", () => {
+  const c = controllerWithSpies();
+  c.attach();
+  c.controller.updateAvailable(AN_UPDATE);
+  assert.deepEqual(c.shown, [AN_UPDATE]);
+});
+
+test("an update reported BEFORE the UI is ready is buffered, not dropped", () => {
+  // The Rust check runs from .setup() and can fire before the webview has
+  // finished booting. Tauri's emit has no replay, so the controller has to
+  // hold the payload until attach() rather than losing it for that launch.
+  const c = controllerWithSpies();
+  c.controller.updateAvailable(AN_UPDATE);
+  assert.deepEqual(c.shown, [], "nothing can render before attach");
+  c.attach();
+  assert.deepEqual(c.shown, [AN_UPDATE], "buffered update renders once attached");
+});
+
+test("a dismissed version is not buffered and never reaches the UI", () => {
+  const storage = fakeUpdateStorage({ [UPDATE_DISMISSED_VERSION_STORAGE_KEY]: "0.5.0" });
+  const c = controllerWithSpies(storage);
+  c.controller.updateAvailable(AN_UPDATE);
+  c.attach();
+  assert.deepEqual(c.shown, []);
+});
+
+test("dismissing persists the version and retracts the banner", () => {
+  const storage = fakeUpdateStorage();
+  const c = controllerWithSpies(storage);
+  c.attach();
+  c.controller.updateAvailable(AN_UPDATE);
+  c.controller.handlers.onDismiss();
+
+  assert.deepEqual(c.shown, [AN_UPDATE, null], "banner retracted");
+  assert.equal(getDismissedUpdateVersion(storage), "0.5.0", "dismissal persisted");
+});
+
+test("a version dismissed in an earlier run stays hidden in the next one", () => {
+  const storage = fakeUpdateStorage();
+  const first = controllerWithSpies(storage);
+  first.attach();
+  first.controller.updateAvailable(AN_UPDATE);
+  first.controller.handlers.onDismiss();
+
+  const second = controllerWithSpies(storage);
+  second.attach();
+  second.controller.updateAvailable(AN_UPDATE);
+
+  assert.deepEqual(second.shown, []);
+});
+
+test("install delegates to the injected installer", async () => {
+  const c = controllerWithSpies();
+  c.attach();
+  c.controller.updateAvailable(AN_UPDATE);
+  await c.controller.handlers.onInstall();
+  assert.deepEqual(c.installs, [1]);
+});
+
+test("a failing install is reported instead of rejecting into the click handler", async () => {
+  const shown: Array<UpdateAvailablePayload | null> = [];
+  const errors: unknown[] = [];
+  const controller = createUpdateNotificationController({
+    storage: fakeUpdateStorage(),
+    installUpdate: async () => { throw new Error("installer exploded"); },
+    onInstallError: (e) => errors.push(e),
+  });
+  controller.attach((p) => shown.push(p));
+  controller.updateAvailable(AN_UPDATE);
+
+  await controller.handlers.onInstall();
+
+  assert.equal(errors.length, 1, "the failure is surfaced to the caller");
+  assert.match(String(errors[0]), /installer exploded/);
 });

--- a/apps/desktop/test/update-notification.test.ts
+++ b/apps/desktop/test/update-notification.test.ts
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  UPDATE_DISMISSED_VERSION_STORAGE_KEY,
+  shouldShowUpdateBanner,
+  getDismissedUpdateVersion,
+  dismissUpdateVersion,
+  type UpdateDismissalStorage,
+} from "../src/updateNotification.js";
+
+function createFakeStorage(initial: Record<string, string> = {}): UpdateDismissalStorage {
+  const data = new Map(Object.entries(initial));
+  return {
+    getItem: (key: string) => data.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      data.set(key, value);
+    },
+  };
+}
+
+test("shows the banner for a newer version that was never dismissed", () => {
+  assert.equal(
+    shouldShowUpdateBanner({ availableVersion: "0.5.0", dismissedVersion: undefined }),
+    true,
+  );
+});
+
+test("stays hidden for a version the user already dismissed", () => {
+  assert.equal(
+    shouldShowUpdateBanner({ availableVersion: "0.5.0", dismissedVersion: "0.5.0" }),
+    false,
+  );
+});
+
+test("shows again for a different version after an earlier dismissal", () => {
+  assert.equal(
+    shouldShowUpdateBanner({ availableVersion: "0.6.0", dismissedVersion: "0.5.0" }),
+    true,
+  );
+});
+
+test("stays hidden when no update was reported", () => {
+  assert.equal(
+    shouldShowUpdateBanner({ availableVersion: undefined, dismissedVersion: undefined }),
+    false,
+  );
+});
+
+test("getDismissedUpdateVersion reads the dismissal key from storage", () => {
+  const storage = createFakeStorage({ [UPDATE_DISMISSED_VERSION_STORAGE_KEY]: "0.5.0" });
+  assert.equal(getDismissedUpdateVersion(storage), "0.5.0");
+});
+
+test("getDismissedUpdateVersion is undefined when nothing was dismissed", () => {
+  const storage = createFakeStorage();
+  assert.equal(getDismissedUpdateVersion(storage), undefined);
+});
+
+test("dismissUpdateVersion persists the version so it reads back", () => {
+  const storage = createFakeStorage();
+  dismissUpdateVersion(storage, "0.5.0");
+  assert.equal(getDismissedUpdateVersion(storage), "0.5.0");
+});

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -204,16 +204,16 @@ Render auto-deploys on every push to the connected branch, so no separate deploy
 
 **Spec:** [`docs/architecture/2026-06-03-auto-update-plan.md`](architecture/2026-06-03-auto-update-plan.md)
 
-Tester werden direkt in der App über neue Versionen informiert. Windows & Linux: vollautomatischer Ein-Klick-Update via `tauri-plugin-updater`. macOS: Banner mit Link zur GitHub-Releases-Seite (kein Code-Signing nötig).
+Tester werden direkt in der App über neue Versionen informiert. Windows & Linux: vollautomatischer Ein-Klick-Update via `tauri-plugin-updater`. macOS: kein Update-Pfad in diesem Zyklus (siehe Deviations im Plan) — ohne Code-Signing liefert der Rust-Updater keinen macOS-Eintrag in `latest.json`, daher kein Banner für macOS-Tester vorerst.
 
-- [ ] `tauri-plugin-updater` einbinden, Version auf `0.4.0` synchronisieren
-- [ ] Hintergrund-Check beim App-Start (Rust → Tauri-Event, event-getrieben)
-- [ ] `install_update` Tauri-Command (Windows & Linux)
-- [ ] macOS: Frontend-seitiger GitHub-API-Check
-- [ ] Einheitlicher Update-Banner im Frontend (kein neues File)
-- [ ] GitHub Actions Release-Workflow für Linux, Windows & macOS (Node-Sidecar-Download, `tauri-action`)
-- [ ] Signing-Key generieren + GitHub Secrets konfigurieren
-- [ ] Erstes versioniertes Release (`v0.4.0`) als Testlauf
+- [x] `tauri-plugin-updater` einbinden — bereits vor diesem Zyklus erledigt (Dependency, Plugin-Registrierung, `pubkey` + Endpoint in `tauri.conf.json`); Version auf `0.4.0` synchronisiert (dieser Zyklus, `apps/desktop/test/app-version.test.ts`) ✓ Done
+- [x] Hintergrund-Check beim App-Start (Rust → Tauri-Event, event-getrieben, ein Check pro Start statt Polling) ✓ Done
+- [x] `install_update` Tauri-Command (Windows & Linux) ✓ Done
+- [ ] macOS: Frontend-seitiger GitHub-API-Check — bewusst zurückgestellt (zweiter Code-Pfad mit eigenem Versionsvergleich/Error-Handling, noch nicht die Fläche wert)
+- [x] Einheitlicher Update-Banner im Frontend — als React-Komponente (`UpdateBanner.ts`) statt „kein neues File": das restliche UI ist durchgehend `React.createElement` mit eigenem File pro View, `innerHTML` kommt sonst nirgends vor ✓ Done
+- [x] GitHub Actions Release-Workflow für Linux, Windows & macOS (Node-Sidecar-Download, `tauri-action`) — bereits vor diesem Zyklus erledigt (Phase 7, `.github/workflows/release.yml`) ✓ Done
+- [ ] Signing-Key generieren + GitHub Secrets konfigurieren — manueller Schritt, außerhalb Scope
+- [ ] Erstes versioniertes Release (`v0.4.0`) als Testlauf — manueller Schritt, außerhalb Scope
 
 ---
 

--- a/docs/architecture/2026-06-03-auto-update-plan.md
+++ b/docs/architecture/2026-06-03-auto-update-plan.md
@@ -3,6 +3,30 @@
 **Datum:** 2026-06-03  
 **Ziel:** Tester sehen in der App sofort wenn eine neue Version verfügbar ist und können auf Windows/Linux per Klick aktualisieren. macOS bekommt einen Banner mit Download-Link.
 
+> **Status (2026-08-30):** Windows/Linux-Pfad ist umgesetzt, siehe
+> [`docs/superpowers/plans/2026-08-30-in-app-update-notification.md`](../superpowers/plans/2026-08-30-in-app-update-notification.md)
+> für den tatsächlichen Implementierungsplan. Die Umsetzung weicht in drei
+> Punkten von diesem Dokument ab:
+>
+> 1. **macOS zurückgestellt.** Kein Code-Signing für macOS-Builds → kein
+>    macOS-Eintrag in `latest.json`. Der unten beschriebene
+>    Frontend-seitige GitHub-API-Check (Abschnitt "B) macOS") ist ein
+>    zweiter Code-Pfad mit eigenem Versionsvergleich und Error-Handling —
+>    das war die Fläche noch nicht wert, solange niemand ihn testet.
+>    macOS-Tester sehen vorerst keinen Banner.
+> 2. **Banner als React-Komponente, nicht `innerHTML`.** Das restliche UI
+>    ist durchgehend `React.createElement` mit eigenem File pro View und
+>    einer inline `palette`; `innerHTML` kommt sonst nirgends im Code vor.
+>    Der Banner lebt in `apps/desktop/src/ui/UpdateBanner.ts` — "kein
+>    neues File" (unten) wurde nicht eingehalten.
+> 3. **Englische UI-Strings**, nicht "Jetzt installieren"/"Später": die
+>    gesamte UI (`WelcomeView`, `SettingsView`, ...) ist englisch.
+>
+> Der Rust-seitige Teil (Abschnitt `main.rs`), der Release-Workflow
+> (Abschnitt `.github/workflows/release.yml`, bereits vor diesem Zyklus in
+> Phase 7 gebaut) und der Windows/Linux-Event-Listener (Abschnitt "A)")
+> entsprechen im Kern dem, was tatsächlich gebaut wurde.
+
 ---
 
 ## Ansatz

--- a/docs/superpowers/plans/2026-08-30-in-app-update-notification.md
+++ b/docs/superpowers/plans/2026-08-30-in-app-update-notification.md
@@ -95,10 +95,10 @@ Conventions in `AGENTS.md` and the existing code win over the spec, which predat
 
 ### Phase 1: One version across the whole repo 🟡
 
-- [ ] **Red** — `apps/desktop/test/app-version.test.ts`: the version in `Cargo.toml`, `tauri.conf.json` and every workspace `package.json` is the same string. Fails today (`0.2.0` vs `0.4.0-alpha.0` vs `0.2.0-alpha.1` vs `0.1.0`).
-- [ ] **Green** — set all seven to `0.4.0`.
-- [ ] `npm test` green.
-- [ ] **Commit** — `chore: sync the app version across npm, Cargo and Tauri`
+- [x] **Red** — `apps/desktop/test/app-version.test.ts`: the version in `Cargo.toml`, `tauri.conf.json` and every workspace `package.json` is the same string. Fails today (`0.2.0` vs `0.4.0-alpha.0` vs `0.2.0-alpha.1` vs `0.1.0`).
+- [x] **Green** — set all seven to `0.4.0`.
+- [x] `npm test` green.
+- [x] **Commit** — `chore: sync the app version across npm, Cargo and Tauri`
 
 Not a tautology: it cross-checks independent files that must agree because the updater compares `tauri.conf.json`'s version against `latest.json`. It would have caught the bug that exists right now.
 
@@ -108,13 +108,13 @@ Not a tautology: it cross-checks independent files that must agree because the u
 
 ### Phase 2: Decide when a banner is shown 🟢
 
-- [ ] **Red** — `apps/desktop/test/update-notification.test.ts`, at the seam:
+- [x] **Red** — `apps/desktop/test/update-notification.test.ts`, at the seam:
   - shows the banner for a newer version that was never dismissed
   - stays hidden for a version the user already dismissed
   - shows again for a *different* version after an earlier dismissal
   - stays hidden when no update was reported
-- [ ] **Green** — `apps/desktop/src/updateNotification.ts`: pure decision + a dismissal store against injected storage. No DOM, no Tauri, no `fetch`.
-- [ ] **Commit** — `feat(desktop): decide when an update banner is shown`
+- [x] **Green** — `apps/desktop/src/updateNotification.ts`: pure decision + a dismissal store against injected storage. No DOM, no Tauri, no `fetch`.
+- [x] **Commit** — `feat(desktop): decide when an update banner is shown`
 
 **Depends on:** nothing. Isolated.
 
@@ -122,14 +122,14 @@ Not a tautology: it cross-checks independent files that must agree because the u
 
 ### Phase 3: Background check and install command 🔴
 
-- [ ] **Red** — Rust test in `main.rs`'s existing `#[cfg(test)]` module asserting the config/command surface.
-- [ ] **Green** — in `main.rs`:
+- [x] **Red** — Rust test in `main.rs`'s existing `#[cfg(test)]` module asserting the config/command surface.
+- [x] **Green** — in `main.rs`:
   - `use tauri::Emitter`
   - spawn the updater check in the `.setup()` hook, after `app.manage(...)`; on a hit emit `update-available` with `{ version, canAutoInstall }` (`canAutoInstall = cfg!(not(target_os = "macos"))`)
   - `install_update` command: check, then `download_and_install`
   - register `install_update` in `generate_handler![...]`
-- [ ] `cargo test --manifest-path src-tauri/Cargo.toml` green; `npm test` green.
-- [ ] **Commit** — `feat(desktop): check for updates on startup and expose install_update` (🔴 → commit body: why event-driven over polling, what stays unverified)
+- [x] `cargo test --manifest-path src-tauri/Cargo.toml` green; `npm test` green.
+- [x] **Commit** — `feat(desktop): check for updates on startup and expose install_update` (🔴 → commit body: why event-driven over polling, what stays unverified)
 
 **Depends on:** Phase 1 — the version is what the updater compares.
 
@@ -139,9 +139,9 @@ Not a tautology: it cross-checks independent files that must agree because the u
 
 ### Phase 4: The banner 🟡
 
-- [ ] **Red** — `apps/desktop/test/update-banner.test.ts`: renders the version; shows an Install button when `canAutoInstall`; calls the dismiss handler on "Later".
-- [ ] **Green** — `apps/desktop/src/ui/UpdateBanner.ts` (`React.createElement`, existing `palette`, English strings, `position: fixed` + high `z-index`); `UpdateBannerHandlers` added to `viewTypes.ts`.
-- [ ] **Commit** — `feat(desktop): add the update notification banner`
+- [x] **Red** — `apps/desktop/test/update-banner.test.ts`: renders the version; shows an Install button when `canAutoInstall`; calls the dismiss handler on "Later".
+- [x] **Green** — `apps/desktop/src/ui/UpdateBanner.ts` (`React.createElement`, existing `palette`, English strings, `position: fixed` + high `z-index`); `UpdateBannerHandlers` added to `viewTypes.ts`.
+- [x] **Commit** — `feat(desktop): add the update notification banner`
 
 **Depends on:** nothing at runtime; slots into Phase 5.
 
@@ -151,10 +151,10 @@ Not a tautology: it cross-checks independent files that must agree because the u
 
 ### Phase 5: Wire it through the app 🔴
 
-- [ ] **Red** — extend `apps/desktop/test/start-desktop-browser-app.test.ts` with an injected event listener: an `update-available` payload makes the banner appear; "Later" persists and it does not reappear on the next start; "Install" invokes `install_update`.
-- [ ] **Green** — `startDesktopBrowserApp.ts` subscribes (injectable, so tests need no Tauri) and feeds the Phase 2 decision; `mountDesktopReactApp.ts` renders the banner above the routed view.
-- [ ] `npm test` + `npm run typecheck` + `npm run lint` green.
-- [ ] **Commit** — `feat(desktop): show the update banner when a new version is available` (🔴 → commit body)
+- [x] **Red** — extend `apps/desktop/test/start-desktop-browser-app.test.ts` with an injected event listener: an `update-available` payload makes the banner appear; "Later" persists and it does not reappear on the next start; "Install" invokes `install_update`.
+- [x] **Green** — `startDesktopBrowserApp.ts` subscribes (injectable, so tests need no Tauri) and feeds the Phase 2 decision; `mountDesktopReactApp.ts` renders the banner above the routed view.
+- [x] `npm test` + `npm run typecheck` + `npm run lint` green.
+- [x] **Commit** — `feat(desktop): show the update banner when a new version is available` (🔴 → commit body)
 
 **Depends on:** Phases 2, 3, 4.
 
@@ -162,10 +162,10 @@ Not a tautology: it cross-checks independent files that must agree because the u
 
 ### Phase 6: Docs 🟢
 
-- [ ] `docs/ROADMAP.md` — tick the Phase 10 boxes that are now true, and correct the entry: the plugin/pubkey/workflow items were already done before this cycle.
-- [ ] `docs/architecture/2026-06-03-auto-update-plan.md` — record the deviations above and the macOS deferral, so the doc stops describing an implementation that was never built this way.
-- [ ] `README.md` — how updates reach testers, and that macOS is not covered.
-- [ ] **Commit** — `docs: record the in-app update notification behaviour`
+- [x] `docs/ROADMAP.md` — tick the Phase 10 boxes that are now true, and correct the entry: the plugin/pubkey/workflow items were already done before this cycle.
+- [x] `docs/architecture/2026-06-03-auto-update-plan.md` — record the deviations above and the macOS deferral, so the doc stops describing an implementation that was never built this way.
+- [x] `README.md` — how updates reach testers, and that macOS is not covered.
+- [x] **Commit** — `docs: record the in-app update notification behaviour`
 
 ---
 

--- a/docs/superpowers/plans/2026-08-30-in-app-update-notification.md
+++ b/docs/superpowers/plans/2026-08-30-in-app-update-notification.md
@@ -1,0 +1,182 @@
+# In-App Update Notification Implementation Plan (Phase 10)
+
+> **For agentic workers:** Steps use checkbox (`- [ ]`) syntax for tracking. Work one phase at a time, TDD (red → green → refactor), one commit per phase.
+
+**Goal:** Testers see a banner in the running app when a newer version is available, and on Windows/Linux can install it with one click.
+
+**Branch:** `feature/in-app-update-notification` (base: `staging`)
+
+**Spec:** [`docs/architecture/2026-06-03-auto-update-plan.md`](../../architecture/2026-06-03-auto-update-plan.md) — see *Deviations* below; the spec is partly stale.
+
+---
+
+## Starting state (verified 2026-08-30)
+
+Phase 10 is **half-built**. The plumbing exists; nothing surfaces an update to the user.
+
+| Already done | Where |
+|---|---|
+| `tauri-plugin-updater = "2"` dependency | `apps/desktop/src-tauri/Cargo.toml` |
+| Plugin registered on the builder | `apps/desktop/src-tauri/src/main.rs:539` |
+| `pubkey` + GitHub `latest.json` endpoint + `createUpdaterArtifacts: true` | `apps/desktop/src-tauri/tauri.conf.json` |
+| `updater:default` capability | `apps/desktop/src-tauri/capabilities/default.json` |
+| Release workflow with signing + draft prerelease (8 passing tests) | `.github/workflows/release.yml` |
+| Updater endpoint matches the real repo (`eikrad/bandsearch-app`, public) | verified against `git remote` |
+
+| Still missing | Consequence |
+|---|---|
+| Version desync: Cargo + `tauri.conf.json` say `0.2.0`, npm packages say `0.4.0-alpha.0` / `0.2.0-alpha.1` / `0.1.0` | A release cut from this tree is labelled `0.2.0`. The updater compares exactly this string. |
+| No `updater().check()` call anywhere | The registered plugin is dead weight; no update is ever detected. |
+| No `install_update` command | Nothing to invoke from the UI. |
+| No banner, no event listener | CI already produces `latest.json` that nothing consumes. |
+
+---
+
+## Scope
+
+**Does:** version consistency across the repo; startup update check; `install_update` command; a dismissible banner on Windows and Linux.
+
+**Does not:**
+- **macOS** — deferred by decision. No code signing, so the Rust updater yields no macOS entry in `latest.json`. The spec's frontend GitHub-API fallback is a second code path with its own version-compare and error handling; not worth the surface yet. macOS testers get no banner for now.
+- **Signing-key generation and the `v0.4.0` tag** — manual steps, out of scope.
+
+---
+
+## Decisions
+
+| Question | Decision |
+|---|---|
+| macOS path | Defer. Windows/Linux only. |
+| "Later" button | Dismisses **per version**, persisted in `localStorage` (same idiom as `bandsearch_onboarding_complete`). Next version shows the banner again. |
+| Version number | `0.4.0` everywhere — **one version for the whole monorepo**, including `shared/schemas` and `services/eval`. |
+| Banner placement | `position: fixed`, top, overlaying — visible on every screen regardless of route. |
+
+## Deviations from the 2026-06-03 spec
+
+Conventions in `AGENTS.md` and the existing code win over the spec, which predates the strict-TypeScript/React state of the app.
+
+| Spec says | We do | Why |
+|---|---|---|
+| `document.createElement` + `innerHTML` blob | React component in `src/ui/` | Every other view is `React.createElement` with an inline `palette`. `innerHTML` appears nowhere else. |
+| German UI strings ("Jetzt installieren", "Später") | English | The whole UI is English — `WelcomeView`, `SettingsView`, all of it. |
+| "`release.yml` (neu)" | Already exists, tested | Built in Phase 7. |
+| Add `allow-install-update` to capabilities | Not needed | `updater:default` is already present, and the four existing app commands (`save_brave_api_key`, `save_turso_config`, `save_api_endpoint_url`, `complete_onboarding`) are not listed individually either. Follow the existing pattern. |
+
+---
+
+## Global constraints
+
+- Base the PR on `staging`, never `main` (`AGENTS.md`).
+- TypeScript only, `strict` + `noImplicitAny`. No new `.js`/`.mjs`. No durable `any`.
+- NodeNext: local imports carry `.js` extensions in TypeScript source.
+- TDD: failing test first, then the minimum code to pass, then refactor.
+- `npm test` green before every commit.
+- Test at seams through public interfaces — pure decision modules with injected side effects, mirroring [`firstRunOnboarding.ts`](../../../apps/desktop/src/firstRunOnboarding.ts).
+- Mark completed items `✓ Done` in `docs/ROADMAP.md`.
+
+---
+
+## File map
+
+| Path | Responsibility | New? |
+|---|---|---|
+| `apps/desktop/src/updateNotification.ts` | Pure decision: should the banner show, given payload + dismissal state | new |
+| `apps/desktop/src/ui/UpdateBanner.ts` | The banner view | new |
+| `apps/desktop/src/ui/viewTypes.ts` | `UpdateBannerHandlers` | edit |
+| `apps/desktop/src/startDesktopBrowserApp.ts` | Listen for `update-available`, wire decision → banner → `install_update` | edit |
+| `apps/desktop/src/ui/mountDesktopReactApp.ts` | Render the banner above the routed view | edit |
+| `apps/desktop/src-tauri/src/main.rs` | Startup check, `update-available` event, `install_update` command | edit |
+| `apps/desktop/src-tauri/Cargo.toml`, `tauri.conf.json` | Version `0.4.0` | edit |
+| `package.json`, `apps/desktop/`, `services/api/`, `services/eval/`, `shared/schemas/` | Version `0.4.0` | edit |
+
+---
+
+## Phases
+
+### Phase 1: One version across the whole repo 🟡
+
+- [ ] **Red** — `apps/desktop/test/app-version.test.ts`: the version in `Cargo.toml`, `tauri.conf.json` and every workspace `package.json` is the same string. Fails today (`0.2.0` vs `0.4.0-alpha.0` vs `0.2.0-alpha.1` vs `0.1.0`).
+- [ ] **Green** — set all seven to `0.4.0`.
+- [ ] `npm test` green.
+- [ ] **Commit** — `chore: sync the app version across npm, Cargo and Tauri`
+
+Not a tautology: it cross-checks independent files that must agree because the updater compares `tauri.conf.json`'s version against `latest.json`. It would have caught the bug that exists right now.
+
+**Files:** `apps/desktop/src-tauri/Cargo.toml`, `apps/desktop/src-tauri/tauri.conf.json`, `package.json`, `apps/desktop/package.json`, `services/api/package.json`, `services/eval/package.json`, `shared/schemas/package.json`, `apps/desktop/test/app-version.test.ts`
+
+---
+
+### Phase 2: Decide when a banner is shown 🟢
+
+- [ ] **Red** — `apps/desktop/test/update-notification.test.ts`, at the seam:
+  - shows the banner for a newer version that was never dismissed
+  - stays hidden for a version the user already dismissed
+  - shows again for a *different* version after an earlier dismissal
+  - stays hidden when no update was reported
+- [ ] **Green** — `apps/desktop/src/updateNotification.ts`: pure decision + a dismissal store against injected storage. No DOM, no Tauri, no `fetch`.
+- [ ] **Commit** — `feat(desktop): decide when an update banner is shown`
+
+**Depends on:** nothing. Isolated.
+
+---
+
+### Phase 3: Background check and install command 🔴
+
+- [ ] **Red** — Rust test in `main.rs`'s existing `#[cfg(test)]` module asserting the config/command surface.
+- [ ] **Green** — in `main.rs`:
+  - `use tauri::Emitter`
+  - spawn the updater check in the `.setup()` hook, after `app.manage(...)`; on a hit emit `update-available` with `{ version, canAutoInstall }` (`canAutoInstall = cfg!(not(target_os = "macos"))`)
+  - `install_update` command: check, then `download_and_install`
+  - register `install_update` in `generate_handler![...]`
+- [ ] `cargo test --manifest-path src-tauri/Cargo.toml` green; `npm test` green.
+- [ ] **Commit** — `feat(desktop): check for updates on startup and expose install_update` (🔴 → commit body: why event-driven over polling, what stays unverified)
+
+**Depends on:** Phase 1 — the version is what the updater compares.
+
+**Known gap, accepted:** `cargo test` proves it compiles and the command is registered. That the updater actually reaches GitHub, finds a release and emits the event needs a real signed release — a manual step held out of scope. Keep the untestable surface thin and say so in the commit body.
+
+---
+
+### Phase 4: The banner 🟡
+
+- [ ] **Red** — `apps/desktop/test/update-banner.test.ts`: renders the version; shows an Install button when `canAutoInstall`; calls the dismiss handler on "Later".
+- [ ] **Green** — `apps/desktop/src/ui/UpdateBanner.ts` (`React.createElement`, existing `palette`, English strings, `position: fixed` + high `z-index`); `UpdateBannerHandlers` added to `viewTypes.ts`.
+- [ ] **Commit** — `feat(desktop): add the update notification banner`
+
+**Depends on:** nothing at runtime; slots into Phase 5.
+
+🟡 because `viewTypes.ts` is shared by every view.
+
+---
+
+### Phase 5: Wire it through the app 🔴
+
+- [ ] **Red** — extend `apps/desktop/test/start-desktop-browser-app.test.ts` with an injected event listener: an `update-available` payload makes the banner appear; "Later" persists and it does not reappear on the next start; "Install" invokes `install_update`.
+- [ ] **Green** — `startDesktopBrowserApp.ts` subscribes (injectable, so tests need no Tauri) and feeds the Phase 2 decision; `mountDesktopReactApp.ts` renders the banner above the routed view.
+- [ ] `npm test` + `npm run typecheck` + `npm run lint` green.
+- [ ] **Commit** — `feat(desktop): show the update banner when a new version is available` (🔴 → commit body)
+
+**Depends on:** Phases 2, 3, 4.
+
+---
+
+### Phase 6: Docs 🟢
+
+- [ ] `docs/ROADMAP.md` — tick the Phase 10 boxes that are now true, and correct the entry: the plugin/pubkey/workflow items were already done before this cycle.
+- [ ] `docs/architecture/2026-06-03-auto-update-plan.md` — record the deviations above and the macOS deferral, so the doc stops describing an implementation that was never built this way.
+- [ ] `README.md` — how updates reach testers, and that macOS is not covered.
+- [ ] **Commit** — `docs: record the in-app update notification behaviour`
+
+---
+
+## Remaining manual steps (not in this plan)
+
+1. `npx tauri signer generate -w ~/.tauri/bandsearch.key` → public key into `tauri.conf.json`, private key + password into GitHub secrets `TAURI_SIGNING_PRIVATE_KEY` / `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`. *(A pubkey is already committed — confirm the matching private key is in the repo secrets before tagging, or regenerate both.)*
+2. Push tag `v0.4.0` → three CI jobs → draft prerelease with `.msi`, `.deb`/`.AppImage`, `.dmg` and `latest.json`.
+3. Verify end to end: run a `0.3.x` build against the `v0.4.0` release, confirm the banner appears and Install completes.
+
+## Follow-ups this cycle deliberately leaves open
+
+- macOS update path (GitHub-API check + download link banner).
+- Issue #133 — `foreign_keys` pragma inconsistent across SQLite connections.
+- Architecture entry 9 — `services/api` CommonJS → ESM.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bandsearch",
-  "version": "0.4.0-alpha.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bandsearch",
-      "version": "0.4.0-alpha.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "workspaces": [
         "apps/*",
@@ -39,7 +39,7 @@
     },
     "apps/desktop": {
       "name": "@bandsearch/desktop",
-      "version": "0.4.0-alpha.0",
+      "version": "0.4.0",
       "dependencies": {
         "@tauri-apps/api": "^2.11.1",
         "react": "^19.2.7",
@@ -4019,7 +4019,7 @@
     },
     "services/api": {
       "name": "@bandsearch/api",
-      "version": "0.4.0-alpha.0",
+      "version": "0.4.0",
       "dependencies": {
         "@langchain/google-genai": "^2.3.0",
         "@langchain/langgraph": "^1.4.12",
@@ -4038,11 +4038,11 @@
     },
     "services/eval": {
       "name": "@bandsearch/eval",
-      "version": "0.1.0"
+      "version": "0.4.0"
     },
     "shared/schemas": {
       "name": "@bandsearch/schemas",
-      "version": "0.2.0-alpha.1"
+      "version": "0.4.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bandsearch",
-  "version": "0.4.0-alpha.0",
+  "version": "0.4.0",
   "private": true,
   "description": "Bandsearch monorepo foundation",
   "license": "Apache-2.0",

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bandsearch/api",
-  "version": "0.4.0-alpha.0",
+  "version": "0.4.0",
   "private": true,
   "description": "Bandsearch Express API",
   "scripts": {

--- a/services/eval/package.json
+++ b/services/eval/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bandsearch/eval",
-  "version": "0.1.0",
+  "version": "0.4.0",
   "private": true,
   "description": "Eval scripts: judge calibration and golden dataset regression runner",
   "type": "module",

--- a/shared/schemas/package.json
+++ b/shared/schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bandsearch/schemas",
-  "version": "0.2.0-alpha.1",
+  "version": "0.4.0",
   "private": true,
   "description": "Shared schema contracts package",
   "scripts": {


### PR DESCRIPTION
Implements Phase 10 from [`docs/superpowers/plans/2026-08-30-in-app-update-notification.md`](docs/superpowers/plans/2026-08-30-in-app-update-notification.md): testers see a banner in the running app when a newer version is available, and on Windows/Linux can install it in one click.

The plumbing already existed before this branch (plugin, pubkey, endpoint, release workflow from Phase 7) — nothing surfaced an update to the user.

## What changed

| | |
|---|---|
| **Version sync** | All seven version-bearing files (`Cargo.toml`, `tauri.conf.json`, four `package.json`) now read `0.4.0`. They had drifted across `0.2.0` / `0.4.0-alpha.0` / `0.2.0-alpha.1` / `0.1.0`. The updater compares `tauri.conf.json`'s string against `latest.json`, so a release cut from the old tree would have been labelled `0.2.0`. A test now fails whenever they drift. |
| **Rust** | One update check per launch, spawned from `.setup()`; emits `update-available` with `{ version, canAutoInstall }`. New `install_update` command downloads, verifies the signature, and installs. |
| **Decision + state** | `createUpdateNotificationController` owns the show/hide decision, per-version dismissal, and install failure. |
| **UI** | `UpdateBanner` — fixed-position, above every route. Install only when `canAutoInstall`; "Later" dismisses per version. |

## Notable fix found in review

Four review agents went over the branch afterwards. One real bug: **the update could be dropped entirely.** Rust spawns the check from `.setup()`, but the frontend originally subscribed only after `getBootstrapGate()`, `runAuthGate()` and `mount()`. Tauri's `emit` has no replay buffer, so if the check won that race the event reached nobody — no banner for that launch, with nothing logged. The controller now buffers an update reported before the UI attaches, and the subscription moved ahead of every `await`.

Two smaller ones: the check was queued behind `reconcile_sidecar`, which blocks up to 30s in `wait_for_api_tcp` (it needs no managed state, so it now overlaps that wait); and toggling the banner re-ran the whole route render, repeating the settings IPC just to paint an overlay — and changed the root element's type, remounting the routed view and wiping whatever the user was typing.

## Deviations from the 2026-06-03 spec

The spec predates the strict-TypeScript/React state of the app. Recorded in the architecture doc:

- **macOS deferred** — no code signing, so the Rust updater yields no macOS entry in `latest.json`. The spec's frontend GitHub-API fallback is a second code path with its own version compare and error handling; not worth the surface until someone tests it. macOS testers get no banner and download manually.
- **React component, not `innerHTML`** — every other view is `React.createElement` with an inline palette; `innerHTML` appears nowhere else in the codebase.
- **English strings**, not German — the whole UI is English.

## Testing

`npm run ci` (lint + typecheck + 273 desktop tests) and `cargo test` (23) green.

Behaviour is covered at injected seams — no Tauri host needed — including the dropped-event regression, per-version dismissal surviving a restart, and install failure being reported rather than rejecting into a click handler.

## Not in this PR

- **macOS update path** (GitHub-API check + download-link banner).
- **The manual release steps**: confirming the committed pubkey matches the private key in repo secrets, pushing `v0.4.0`, and verifying end to end that a `0.3.x` build sees the banner and Install completes. **The release pipeline has only ever run against a throwaway `v0.2.1-test` tag on 2026-08-11 — never against current code**, so the updater flow is unproven until someone does that.
- Phase 9.5 (Render/Turso end-to-end verification) is still open and is the bigger gap before any real release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiphXDP4gVnxirBQw9YnPC
