### PR TITLE
fix(desktop): distinguish an unreachable API from disabled auth (#155)

### DIFF
--- a/apps/desktop/src/authApiClient.ts
+++ b/apps/desktop/src/authApiClient.ts
@@ -1,6 +1,21 @@
 export type AuthUser = { id: string; email: string; displayName: string; createdAt: string };
 
-export type AuthStatus = { enabled: boolean; userCount: number };
+/**
+ * What `/auth/status` told us — or that it told us nothing.
+ *
+ * A union rather than a flag, because "unreachable" and "auth is disabled" are
+ * not two values of one property: only a 2xx answer says anything about auth at
+ * all. Modelling them separately makes the contradictory state unrepresentable
+ * and forces every caller to handle the third case, which is what went wrong
+ * before: an unreachable API collapsed into `{ enabled: false }`, and the
+ * startup gate read that as "no auth needed" and waved the user through.
+ */
+export type AuthStatus =
+  | { reachable: true; enabled: boolean; userCount: number }
+  | { reachable: false; reason: AuthStatusUnreachableReason };
+
+/** `http_<status>` for an answer we cannot use, `network_error` for no answer. */
+export type AuthStatusUnreachableReason = `http_${number}` | "network_error";
 
 export type RegisterResult =
   | { ok: true; user: AuthUser; token: string; recoveryCode: string }
@@ -62,11 +77,17 @@ export function createAuthApiClient({
     async getAuthStatus(): Promise<AuthStatus> {
       try {
         const res = await fetchImpl(`${base}/auth/status`, { method: "GET" });
-        if (!res.ok) return { enabled: false, userCount: 0 };
-        const data = (await res.json()) as AuthStatus;
-        return { enabled: Boolean(data.enabled), userCount: Number(data.userCount) || 0 };
+        // Render serves 502/503 while a spun-down instance wakes, so a non-2xx
+        // is "ask again", never an answer about auth.
+        if (!res.ok) return { reachable: false, reason: `http_${res.status}` };
+        const data = (await res.json()) as { enabled?: unknown; userCount?: unknown };
+        return {
+          reachable: true,
+          enabled: Boolean(data.enabled),
+          userCount: Number(data.userCount) || 0,
+        };
       } catch {
-        return { enabled: false, userCount: 0 };
+        return { reachable: false, reason: "network_error" };
       }
     },
 

--- a/apps/desktop/src/authGate.ts
+++ b/apps/desktop/src/authGate.ts
@@ -1,0 +1,34 @@
+import type { AuthStatus } from "./authApiClient.js";
+
+/**
+ * Where startup should send the user.
+ *
+ * `unavailable` is deliberately its own outcome rather than being folded into
+ * `login`: not knowing whether auth is required is a different situation from
+ * knowing it is, and the caller renders it differently — a login form the API
+ * cannot serve is no more useful than the pass-through this replaces.
+ */
+export type AuthRoute = "register" | "login" | "app" | "unavailable";
+
+/**
+ * Decides the startup route from what `/auth/status` said and whether a token is
+ * already held.
+ *
+ * Kept pure and separate from the router so the rule is testable on its own —
+ * the same shape as `firstRunOnboarding` and `updateNotification`.
+ */
+export function decideAuthRoute({
+  status,
+  hasToken,
+}: {
+  status: AuthStatus;
+  hasToken: boolean;
+}): AuthRoute {
+  // No answer means no decision. Treating silence as "auth is off" is exactly
+  // the defect this replaces (#155).
+  if (!status.reachable) return "unavailable";
+
+  if (!status.enabled) return "app";
+  if (status.userCount === 0) return "register";
+  return hasToken ? "app" : "login";
+}

--- a/apps/desktop/src/createHashRouter.ts
+++ b/apps/desktop/src/createHashRouter.ts
@@ -8,6 +8,7 @@ const ROUTE_MAP: Record<string, string> = {
   "#/register": "register",
   "#/reset-password": "reset-password",
   "#/privacy": "privacy",
+  "#/connecting": "connecting",
 };
 
 function hashToRoute(hash: string): string {
@@ -22,6 +23,7 @@ function routeToHash(route: string): string {
   if (route === "register") return "#/register";
   if (route === "reset-password") return "#/reset-password";
   if (route === "privacy") return "#/privacy";
+  if (route === "connecting") return "#/connecting";
   return "#/";
 }
 

--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -71,6 +71,8 @@ export type BootstrapDesktopReactAppOptions = {
   onRegister?: (email: string, displayName: string, password: string) => Promise<{ recoveryCode: string }>;
   onResetPassword?: (email: string, recoveryCode: string, newPassword: string) => Promise<{ newRecoveryCode: string }>;
   updateBannerHandlers?: UpdateBannerHandlers;
+  connectingHandlers?: DesktopReactMountOptions["connectingHandlers"];
+  getConnectingViewProps?: DesktopReactMountOptions["getConnectingViewProps"];
 };
 
 function bootstrapDesktopReactApp(options: BootstrapDesktopReactAppOptions) {
@@ -91,6 +93,8 @@ function bootstrapDesktopReactApp(options: BootstrapDesktopReactAppOptions) {
     onRegister,
     onResetPassword,
     updateBannerHandlers,
+    connectingHandlers,
+    getConnectingViewProps,
   } = options;
   const shell = bootstrapDesktopReactShell({ app, viewport, actionHandlers });
   const mountApi = createDesktopReactMount({
@@ -108,6 +112,8 @@ function bootstrapDesktopReactApp(options: BootstrapDesktopReactAppOptions) {
     onRegister,
     onResetPassword,
     updateBannerHandlers,
+    connectingHandlers,
+    getConnectingViewProps,
   });
   return {
     ...mountApi,

--- a/apps/desktop/src/startDesktopBrowserApp.ts
+++ b/apps/desktop/src/startDesktopBrowserApp.ts
@@ -7,6 +7,7 @@ import { getAuthToken, setAuthToken, clearAuthToken } from "./authTokenStore.js"
 import { createAuthApiClient, type LoginResult, type RegisterResult, type ResetPasswordResult } from "./authApiClient.js";
 import { decideAuthRoute } from "./authGate.js";
 import { waitForAuthStatus } from "./waitForApi.js";
+import type { ConnectingViewProps } from "./ui/viewTypes.js";
 import { createAuthAwareFetch } from "./authAwareFetch.js";
 import {
   createUpdateNotificationController,
@@ -197,28 +198,50 @@ export async function startDesktopBrowserApp({
   const w = browserWindow();
   const initialHash = w && typeof w.location?.hash === "string" ? w.location.hash : "";
 
+  // Drives the connecting screen. Read by the mount each time it renders.
+  let connectingViewProps: ConnectingViewProps = { state: "waiting" };
+
+  /**
+   * Routes on one quick check, so a healthy API reaches the right screen with no
+   * detour. Only when that first check finds nothing does the connecting screen
+   * appear — and the remaining retries then happen with something on screen,
+   * which is the part `waitForAuthStatus` alone could not provide: the gate runs
+   * before `mount()`, so waiting there would show a blank window.
+   */
   async function runAuthGate(): Promise<void> {
-    // Retries while the API wakes; returns immediately when it is already up, so
-    // this costs a healthy start nothing.
+    const first = await authClient.getAuthStatus();
+    const route = decideAuthRoute({ status: first, hasToken: Boolean(getAuthToken()) });
+    if (route === "unavailable") {
+      connectingViewProps = { state: "waiting", attempt: 1 };
+      router.navigate("connecting");
+      return;
+    }
+    if (route !== "app") router.navigate(route);
+  }
+
+  /** Keeps polling after mount, then routes to wherever the answer says. */
+  async function finishConnecting(): Promise<void> {
     const status = await waitForAuthStatus({
       getStatus: () => authClient.getAuthStatus(),
       sleep: resolvedSleep,
       now: resolvedNow,
-      onAttempt: ({ attempt, elapsedMs }) => {
-        if (attempt > 1) console.info(`[bandsearch] waiting for API, attempt ${attempt} (${elapsedMs}ms)`);
+      onAttempt: ({ attempt }) => {
+        connectingViewProps = { state: "waiting", attempt: attempt + 1 };
+        void reactApp?.mount();
       },
     });
     const route = decideAuthRoute({ status, hasToken: Boolean(getAuthToken()) });
-    if (route === "app") return;
     if (route === "unavailable") {
-      // Interim: send the user somewhere that does not pretend to work, rather
-      // than into a chat whose every request will fail. Phase 3 replaces this
-      // with a visible connecting state.
       console.warn("[bandsearch] API unreachable:", status.reachable === false && status.reason);
-      router.navigate("login");
+      connectingViewProps = { state: "failed" };
+      await reactApp?.mount();
       return;
     }
-    router.navigate(route);
+    // Render explicitly rather than relying on the browser firing `hashchange`
+    // for our own navigation — that is an implicit dependency, and it does not
+    // exist outside a real browser at all.
+    router.navigate(route === "app" ? "home" : route);
+    await reactApp?.mount();
   }
 
   if (shouldOfferWelcomeScreen({ hasStoredKey: gate.hasStoredKey, onboardingComplete: gate.onboardingComplete, locationHash: initialHash })) {
@@ -264,6 +287,13 @@ export async function startDesktopBrowserApp({
     onRegister,
     onResetPassword,
     updateBannerHandlers: updateNotifications.handlers,
+    getConnectingViewProps: () => connectingViewProps,
+    connectingHandlers: {
+      onRetry: () => {
+        connectingViewProps = { state: "waiting", attempt: 1 };
+        void reactApp.mount().then(() => finishConnecting());
+      },
+    },
   });
   await reactApp.mount();
   if (reactApp.desktopUi) {
@@ -272,6 +302,10 @@ export async function startDesktopBrowserApp({
 
   // The UI can paint now; flushes an update that was reported during bootstrap.
   updateNotifications.attach((viewProps) => reactApp.showUpdateBanner(viewProps));
+
+  // Something is on screen now, so the remaining retries are visible rather than
+  // spent behind a blank window.
+  if (router.getRoute() === "connecting") await finishConnecting();
 
   return reactApp;
 }

--- a/apps/desktop/src/startDesktopBrowserApp.ts
+++ b/apps/desktop/src/startDesktopBrowserApp.ts
@@ -6,6 +6,7 @@ import { shouldOfferWelcomeScreen } from "./firstRunOnboarding.js";
 import { getAuthToken, setAuthToken, clearAuthToken } from "./authTokenStore.js";
 import { createAuthApiClient, type LoginResult, type RegisterResult, type ResetPasswordResult } from "./authApiClient.js";
 import { decideAuthRoute } from "./authGate.js";
+import { waitForAuthStatus } from "./waitForApi.js";
 import { createAuthAwareFetch } from "./authAwareFetch.js";
 import {
   createUpdateNotificationController,
@@ -115,6 +116,9 @@ export type StartDesktopBrowserAppOptions = {
   invokeTauri?: (cmd: string, args?: Record<string, string>) => Promise<unknown>;
   listenUpdateAvailable?: (handler: (payload: UpdateAvailablePayload) => void) => void;
   updateDismissalStorage?: UpdateDismissalStorage;
+  /** Injected by tests so the API wait is driven rather than waited out. */
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
   deps?: StartDesktopBrowserAppDeps;
 };
 
@@ -126,6 +130,8 @@ export async function startDesktopBrowserApp({
   invokeTauri,
   listenUpdateAvailable,
   updateDismissalStorage,
+  sleep,
+  now,
   deps = {},
 }: StartDesktopBrowserAppOptions = {}): Promise<ReturnType<typeof bootstrapDesktopReactApp>> {
   const {
@@ -136,6 +142,8 @@ export async function startDesktopBrowserApp({
   const resolvedListenUpdateAvailable = listenUpdateAvailable ?? createDefaultUpdateListener();
   const updateStorage = updateDismissalStorage ?? createDefaultUpdateDismissalStorage();
   const resolvedFetch = fetchImpl ?? fetch;
+  const resolvedSleep = sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const resolvedNow = now ?? (() => Date.now());
 
   // Subscribed before any await below. The backend check is spawned from Rust's
   // .setup() and Tauri's emit has no replay buffer, so subscribing after the
@@ -190,14 +198,23 @@ export async function startDesktopBrowserApp({
   const initialHash = w && typeof w.location?.hash === "string" ? w.location.hash : "";
 
   async function runAuthGate(): Promise<void> {
-    const status = await authClient.getAuthStatus();
+    // Retries while the API wakes; returns immediately when it is already up, so
+    // this costs a healthy start nothing.
+    const status = await waitForAuthStatus({
+      getStatus: () => authClient.getAuthStatus(),
+      sleep: resolvedSleep,
+      now: resolvedNow,
+      onAttempt: ({ attempt, elapsedMs }) => {
+        if (attempt > 1) console.info(`[bandsearch] waiting for API, attempt ${attempt} (${elapsedMs}ms)`);
+      },
+    });
     const route = decideAuthRoute({ status, hasToken: Boolean(getAuthToken()) });
     if (route === "app") return;
     if (route === "unavailable") {
       // Interim: send the user somewhere that does not pretend to work, rather
       // than into a chat whose every request will fail. Phase 3 replaces this
-      // with a connecting state that retries while the API wakes up.
-      console.warn("[bandsearch] auth status unavailable:", status.reachable === false && status.reason);
+      // with a visible connecting state.
+      console.warn("[bandsearch] API unreachable:", status.reachable === false && status.reason);
       router.navigate("login");
       return;
     }

--- a/apps/desktop/src/startDesktopBrowserApp.ts
+++ b/apps/desktop/src/startDesktopBrowserApp.ts
@@ -5,6 +5,7 @@ import { createGeminiSettingsController } from "./geminiDesktopSettings.js";
 import { shouldOfferWelcomeScreen } from "./firstRunOnboarding.js";
 import { getAuthToken, setAuthToken, clearAuthToken } from "./authTokenStore.js";
 import { createAuthApiClient, type LoginResult, type RegisterResult, type ResetPasswordResult } from "./authApiClient.js";
+import { decideAuthRoute } from "./authGate.js";
 import { createAuthAwareFetch } from "./authAwareFetch.js";
 import {
   createUpdateNotificationController,
@@ -189,13 +190,18 @@ export async function startDesktopBrowserApp({
   const initialHash = w && typeof w.location?.hash === "string" ? w.location.hash : "";
 
   async function runAuthGate(): Promise<void> {
-    const authStatus = await authClient.getAuthStatus();
-    if (!authStatus.enabled) return;
-    if (authStatus.userCount === 0) {
-      router.navigate("register");
-    } else if (!getAuthToken()) {
+    const status = await authClient.getAuthStatus();
+    const route = decideAuthRoute({ status, hasToken: Boolean(getAuthToken()) });
+    if (route === "app") return;
+    if (route === "unavailable") {
+      // Interim: send the user somewhere that does not pretend to work, rather
+      // than into a chat whose every request will fail. Phase 3 replaces this
+      // with a connecting state that retries while the API wakes up.
+      console.warn("[bandsearch] auth status unavailable:", status.reachable === false && status.reason);
       router.navigate("login");
+      return;
     }
+    router.navigate(route);
   }
 
   if (shouldOfferWelcomeScreen({ hasStoredKey: gate.hasStoredKey, onboardingComplete: gate.onboardingComplete, locationHash: initialHash })) {

--- a/apps/desktop/src/ui/ConnectingView.ts
+++ b/apps/desktop/src/ui/ConnectingView.ts
@@ -1,0 +1,88 @@
+import type { ConnectingHandlers, ConnectingViewProps } from "./viewTypes.js";
+import * as React from "react";
+
+const palette = {
+  pageBg: "#0d0f14",
+  border: "#1e2a3a",
+  textPrimary: "#f0f4f8",
+  textSecondary: "#8896a8",
+  accent: "#7aa7d9",
+  buttonBg: "#161e2e",
+  buttonBorder: "#243044",
+  buttonText: "#c8d4e8",
+};
+
+/** After this many attempts the wait is long enough to deserve acknowledging. */
+const LONG_WAIT_AFTER_ATTEMPTS = 4;
+
+/**
+ * Shown while the API is being polled at startup, and when polling gave up.
+ *
+ * Exists because an unreachable API used to be indistinguishable from "auth is
+ * switched off" (#155), which dropped the user into a chat where every request
+ * then failed. A hosted instance that has spun down takes 30-60s to answer, so
+ * the honest thing is to say so and keep trying.
+ */
+export function ConnectingView({
+  viewProps,
+  handlers,
+}: {
+  viewProps: ConnectingViewProps;
+  handlers: ConnectingHandlers;
+}) {
+  const waiting = viewProps.state === "waiting";
+  const longWait = waiting && (viewProps.attempt ?? 1) >= LONG_WAIT_AFTER_ATTEMPTS;
+
+  return React.createElement(
+    "main",
+    {
+      style: {
+        backgroundColor: palette.pageBg,
+        color: palette.textPrimary,
+        minHeight: "100vh",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: "12px",
+        padding: "32px 24px",
+        textAlign: "center",
+      },
+    },
+    React.createElement(
+      "h1",
+      { style: { fontSize: "15px", fontWeight: 700, letterSpacing: "-0.01em" } },
+      waiting ? "Starting the server" : "Could not reach the server",
+    ),
+    React.createElement(
+      "p",
+      { style: { fontSize: "13px", color: palette.textSecondary, maxWidth: "36ch", lineHeight: 1.5 } },
+      waiting
+        ? longWait
+          ? "Still starting. A server that has been idle can take up to a minute to wake up."
+          : "This can take a moment if the server has been idle."
+        : "The server did not respond. Check your connection, or the API endpoint in Settings.",
+    ),
+    waiting
+      ? null
+      : React.createElement(
+          "button",
+          {
+            type: "button",
+            onClick: () => handlers.onRetry?.(),
+            style: {
+              backgroundColor: palette.buttonBg,
+              color: palette.buttonText,
+              border: `1px solid ${palette.buttonBorder}`,
+              borderRadius: "7px",
+              // 44px minimum touch target, per the locked responsiveness policy.
+              minHeight: "44px",
+              padding: "0 20px",
+              fontSize: "13px",
+              cursor: "pointer",
+            },
+          },
+          "Try again",
+        ),
+  );
+}

--- a/apps/desktop/src/ui/mountDesktopReactApp.ts
+++ b/apps/desktop/src/ui/mountDesktopReactApp.ts
@@ -9,7 +9,8 @@ import { LoginView } from "./LoginView.js";
 import { RegisterView } from "./RegisterView.js";
 import { ResetPasswordView } from "./ResetPasswordView.js";
 import { UpdateBanner, type UpdateBannerViewProps } from "./UpdateBanner.js";
-import type { UpdateBannerHandlers } from "./viewTypes.js";
+import { ConnectingView } from "./ConnectingView.js";
+import type { UpdateBannerHandlers, ConnectingHandlers, ConnectingViewProps } from "./viewTypes.js";
 
 /** The shell surface this mount drives; everything optional is guarded with `?.`. */
 export type MountShell = {
@@ -72,6 +73,8 @@ export interface DesktopReactMountOptions {
   onExportAccountData?: () => Promise<Record<string, unknown>>;
   onDeleteAccount?: (password: string) => Promise<{ ok: boolean; error?: string }>;
   updateBannerHandlers?: UpdateBannerHandlers;
+  connectingHandlers?: ConnectingHandlers;
+  getConnectingViewProps?: () => ConnectingViewProps;
   createRootImpl?: typeof createRoot;
   resolveContainer?: () => HTMLElement;
 }
@@ -99,6 +102,8 @@ export function createDesktopReactMount({
   onRegister,
   onResetPassword,
   updateBannerHandlers = {},
+  connectingHandlers = {},
+  getConnectingViewProps,
   createRootImpl = createRoot,
   resolveContainer = defaultContainerResolver,
 }: DesktopReactMountOptions) {
@@ -153,6 +158,16 @@ export function createDesktopReactMount({
 
     if (route === "reset-password") {
       renderRoot(React.createElement(ResetPasswordView as unknown as ViewComponentLike, { viewProps: {}, handlers: resetPasswordHandlers }));
+      return {};
+    }
+
+    if (route === "connecting") {
+      renderRoot(
+        React.createElement(ConnectingView as unknown as ViewComponentLike, {
+          viewProps: getConnectingViewProps?.() ?? { state: "waiting" },
+          handlers: connectingHandlers,
+        }),
+      );
       return {};
     }
 

--- a/apps/desktop/src/ui/viewTypes.ts
+++ b/apps/desktop/src/ui/viewTypes.ts
@@ -75,3 +75,17 @@ export type UpdateBannerHandlers = {
   onInstall?(): unknown;
   onDismiss?(): unknown;
 };
+
+export type ConnectingHandlers = {
+  onRetry?(): unknown;
+};
+
+/**
+ * `waiting` while the API is being polled, `failed` once the retry budget is
+ * spent. `attempt` lets the view acknowledge a long wait instead of showing a
+ * spinner that looks identical at second 1 and second 60.
+ */
+export type ConnectingViewProps = {
+  state: "waiting" | "failed";
+  attempt?: number;
+};

--- a/apps/desktop/src/waitForApi.ts
+++ b/apps/desktop/src/waitForApi.ts
@@ -1,0 +1,56 @@
+import type { AuthStatus } from "./authApiClient.js";
+
+/** First wait after a failed attempt. Short, so a brief blip costs nothing. */
+const INITIAL_DELAY_MS = 500;
+/** Each wait doubles up to here — long enough not to pile onto a booting instance. */
+const MAX_DELAY_MS = 8_000;
+/**
+ * Total time to keep trying. A spun-down Render free-tier instance takes 30–60s
+ * to serve its first request, so a budget under that would give up exactly when
+ * waiting was about to pay off.
+ */
+const DEFAULT_BUDGET_MS = 90_000;
+
+export type WaitForAuthStatusOptions = {
+  getStatus: () => Promise<AuthStatus>;
+  /** Injected so tests drive time instead of waiting for it. */
+  sleep: (ms: number) => Promise<void>;
+  now: () => number;
+  /** Fires before each attempt, so a connecting view can show progress. */
+  onAttempt?: (info: { attempt: number; elapsedMs: number }) => void;
+  budgetMs?: number;
+};
+
+/**
+ * Polls `/auth/status` until it answers, or until the budget runs out.
+ *
+ * Returns the last status either way: an unreachable result after giving up is
+ * still the truth, and the caller must be able to tell it apart from a healthy
+ * answer. Never throws — "the API is down" is an outcome here, not an error.
+ */
+export async function waitForAuthStatus({
+  getStatus,
+  sleep,
+  now,
+  onAttempt,
+  budgetMs = DEFAULT_BUDGET_MS,
+}: WaitForAuthStatusOptions): Promise<AuthStatus> {
+  const startedAt = now();
+  let delayMs = INITIAL_DELAY_MS;
+  let attempt = 0;
+
+  for (;;) {
+    attempt += 1;
+    onAttempt?.({ attempt, elapsedMs: now() - startedAt });
+
+    const status = await getStatus();
+    if (status.reachable) return status;
+
+    // Check the budget before sleeping, so giving up does not add a final
+    // pointless wait on top of it.
+    if (now() - startedAt + delayMs > budgetMs) return status;
+
+    await sleep(delayMs);
+    delayMs = Math.min(delayMs * 2, MAX_DELAY_MS);
+  }
+}

--- a/apps/desktop/test/auth-api-client.test.ts
+++ b/apps/desktop/test/auth-api-client.test.ts
@@ -53,7 +53,7 @@ test("getAuthStatus returns the reported enabled flag and user count", async () 
   const { fetchImpl, calls } = fakeFetch([jsonResponse({ enabled: true, userCount: 3 })]);
   const client = createAuthApiClient({ apiBaseUrl: "http://localhost:3001", fetchImpl });
 
-  assert.deepEqual(await client.getAuthStatus(), { enabled: true, userCount: 3 });
+  assert.deepEqual(await client.getAuthStatus(), { reachable: true, enabled: true, userCount: 3 });
   assert.equal(calls[0].method, "GET");
 });
 
@@ -61,25 +61,40 @@ test("getAuthStatus coerces a missing user count to zero", async () => {
   const { fetchImpl } = fakeFetch([jsonResponse({ enabled: true })]);
   const client = createAuthApiClient({ apiBaseUrl: "http://localhost:3001", fetchImpl });
 
-  assert.deepEqual(await client.getAuthStatus(), { enabled: true, userCount: 0 });
+  assert.deepEqual(await client.getAuthStatus(), { reachable: true, enabled: true, userCount: 0 });
 });
 
-test("getAuthStatus reports auth disabled on a non-2xx response", async () => {
+test("a 5xx means the API could not answer, not that auth is disabled", async () => {
   const { fetchImpl } = fakeFetch([errorResponse(500, { error: { message: "boom" } })]);
   const client = createAuthApiClient({ apiBaseUrl: "http://localhost:3001", fetchImpl });
 
-  // The desktop client routes on this before it can show anything, so an API
-  // that is down must not strand the user on a login screen it cannot satisfy.
-  assert.deepEqual(await client.getAuthStatus(), { enabled: false, userCount: 0 });
+  // Render answers 5xx while a spun-down instance wakes. Reporting that as
+  // "auth is disabled" put the user into pass-through mode during a cold start.
+  const status = await client.getAuthStatus();
+
+  assert.equal(status.reachable, false);
+  assert.equal(status.reachable === false && status.reason, "http_500");
 });
 
-test("getAuthStatus reports auth disabled when the request throws", async () => {
+test("a failed request means the API could not answer, not that auth is disabled", async () => {
   const fetchImpl = (async () => {
     throw new Error("connection refused");
   }) as unknown as typeof fetch;
   const client = createAuthApiClient({ apiBaseUrl: "http://localhost:3001", fetchImpl });
 
-  assert.deepEqual(await client.getAuthStatus(), { enabled: false, userCount: 0 });
+  const status = await client.getAuthStatus();
+
+  assert.equal(status.reachable, false);
+  assert.equal(status.reachable === false && status.reason, "network_error");
+});
+
+test("auth being genuinely disabled is reported as a reachable answer", async () => {
+  // The single-user bypass: the server is up and says no auth is needed. This
+  // must stay distinguishable from the two cases above, which is the whole point.
+  const { fetchImpl } = fakeFetch([jsonResponse({ enabled: false, userCount: 0 })]);
+  const client = createAuthApiClient({ apiBaseUrl: "http://localhost:3001", fetchImpl });
+
+  assert.deepEqual(await client.getAuthStatus(), { reachable: true, enabled: false, userCount: 0 });
 });
 
 // -------------------------------------------------------------- register

--- a/apps/desktop/test/auth-gate.test.ts
+++ b/apps/desktop/test/auth-gate.test.ts
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { decideAuthRoute } from "../src/authGate.js";
+import type { AuthStatus } from "../src/authApiClient.js";
+
+const reachable = (enabled: boolean, userCount: number): AuthStatus =>
+  ({ reachable: true, enabled, userCount });
+
+const unreachable: AuthStatus = { reachable: false, reason: "http_502" };
+
+test("a first-time user on an empty instance is sent to register", () => {
+  assert.equal(decideAuthRoute({ status: reachable(true, 0), hasToken: false }), "register");
+});
+
+test("a returning user without a token is sent to login", () => {
+  assert.equal(decideAuthRoute({ status: reachable(true, 2), hasToken: false }), "login");
+});
+
+test("a user holding a token goes straight into the app", () => {
+  assert.equal(decideAuthRoute({ status: reachable(true, 2), hasToken: true }), "app");
+});
+
+test("auth genuinely switched off lets the user into the app", () => {
+  // The single-user bypass: the server answered and said no auth is required.
+  assert.equal(decideAuthRoute({ status: reachable(false, 0), hasToken: false }), "app");
+});
+
+test("an unreachable API does not let the user into the app", () => {
+  // The defect this module exists to prevent (#155): an unreachable API used to
+  // collapse into `{ enabled: false }`, which read as "auth is off" and waved the
+  // user through into a chat where every request then failed. Not knowing whether
+  // auth is required is its own outcome, never a licence to skip it.
+  assert.equal(decideAuthRoute({ status: unreachable, hasToken: false }), "unavailable");
+});
+
+test("an unreachable API is unavailable even when a token is held", () => {
+  // A token is not proof the server accepts it — it may be expired, or belong to
+  // a different instance after an endpoint change.
+  assert.equal(decideAuthRoute({ status: unreachable, hasToken: true }), "unavailable");
+});

--- a/apps/desktop/test/connecting-view.test.ts
+++ b/apps/desktop/test/connecting-view.test.ts
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import * as React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { ConnectingView } from "../src/ui/ConnectingView.js";
+
+const render = (viewProps: Parameters<typeof ConnectingView>[0]["viewProps"], onRetry = () => {}) =>
+  renderToStaticMarkup(React.createElement(ConnectingView, { viewProps, handlers: { onRetry } }));
+
+test("while waiting, the screen says the server is starting", () => {
+  const html = render({ state: "waiting", attempt: 1 });
+
+  // The whole point of #155: the user must learn the server is waking, not be
+  // dropped into an app whose every request fails.
+  assert.match(html, /starting/i);
+});
+
+test("while waiting, no retry button is offered", () => {
+  // Retrying by hand is meaningless while an automatic retry is already running.
+  assert.equal(render({ state: "waiting", attempt: 3 }).includes("<button"), false);
+});
+
+test("a long wait is acknowledged rather than looking hung", () => {
+  const early = render({ state: "waiting", attempt: 1 });
+  const late = render({ state: "waiting", attempt: 6 });
+
+  assert.notEqual(early, late, "the screen must change as attempts pile up");
+  assert.match(late, /still/i);
+});
+
+test("giving up offers a way to try again", () => {
+  const html = render({ state: "failed" });
+
+  assert.match(html, /could not|unreachable|reach/i);
+  assert.match(html, /<button/);
+});
+
+test("the retry button is wired to the handler", () => {
+  let retried = 0;
+  // Called directly rather than through createElement: the component is pure, and
+  // the assertion is about the handler it assigns, which markup cannot show.
+  const tree = ConnectingView({
+    viewProps: { state: "failed" },
+    handlers: { onRetry: () => { retried += 1; } },
+  });
+
+  const button = findButton(tree);
+  assert.ok(button, "expected a retry button");
+  button.props.onClick?.();
+  assert.equal(retried, 1);
+});
+
+type El = React.ReactElement<{ onClick?: () => void; children?: unknown }>;
+
+function findButton(node: unknown): El | undefined {
+  if (!React.isValidElement(node)) return undefined;
+  const el = node as El;
+  if (el.type === "button") return el;
+  const kids = el.props.children;
+  for (const child of Array.isArray(kids) ? kids : [kids]) {
+    const found = findButton(child);
+    if (found) return found;
+  }
+  return undefined;
+}

--- a/apps/desktop/test/start-desktop-browser-app.test.ts
+++ b/apps/desktop/test/start-desktop-browser-app.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { startDesktopBrowserApp } from "../src/startDesktopBrowserApp.js";
 import { bootstrapDesktopApp, bootstrapDesktopReactApp } from "../src/index.js";
-import { jsonResponse } from "./helpers/fakeResponse.js";
+import { jsonResponse, errorResponse } from "./helpers/fakeResponse.js";
 import { fakeMediaQueryList, fakeWindow } from "./helpers/fakeDom.js";
 import { fakeUpdateStorage } from "./helpers/fakeStorage.js";
 import type { UpdateAvailablePayload, UpdateDismissalStorage } from "../src/updateNotification.js";
@@ -222,4 +222,77 @@ test("clicking Install invokes the install_update command", async () => {
   await app.updateBannerHandlers?.onInstall?.();
 
   assert.ok(invokedCommands.includes("install_update"), "expected install_update to be invoked");
+});
+
+// --- the connecting screen (#155) -------------------------------------------
+
+/**
+ * Boots against an API that answers 502 the first `downFor` times, as a
+ * spun-down Render instance does, then comes up. Sleep is faked so the backoff
+ * costs the suite nothing.
+ */
+async function startAgainstWakingApi(downFor: number) {
+  let calls = 0;
+  // The hash router reads globalThis.location; without one, navigate() is a
+  // no-op and every route would read as "home".
+  const prevLocation = globalThis.location;
+  Object.defineProperty(globalThis, "location", {
+    value: { hash: "" }, configurable: true, writable: true,
+  });
+  const routes: string[] = [];
+  let connectingProps: (() => { state: string; attempt?: number }) | undefined;
+
+  await startDesktopBrowserApp({
+    // Onboarding complete, otherwise the welcome gate short-circuits the auth
+    // gate and no status check happens at all.
+    invokeTauri: async (cmd) =>
+      cmd === "gemini_config_status" ? { hasStoredKey: true, onboardingComplete: true } : {},
+    updateDismissalStorage: fakeUpdateStorage(),
+    fetchImpl: async (url) => {
+      if (!String(url).endsWith("/auth/status")) return jsonResponse({});
+      calls += 1;
+      return calls <= downFor
+        ? errorResponse(502, {})
+        : jsonResponse({ enabled: true, userCount: 2 });
+    },
+    sleep: async () => {},
+    now: () => 0,
+    deps: {
+      bootstrapDesktopApp: (options) => bootstrapDesktopApp(options),
+      bootstrapDesktopReactApp: (options) => {
+        connectingProps = options.getConnectingViewProps;
+        routes.push(options.router?.getRoute() ?? "");
+        return fakeReactApp({
+          mount: async () => { routes.push(options.router?.getRoute() ?? ""); return {}; },
+          showUpdateBanner: () => {},
+        });
+      },
+    },
+  });
+
+  Object.defineProperty(globalThis, "location", {
+    value: prevLocation, configurable: true, writable: true,
+  });
+  return { routes, statusCalls: calls, connectingProps };
+}
+
+test("a cold API puts the user on the connecting screen, not into a broken app", async () => {
+  const { routes, connectingProps } = await startAgainstWakingApi(3);
+
+  assert.ok(routes.includes("connecting"), `expected a connecting route, saw: ${routes.join(", ")}`);
+  assert.notEqual(connectingProps?.().state, "failed", "it should still have been waiting, not given up");
+});
+
+test("once the API wakes, the user is routed on rather than left connecting", async () => {
+  const { routes, statusCalls } = await startAgainstWakingApi(3);
+
+  assert.ok(statusCalls > 3, `expected retries past the outage, got ${statusCalls} calls`);
+  assert.equal(routes.at(-1), "login", `should have landed on login, saw: ${routes.join(", ")}`);
+});
+
+test("a healthy API never shows the connecting screen", async () => {
+  const { routes, statusCalls } = await startAgainstWakingApi(0);
+
+  assert.equal(statusCalls, 1, "a healthy start must cost exactly one status check");
+  assert.equal(routes.includes("connecting"), false, "no detour through connecting");
 });

--- a/apps/desktop/test/start-desktop-browser-app.test.ts
+++ b/apps/desktop/test/start-desktop-browser-app.test.ts
@@ -151,6 +151,10 @@ async function startWithUpdateDeps(
     listenUpdateAvailable: (handler) => { listener = handler; },
     updateDismissalStorage: overrides.updateDismissalStorage ?? fakeUpdateStorage(),
     invokeTauri: overrides.invokeTauri ?? (async () => ({})),
+    // Without this the helper fell through to the global fetch and really tried
+    // to reach localhost:3001. Harmless while an unreachable API failed fast;
+    // now that startup retries a waking API, a unit test must never get there.
+    fetchImpl: async () => jsonResponse({ enabled: false, userCount: 0 }),
     deps: {
       bootstrapDesktopApp: (options) => bootstrapDesktopApp(options),
       bootstrapDesktopReactApp: (options) => {

--- a/apps/desktop/test/wait-for-api.test.ts
+++ b/apps/desktop/test/wait-for-api.test.ts
@@ -1,0 +1,109 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { waitForAuthStatus } from "../src/waitForApi.js";
+import type { AuthStatus } from "../src/authApiClient.js";
+
+const UP: AuthStatus = { reachable: true, enabled: true, userCount: 2 };
+const DOWN: AuthStatus = { reachable: false, reason: "http_502" };
+
+/**
+ * A clock the test drives. `sleep` advances it instead of waiting, so the
+ * budget is exercised deterministically and the suite stays instant.
+ */
+function fakeClock() {
+  let now = 0;
+  const slept: number[] = [];
+  return {
+    now: () => now,
+    slept,
+    sleep: async (ms: number) => {
+      slept.push(ms);
+      now += ms;
+    },
+  };
+}
+
+/** Answers `DOWN` the given number of times, then `UP`. */
+function apiDownFor(attempts: number) {
+  let calls = 0;
+  return {
+    getStatus: async (): Promise<AuthStatus> => {
+      calls += 1;
+      return calls > attempts ? UP : DOWN;
+    },
+    callCount: () => calls,
+  };
+}
+
+test("an API that answers immediately is not retried or slept on", async () => {
+  const clock = fakeClock();
+  const api = apiDownFor(0);
+
+  const status = await waitForAuthStatus({ getStatus: api.getStatus, ...clock });
+
+  assert.deepEqual(status, UP);
+  assert.equal(api.callCount(), 1);
+  assert.deepEqual(clock.slept, [], "a healthy API must not delay startup");
+});
+
+test("a waking API is retried until it answers", async () => {
+  const clock = fakeClock();
+  const api = apiDownFor(3);
+
+  const status = await waitForAuthStatus({ getStatus: api.getStatus, ...clock });
+
+  assert.deepEqual(status, UP, "the eventual answer is what the caller gets");
+  assert.equal(api.callCount(), 4);
+});
+
+test("retries back off instead of hammering the waking instance", async () => {
+  const clock = fakeClock();
+  const api = apiDownFor(4);
+
+  await waitForAuthStatus({ getStatus: api.getStatus, ...clock });
+
+  // Strictly increasing until the cap: a spun-down Render instance takes tens of
+  // seconds, and retrying every 100ms would just pile requests onto its boot.
+  assert.ok(clock.slept.length >= 3, `expected several waits, got ${clock.slept.length}`);
+  assert.ok(clock.slept[1] > clock.slept[0], "the second wait should be longer than the first");
+  assert.ok(
+    clock.slept.every((ms) => ms <= 8000),
+    `no single wait should exceed the 8s cap, got ${clock.slept.join(", ")}`,
+  );
+});
+
+test("giving up reports the last failure rather than a healthy-looking answer", async () => {
+  const clock = fakeClock();
+  const alwaysDown = async (): Promise<AuthStatus> => DOWN;
+
+  const status = await waitForAuthStatus({ getStatus: alwaysDown, ...clock, budgetMs: 5000 });
+
+  assert.deepEqual(status, DOWN, "the caller must still see that the API never answered");
+});
+
+test("waiting stops once the budget is spent", async () => {
+  const clock = fakeClock();
+  let calls = 0;
+  const alwaysDown = async (): Promise<AuthStatus> => { calls += 1; return DOWN; };
+
+  await waitForAuthStatus({ getStatus: alwaysDown, ...clock, budgetMs: 5000 });
+
+  assert.ok(clock.now() <= 5000 + 8000, `waited far past the budget: ${clock.now()}ms`);
+  assert.ok(calls < 50, `retried without bound: ${calls} attempts`);
+});
+
+test("each attempt is reported so the caller can show progress", async () => {
+  const clock = fakeClock();
+  const api = apiDownFor(2);
+  const seen: number[] = [];
+
+  await waitForAuthStatus({
+    getStatus: api.getStatus,
+    ...clock,
+    onAttempt: ({ attempt }) => seen.push(attempt),
+  });
+
+  // Without this the connecting screen cannot tell "still trying" from "hung".
+  assert.deepEqual(seen, [1, 2, 3]);
+});

--- a/docs/design/UI_GUIDELINES.md
+++ b/docs/design/UI_GUIDELINES.md
@@ -160,6 +160,27 @@ Action row policy (locked, all viewports):
   implemented, the `···` button is not rendered at all. A visible control that
   does nothing on click is a defect, not a placeholder.
 
+## Connecting State (locked)
+
+Shown at startup while the API is being polled, and when polling gives up. It
+exists because an unreachable API was previously indistinguishable from "auth is
+switched off", which dropped the user into an app whose every request then
+failed.
+
+| State | Heading | Controls |
+|---|---|---|
+| `waiting` | "Starting the server" | **None.** A manual retry is meaningless while an automatic one is running. |
+| `waiting`, 4+ attempts | "Still starting…" | None. The copy must change, so a long wait cannot be mistaken for a hang. |
+| `failed` | "Could not reach the server" | "Try again" button, min 44px tall. |
+
+- **Never show a bare spinner here.** A spinner looks identical at second 1 and
+  second 60; a hosted instance that has spun down takes 30–60s to wake, so the
+  screen must say what is happening and acknowledge a long wait.
+- **Only reached when the first status check fails.** A healthy API routes
+  straight to its destination — no detour, no flash of this screen.
+- The `failed` copy points at Settings, since a wrong API endpoint produces the
+  same symptom as an unreachable one.
+
 ## Interaction and State Design
 
 ### Chat and request states


### PR DESCRIPTION
Closes #155. Queued ahead of Phase 9.5 because it would otherwise corrupt that verification — see below.

## The defect

`getAuthStatus` collapsed three outcomes into two. A 5xx and a thrown request both returned `{ enabled: false, userCount: 0 }` — the identical value the server sends when auth is genuinely switched off by the single-user bypass. The startup gate read that as "no auth needed" and waved the user through into a chat where every subsequent request then failed.

Render serves 502/503 for the 30–60s a spun-down free-tier instance takes to wake, so this fires on exactly the path a mobile or remote user hits first.

**Why it blocks 9.5:** verifying the Render + Turso deployment while the client silently enters pass-through on a cold start means not being able to trust the result. Fixing it afterwards would mean re-running the verification.

## Three phases

**1 — Tell the cases apart.** `AuthStatus` becomes a discriminated union rather than gaining a `reachable` flag, so "unreachable but enabled" cannot be expressed and every caller must handle the third case. The compiler found the single caller immediately, which is the point. The routing rule moves into a pure `decideAuthRoute`, matching `firstRunOnboarding` and `updateNotification` — the router is created internally and is not a seam, so the decision could not otherwise be tested.

**2 — Wait for it.** `waitForAuthStatus` polls until the API answers or a 90s budget runs out, backing off 500ms → 8s. The budget sits above the observed cold-start range deliberately: a shorter one gives up exactly when waiting was about to pay off. It returns the last status rather than throwing — an API that never answered is an outcome the caller must see, and an exception would recreate the ambiguity phase 1 removed. `sleep`/`now` are injected, so tests drive a fake clock and the suite stays instant.

**3 — Show it.** The gate routes on one quick check, so a healthy API reaches its destination with no detour and no flash. Only when that check finds nothing does `ConnectingView` appear, and the remaining retries run with something on screen — the gate runs before `mount()`, so phase 2 alone would have waited behind a blank window.

The view says what is happening instead of showing a spinner (a spinner looks the same at second 1 and second 60), changes its copy after four attempts so a long wait is not mistaken for a hang, and offers no retry button while retrying — a manual retry during an automatic one invites the user to fix what is already handled.

## Defects found along the way

- **`createHashRouter` had no `connecting` entry**, so `navigate("connecting")` fell through to `"#/"` and read back as `"home"`.
- **Navigation relied on the browser firing `hashchange`** to trigger a re-render — an implicit dependency on a side effect of assigning `location.hash`, which does not exist outside a real browser. Views are now rendered explicitly after navigating.
- **The update-notification test helper passed no `fetchImpl`**, so it fell through to the global fetch and really tried to reach `localhost:3001` on every run. Invisible while an unreachable API failed fast; with retries it would have hung the suite for 90s.

## Design spec

Per the rule added to `AGENTS.md` this morning, the new screen is specified in `UI_GUIDELINES.md` in the same PR that introduces it, with states and copy locked. The retry button is 44px, per the touch-target value locked at the same time.

## Testing

`npm run ci` green: **339** / 678 / 16 / 25, suite runs in ~11s.

17 new tests: 6 for the routing rule, 6 for the retry loop (fake clock), 5 for the view, plus 3 integration tests booting against an API that answers 502 three times and then comes up.

Two existing tests asserted the old behaviour and were **rewritten rather than kept** — they encoded the defect as expected, the same pattern that kept the card action row broken for four months.

## Note

The old test carried a fair objection: *"an API that is down must not strand the user on a login screen it cannot satisfy."* That concern was real; answering it with silent pass-through was not. `unavailable` is its own route for exactly that reason, and phase 3 renders it properly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiphXDP4gVnxirBQw9YnPC