### PR TITLE
docs: sharpen the saved-band model and respecify the card action row

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,12 @@ feature branch  →  staging  →  main
 - When creating a feature branch or fixing a bug, set `base = staging` in the PR
 - `staging` acts as the integration/QA gate before production (`main`)
 
+**Issues do not close themselves here.** GitHub honours `Closes #123` only when a
+PR merges into the *default* branch — `main`. Since PRs target `staging`, the
+keyword never fires, and a finished issue stays open until someone closes it by
+hand. Still write `Closes #123` in the PR so the link is recorded, then close the
+issue manually once the PR is merged.
+
 ## Testing
 
 TDD-Ansatz: erst Tests schreiben (rot), dann implementieren (grün), dann refactoren.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Agent instructions
 
 ## Agent skills
-
+Use /feature-worklfow when useful
 ### Issue tracker
 
 Issues are tracked in GitHub Issues for this repository using the `gh` CLI. See `docs/agents/issue-tracker.md`.
@@ -24,10 +24,6 @@ When working on Roadmap items update Roadmap corresponfingly.
 any UI change. Read them before touching a view, and follow the values marked
 `(locked)` exactly rather than re-deriving them.
 
-Two rules that exist because both were broken at once (see the card action row,
-fixed 2026-08-30 — the spec was written 15 minutes *before* the code that
-contradicted it, and stayed contradicted for four months):
-
 - **Changing the design means changing the spec in the same PR.** If the
   implementation should differ from the spec, update the spec — never leave the
   two disagreeing. A code change that silently deviates is a bug even when the
@@ -36,9 +32,6 @@ contradicted it, and stayed contradicted for four months):
   whatever the code happens to do will lock a spec violation in place and defend
   it against correction. That is worse than having no test.
 
-If a spec rule is prose rather than a number, it will be interpreted and
-therefore eventually ignored — when you rely on such a rule, pin it to a
-concrete value and mark it `(locked)`.
 
 ### TypeScript
 
@@ -50,7 +43,7 @@ Application, test, and JS-toolchain config code is TypeScript only (`strict` + `
 
 ## Git & PR Workflow
 
-**Sequentiell arbeiten, nicht parallel.**
+**Work sequential not parrallel.**
 
 ### Branching workflow
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,6 +20,16 @@ AI-powered music recommendations for niche and lesser-known artists. Combines co
 
 - **Preference context** — a formatted string built from the user's saved bands (ratings, categories, notes) and injected into Gemini prompts for `preference-aware` mode recommendations.
 
+- **Saved band** — an artist the user has kept in their preference memory. Saving is itself a signal of interest; it does not require the user to judge the artist. A saved band may carry a rating, categories and a note, all optional.
+
+- **Rating** — an optional 1–5 judgement on a saved band. A band that is saved but not yet rated is a distinct, legitimate state: "I want to remember this, I have not decided how much I like it." A rating expresses strength of preference only — it never determines ranking or ordering by itself; its whole effect is that it appears in the preference context the recommendation prompt reads.
+
+- **Category** — a free-text tag the user puts on one saved band. Categories **shape what gets recommended**: they are part of the preference context sent to the model. Distinct from an artist group despite the similar wording — see below.
+
+- **Artist group** — a named collection of saved bands, with its own identity, used to browse and organise a collection. A group **does not influence recommendations**; it never reaches the preference context. The rule of thumb: a category says something about a band's character, a group says where the user filed it.
+
+- **Note** — free text on a saved band. Only a note the user has actually written or edited counts as their own preference signal and reaches the recommendation prompt. A note left at the value the system pre-filled — the model's own explanation of why it recommended the artist — stays visible to the user but is kept out of the prompt, so the model cannot read its own words back as if the user had said them. See ADR 0002.
+
 - **Obscurity target** — a user-selectable signal (`Cult Following` / `Underground` / `Truly Obscure`) passed to the planner to tune search queries toward less or more obscure artists. Stored per recommendation event.
 
 - **Eval layer** — an async, non-blocking quality-scoring system that runs after the HTTP response is sent. Three tiers: (1) automatic metrics — Last.fm obscurity score and pipeline funnel counts; (1.5) deterministic checks — citation support rate and generic-why detection; (2) LLM-as-judge — scores each band asynchronously (optional, requires `MISTRAL_API_KEY`).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -17,10 +17,9 @@ says what to do, the numbered sections say what it belongs to.
 Revisit this list whenever something lands or a new blocker appears; it is a
 plan, not a second permanent structure.
 
-1. **#155 — `getAuthStatus` fails open.** Before 9.5, not after: a 502 during a
-   cold start currently reads as "auth disabled", so the app would silently
-   enter pass-through mode during the very test 9.5 is meant to be. Fixing it
-   afterwards means not trusting the result.
+1. ~~**#155 — `getAuthStatus` fails open.**~~ ✓ Done (#161). It had to come first:
+   a 502 during a cold start read as "auth disabled", so the app would have
+   entered pass-through mode during the very test 9.5 is meant to be.
 2. **Phase 9.5 — verify Render + Turso end-to-end.** The bottleneck. Unblocks
    Android, the deploy gate and the eval data, and it is the one thing claimed
    as infrastructure that has never actually been run.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -24,10 +24,16 @@ plan, not a second permanent structure.
 2. **Phase 9.5 — verify Render + Turso end-to-end.** The bottleneck. Unblocks
    Android, the deploy gate and the eval data, and it is the one thing claimed
    as infrastructure that has never actually been run.
-3. **#151–#154 — the card action defects.** Cheap, and three of them are live on
-   desktop today (a dead `···` button on every card, Rate silently writing 5).
-   Independent of everything else, so they can also fill gaps while waiting on
-   infrastructure.
+3. **The card action work — #151–#154 and #163–#167.** Designed in
+   `docs/adr/0002-*` and the action-row policy; not yet built. Start with
+   #164 (rating becomes nullable), since #151, #152 and #165 all sit on top of
+   it. Independent of the infrastructure work, so it can fill gaps while
+   waiting on a deployment.
+
+   Six of these are live defects, not future work: a dead `···` button on
+   every card, Save and Rate writing hidden ratings, the same artist storable
+   twice and then double-counted in the prompt, and the model reading its own
+   text back as the user's preference.
 4. **Phase 10 — signing key, then the first `v0.4.0` release.** In that order.
    This is the first real proof the updater works; the pipeline has only ever
    run against a throwaway `v0.2.1-test` tag.
@@ -50,7 +56,7 @@ Phase 10  signing key + GitHub secrets
 
 Independent, can start any time:
  · Phase 8 F6 / F7 / F8      · Architecture 9 (ESM migration)
- · Phase 10 macOS check      · the card-action defects (#151-#154)
+ · Phase 10 macOS check      · the card-action work (#151-#154, #163-#167)
 ```
 
 When an entry moves, say so in place rather than deleting it — an entry that

--- a/docs/adr/0002-machine-written-notes-stay-out-of-the-prompt.md
+++ b/docs/adr/0002-machine-written-notes-stay-out-of-the-prompt.md
@@ -1,0 +1,72 @@
+# ADR 0002 — Machine-written notes stay out of the recommendation prompt
+
+**Status:** Accepted
+**Date:** 2026-08-30
+
+## Context
+
+Saving a band from a recommendation card pre-fills its `note` with the model's
+own explanation of why it recommended the artist (`bootstrapDesktopApp.ts`:
+`note: options.note || recommendation?.why || …`).
+
+That note is then read back into the preference context on the next request
+(`savedBandContext.ts`), formatted as `note: <text>` alongside the user's
+rating and categories — that is, presented to the model as the user's own words.
+
+So the model writes "atmospheric slowcore with tape hiss", the user saves the
+band, and on the next query the model reads back what looks like independent
+confirmation from the user of a preference the model itself introduced. Across
+many queries this narrows recommendations toward the model's own vocabulary,
+and the narrowing is invisible: nothing distinguishes a note the user wrote from
+one the system pre-filled.
+
+Notes are currently not editable anywhere in the UI, so in practice *every*
+note in the system is machine-written. The `···` overflow that the design spec
+assigns to Category/Note was never implemented, which is why this went unnoticed.
+
+## Decision
+
+**Only a note the user has written or edited enters the preference context.**
+
+A note still left at its pre-filled value stays stored and stays visible in the
+UI — it answers "why was this recommended to me", which is worth keeping — but
+it is not sent to the model as preference signal. Once the user edits it, it
+counts fully, like any other thing they typed.
+
+This requires recording whether a note has been edited; the stored text alone
+cannot tell the two apart.
+
+## Alternatives considered
+
+**Label the provenance in the prompt** ("recommended because …" rather than
+"note: …") and let the model weight it accordingly. Rejected: this is a request
+to the model, not a guarantee. Weighting instructions are followed
+inconsistently, so the separation would be only as reliable as the model's
+cooperation on a given day. The problem is structural and deserves a structural
+fix.
+
+**Never pre-fill the note.** Rejected: it removes the loop but also removes the
+provenance information, which is useful to the user — particularly for a band
+saved months earlier.
+
+**Leave it as is** now that notes are becoming editable. Rejected: the majority
+of notes will never be touched, so the majority of the corpus would keep feeding
+the model its own text.
+
+## Consequences
+
+- A saved band the user never annotated contributes name, rating and categories
+  to the context, but no note text. This is a deliberate reduction in signal:
+  less input, but none of it circular.
+- `SavedBand` gains a way to distinguish a user-authored note from a pre-filled
+  one. The three repository adapters and the contract validator follow.
+- The GDPR export keeps exporting the note either way — it is the user's data
+  regardless of who first wrote it.
+- The rule is testable at the seam that matters: the context builder either
+  includes the text or it does not, and no test needs to reason about how a
+  model weights a hint.
+
+## Related
+
+- `CONTEXT.md` — **Note**, **Category**, **Artist group**
+- ADR 0001 — the other place where untrusted text reaches a prompt

--- a/docs/design/UI_EXAMPLES.md
+++ b/docs/design/UI_EXAMPLES.md
@@ -13,6 +13,8 @@ This file provides practical examples that translate `UI_GUIDELINES.md` into imp
 - Connection text references prior bands in plain language.
 - Rating stars and Save are always visible, on every screen size; Category/Note are compact actions.
 - Tapping a star saves the band with that rating — rating implies saving.
+- Saving does not imply rating: Save alone keeps a band unrated, which is a real state.
+- Both are reversible on the card: the active star clears the rating, Saved removes the band.
 
 Example content structure:
 
@@ -27,6 +29,7 @@ Example content structure:
 - Don't hide all actions behind menus on desktop.
 - Don't hide Save or the rating stars on mobile — saving is the core loop, not a secondary action.
 - Don't render a control that has no handler behind it.
+- Don't write a rating the user did not pick — no silent defaults behind Save.
 - Don't show long generic AI paragraphs as rationale text.
 
 ## Iconography Example

--- a/docs/design/UI_GUIDELINES.md
+++ b/docs/design/UI_GUIDELINES.md
@@ -145,20 +145,36 @@ Action row policy (locked, all viewports):
 
 | Control | Visibility | Behaviour |
 |---|---|---|
-| Rating stars (1–5) | Always | Tapping star *n* saves the band **with rating *n***. Rating implies saving. |
-| Save | Always | Saves without a rating, for "remember this, undecided". |
-| `···` overflow | Always | Category / Note. Must open something — see the rule below. |
+| Rating stars (1–5) | Always | Tapping star *n* saves the band **with rating *n***. Tapping the currently active star clears the rating — the band stays saved, now unrated. |
+| Save / Saved | Always | A toggle. Unsaved → saves **without** a rating ("remember this, undecided"). Saved → removes it again. Label and state are visible, never implied. |
+| `···` overflow | Always | Category and Note. Must open something — see the rule below. |
 | Copy `⎘` | Always, row end | Icon-only, `title="Copy"` tooltip. |
 
-- **Save and the stars are primary and never collapse**, on any screen size.
+- **The stars and Save are primary and never collapse**, on any screen size.
   Saving is what makes `preference-aware` mode work, so it is the one action
   that must always be one tap away. Only Category/Note and Copy are secondary.
-- **Rating implies saving.** There is no state where a band is rated but not
-  saved. A separate "Rate" text button is not used — it cannot express *which*
-  rating is being given, which is why the previous one silently always wrote 5.
+- **Rating implies saving, and saving does not imply rating.** "Saved but not
+  yet rated" is a real state (see `CONTEXT.md`), which is why both controls
+  exist and neither is redundant.
+- **Every write is reversible from the card.** Tapping an active star clears the
+  rating; tapping Saved removes the band. A mis-tap must never require going to
+  another screen to undo — on a phone that is an expensive detour.
+- **No hidden default values.** A control must never write a value the user did
+  not choose. The previous row had two: Save silently wrote rating 3 and Rate
+  silently wrote 5, neither shown anywhere.
 - **No control may render without an action behind it.** If Category/Note is not
   implemented, the `···` button is not rendered at all. A visible control that
   does nothing on click is a defect, not a placeholder.
+
+Category/Note sheet (behind `···`):
+
+- **Category** shapes what gets recommended; the sheet says so in as many words.
+  A user cannot be expected to infer that from the label, and the distinction
+  from an artist group — which does *not* affect recommendations — is otherwise
+  invisible.
+- **Note** is pre-filled with the model's explanation of why the artist was
+  recommended. It is shown as such, and only counts as the user's own input once
+  they edit it. See ADR 0002.
 
 ## Interaction and State Design
 


### PR DESCRIPTION
Outcome of a grilling session on the card action design. **Documentation only** — no code changes. It corrects a spec change I made earlier today that turned out not to be implementable, and records four defects found while pressure-testing it.

## The spec described something the database forbids

This morning's spec said Save meant "remember without a rating". The schema says:

```sql
rating INTEGER NOT NULL CHECK (rating >= 1 AND rating <= 5)
```

An unrated saved band **cannot exist**. What Save actually does is write rating **3**, invisibly; Rate writes **5**, also invisibly. Neither value is ever shown or chosen by the user. Meanwhile `domain.ts` declares `rating?: number | null`, which the database does not permit — the client type contradicts the schema.

**Decided:** rating becomes genuinely optional, so "saved but not yet rated" is a real state rather than a fiction the UI maintains. Both controls then have distinct jobs and neither is redundant.

## Decisions

| Question | Decision |
|---|---|
| Unrated saved bands? | Yes — `rating` becomes nullable |
| What does Gemini read for one? | Included, marked `saved, not yet rated` |
| Tapping the active star? | Clears the rating; band stays saved |
| Un-saving from the card? | Save becomes a toggle (`Save` / `Saved ✓`) |
| `···` overflow? | Build it as specified — Category/Note become editable |
| Machine-written notes? | Kept out of the prompt — see ADR 0002 |
| `categories` vs `ArtistGroup`? | Both stay; the distinction goes in the glossary |

Two principles were added to the spec from this: **every write is reversible from the card** (a mis-tap on a phone shouldn't require another screen), and **no hidden default values** — the row currently has two.

## Defects found (all live)

1. **`saved_bands` has no uniqueness** on `(user_id, musicbrainz_artist_id)`, and `addSavedBand` mints a fresh uuid with no dedup check. Pressing Save twice stores the artist twice and **double-counts it in the preference context**. The client-side guard matches on *name*, not MusicBrainz id.
2. **`categories` and `note` are editable nowhere** — the `···` that should hold them does nothing. So `categories` is permanently `[]` for anything saved from a card, and the `tags:` half of every prompt line is blank.
3. **`rating` is used in exactly one place semantically** — the prompt sentence. Nothing sorts or weights by it. Worth knowing before anyone builds on the assumption that it does.
4. **The GDPR export does `Number(row.rating)`**, so a null rating would export as `0` — outside the 1–5 domain. Relevant once rating becomes nullable.

## ADR 0002 — the one that needed a decision record

`note` is pre-filled with the model's own `why` text, then read back on the next request formatted as `note: …` — presented to the model as the user's own words. So the model writes "atmospheric slowcore with tape hiss", the user saves the band, and next time the model reads that back as independent confirmation of a preference **it invented**. Across many queries this narrows recommendations toward the model's own vocabulary, invisibly. And since notes are editable nowhere, *every* note in the system is currently machine-written.

The question raised in review was the right one: is labelling it as AI-generated enough, or should it stay out of the search entirely?

**Labelling is not enough.** A provenance hint in the prompt is a *request* to the model, not a guarantee — weighting instructions are followed inconsistently, so the separation would only be as reliable as the model's cooperation on a given day. The fix is structural: only a note the user actually wrote or edited reaches the prompt. The pre-filled text stays stored and visible (it answers "why was this recommended to me"), but never counts as preference signal.

## Glossary

`CONTEXT.md` gains **Saved band**, **Rating**, **Category**, **Artist group**, **Note**. The last two were the fuzziest — both sound like categorisation, and nothing said which affects recommendations:

- **Category** → reaches the preference context, **shapes what gets recommended**
- **Artist group** → organisation only, never reaches the prompt

Names kept, distinction written down, and the Category sheet will say so in the UI.

## Follow-up

The defects above still need issues, and the decisions here need implementing — `rating` nullable is a migration plus three adapters plus the contract validator. Nothing is coded yet, which is why the spec was corrected first: cheaper to change now than after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiphXDP4gVnxirBQw9YnPC