### PR TITLE
fix: two defects a cleanup review found in today's merged work

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -863,7 +863,6 @@ mod tests {
         };
         let value = serde_json::to_value(&payload).expect("payload must serialize");
         assert_eq!(value["canAutoInstall"], cfg!(not(target_os = "macos")));
-        assert_eq!(value["canAutoInstall"].as_bool(), Some(!cfg!(target_os = "macos")));
     }
 
     #[test]

--- a/apps/desktop/src/bootstrapDesktopApp.ts
+++ b/apps/desktop/src/bootstrapDesktopApp.ts
@@ -1,3 +1,4 @@
+import { formatRatingForPrompt } from "../../../shared/schemas/src/contracts.js";
 import type { SavedBand } from "./domain.js";
 import type { ChatMessage } from "./chatClient.js";
 import {
@@ -18,7 +19,7 @@ function buildPriorityContext(savedBands: SavedBand[], selectedArtistIds: string
   if (!selectedArtistIds.length) return "";
   const selected = savedBands.filter((b) => selectedArtistIds.includes(b.id));
   if (!selected.length) return "";
-  const names = selected.map((b) => `${b.name} (rating ${b.rating}/5)`).join(", ");
+  const names = selected.map((b) => `${b.name} (${formatRatingForPrompt(b.rating)})`).join(", ");
   return `Priority style references: ${names}`;
 }
 

--- a/apps/desktop/src/startDesktopBrowserApp.ts
+++ b/apps/desktop/src/startDesktopBrowserApp.ts
@@ -219,29 +219,38 @@ export async function startDesktopBrowserApp({
     if (route !== "app") router.navigate(route);
   }
 
+  // Guards the retry button: root.render commits asynchronously, so a double
+  // click would otherwise start a second polling loop writing the same state.
+  let connecting = false;
+
   /** Keeps polling after mount, then routes to wherever the answer says. */
   async function finishConnecting(): Promise<void> {
+    if (connecting) return;
+    connecting = true;
+    try {
     const status = await waitForAuthStatus({
       getStatus: () => authClient.getAuthStatus(),
       sleep: resolvedSleep,
       now: resolvedNow,
       onAttempt: ({ attempt }) => {
         connectingViewProps = { state: "waiting", attempt: attempt + 1 };
-        void reactApp?.mount();
+        void reactApp.mount();
       },
     });
-    const route = decideAuthRoute({ status, hasToken: Boolean(getAuthToken()) });
-    if (route === "unavailable") {
-      console.warn("[bandsearch] API unreachable:", status.reachable === false && status.reason);
-      connectingViewProps = { state: "failed" };
-      await reactApp?.mount();
-      return;
+      const route = decideAuthRoute({ status, hasToken: Boolean(getAuthToken()) });
+      if (route === "unavailable") {
+        if (!status.reachable) console.warn("[bandsearch] API unreachable:", status.reason);
+        connectingViewProps = { state: "failed" };
+      } else {
+        // Render explicitly rather than relying on the browser firing
+        // `hashchange` for our own navigation — that is an implicit dependency,
+        // and it does not exist outside a real browser at all.
+        router.navigate(route === "app" ? "home" : route);
+      }
+      await reactApp.mount();
+    } finally {
+      connecting = false;
     }
-    // Render explicitly rather than relying on the browser firing `hashchange`
-    // for our own navigation — that is an implicit dependency, and it does not
-    // exist outside a real browser at all.
-    router.navigate(route === "app" ? "home" : route);
-    await reactApp?.mount();
   }
 
   if (shouldOfferWelcomeScreen({ hasStoredKey: gate.hasStoredKey, onboardingComplete: gate.onboardingComplete, locationHash: initialHash })) {
@@ -291,7 +300,7 @@ export async function startDesktopBrowserApp({
     connectingHandlers: {
       onRetry: () => {
         connectingViewProps = { state: "waiting", attempt: 1 };
-        void reactApp.mount().then(() => finishConnecting());
+        void finishConnecting();
       },
     },
   });

--- a/apps/desktop/src/updateNotification.ts
+++ b/apps/desktop/src/updateNotification.ts
@@ -57,9 +57,11 @@ export function createUpdateNotificationController({
   onInstallError,
 }: UpdateNotificationControllerOptions) {
   let showBanner: ((viewProps: UpdateAvailablePayload | null) => void) | undefined;
-  /** Reported while no renderer was attached yet; flushed by attach(). */
-  let buffered: UpdateAvailablePayload | undefined;
-  /** The update currently on display, needed to persist the right dismissal. */
+  /**
+   * The update worth showing. Doubles as the buffer: reported before a renderer
+   * attached, it simply waits here until attach() replays it — a separate
+   * `buffered` field only ever held a copy of this same value.
+   */
   let current: UpdateAvailablePayload | undefined;
 
   return {
@@ -68,17 +70,13 @@ export function createUpdateNotificationController({
       const dismissedVersion = getDismissedUpdateVersion(storage);
       if (!shouldShowUpdateBanner({ availableVersion: payload.version, dismissedVersion })) return;
       current = payload;
-      if (showBanner) showBanner(payload);
-      else buffered = payload;
+      showBanner?.(payload);
     },
 
     /** Connect the renderer once the UI can paint, flushing anything buffered. */
     attach(show: (viewProps: UpdateAvailablePayload | null) => void): void {
       showBanner = show;
-      if (buffered) {
-        show(buffered);
-        buffered = undefined;
-      }
+      if (current) show(current);
     },
 
     handlers: {

--- a/apps/desktop/src/waitForApi.ts
+++ b/apps/desktop/src/waitForApi.ts
@@ -17,7 +17,7 @@ export type WaitForAuthStatusOptions = {
   sleep: (ms: number) => Promise<void>;
   now: () => number;
   /** Fires before each attempt, so a connecting view can show progress. */
-  onAttempt?: (info: { attempt: number; elapsedMs: number }) => void;
+  onAttempt?: (info: { attempt: number }) => void;
   budgetMs?: number;
 };
 
@@ -41,7 +41,7 @@ export async function waitForAuthStatus({
 
   for (;;) {
     attempt += 1;
-    onAttempt?.({ attempt, elapsedMs: now() - startedAt });
+    onAttempt?.({ attempt });
 
     const status = await getStatus();
     if (status.reachable) return status;

--- a/apps/desktop/test/connecting-view.test.ts
+++ b/apps/desktop/test/connecting-view.test.ts
@@ -4,6 +4,7 @@ import * as React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import { ConnectingView } from "../src/ui/ConnectingView.js";
+import { findElement } from "./helpers/fakeDom.js";
 
 const render = (viewProps: Parameters<typeof ConnectingView>[0]["viewProps"], onRetry = () => {}) =>
   renderToStaticMarkup(React.createElement(ConnectingView, { viewProps, handlers: { onRetry } }));
@@ -45,22 +46,9 @@ test("the retry button is wired to the handler", () => {
     handlers: { onRetry: () => { retried += 1; } },
   });
 
-  const button = findButton(tree);
+  const button = findElement(tree, (el) => el.type === "button");
   assert.ok(button, "expected a retry button");
-  button.props.onClick?.();
+  (button.props as { onClick?: () => void }).onClick?.();
   assert.equal(retried, 1);
 });
 
-type El = React.ReactElement<{ onClick?: () => void; children?: unknown }>;
-
-function findButton(node: unknown): El | undefined {
-  if (!React.isValidElement(node)) return undefined;
-  const el = node as El;
-  if (el.type === "button") return el;
-  const kids = el.props.children;
-  for (const child of Array.isArray(kids) ? kids : [kids]) {
-    const found = findButton(child);
-    if (found) return found;
-  }
-  return undefined;
-}

--- a/apps/desktop/test/helpers/fakeDom.ts
+++ b/apps/desktop/test/helpers/fakeDom.ts
@@ -4,7 +4,7 @@
 // two fields, so a full DOM implementation would be noise. These helpers keep
 // the narrowing in one place instead of casting at every call site.
 
-import { Fragment, type ReactElement, type ReactNode } from "react";
+import { Fragment, isValidElement, type ReactElement, type ReactNode } from "react";
 import type { Root } from "react-dom/client";
 
 /** A mount container. React roots are faked in these tests, so nothing reads it. */
@@ -46,4 +46,26 @@ export function fakeMediaQueryList(matches: boolean): MediaQueryList {
     addEventListener: () => {},
     removeEventListener: () => {},
   } as unknown as MediaQueryList;
+}
+
+/**
+ * First element in a rendered tree matching `predicate`, or undefined.
+ *
+ * View tests need a handle on one control to fire its `onClick` — markup alone
+ * cannot show which handler a view actually assigned. Shared because two tests
+ * grew their own near-identical walker before this existed.
+ */
+export function findElement(
+  node: unknown,
+  predicate: (element: ReactElement) => boolean,
+): ReactElement | undefined {
+  if (!isValidElement(node)) return undefined;
+  const element = node as ReactElement<{ children?: ReactNode }>;
+  if (predicate(element)) return element;
+  const children = element.props.children;
+  for (const child of Array.isArray(children) ? children : [children]) {
+    const found = findElement(child, predicate);
+    if (found) return found;
+  }
+  return undefined;
 }

--- a/apps/desktop/test/save-band-rating.test.ts
+++ b/apps/desktop/test/save-band-rating.test.ts
@@ -49,3 +49,32 @@ test("a rating of 1 is not mistaken for no rating", async () => {
 
   assert.equal(posted[0].rating, 1, "the lowest rating must survive");
 });
+
+test("an unrated style reference does not claim a rating in the prompt", async () => {
+  // buildPriorityContext is the second place a saved band is formatted for the
+  // model. savedBandContext.ts on the API side was fixed for #164; this copy was
+  // missed and interpolated `rating null/5` straight into the prompt.
+  const sent: Array<Record<string, unknown>> = [];
+  const app = bootstrapDesktopApp({
+    apiBaseUrl: "http://api.test",
+    fetchImpl: (async (url: string, init?: RequestInit) => {
+      const body = typeof init?.body === "string" ? JSON.parse(init.body) : {};
+      if (String(url).endsWith("/recommendations")) {
+        sent.push(body);
+        return jsonResponse({ items: [], assistantReply: "" });
+      }
+      if (String(url).endsWith("/preferences") && init?.method === "POST") {
+        return jsonResponse({ savedBand: { id: "b1", name: body.name, rating: null, categories: [], note: "" } });
+      }
+      return jsonResponse({ savedBands: [] });
+    }) as unknown as typeof fetch,
+  });
+
+  await app.saveBand("Codeine");
+  app.toggleArtistSelection("b1");
+  await app.requestRecommendations("something like that");
+
+  const priorityContext = String(sent[0]?.priorityContext ?? "");
+  assert.doesNotMatch(priorityContext, /rating (null|undefined|0)/, priorityContext);
+  assert.match(priorityContext, /Codeine/);
+});

--- a/apps/desktop/test/update-banner.test.ts
+++ b/apps/desktop/test/update-banner.test.ts
@@ -3,34 +3,9 @@ import assert from "node:assert/strict";
 import * as React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { UpdateBanner } from "../src/ui/UpdateBanner.js";
+import { findElement } from "./helpers/fakeDom.js";
 
-type ButtonElement = React.ReactElement<{
-  className?: string;
-  children?: React.ReactNode;
-  onClick?: () => void;
-}>;
 
-/**
- * UpdateBanner has no internal state, so it is called directly (not mounted)
- * and its returned element tree is walked to find the button to click — the
- * only way to exercise a click handler without a DOM/testing-library setup,
- * which this codebase does not have.
- */
-function findByClassName(node: unknown, className: string): ButtonElement | null {
-  if (!node || typeof node !== "object") return null;
-  const el = node as ButtonElement;
-  if (el.props?.className === className) return el;
-  const children = el.props?.children;
-  if (Array.isArray(children)) {
-    for (const child of children) {
-      const found = findByClassName(child, className);
-      if (found) return found;
-    }
-  } else if (children) {
-    return findByClassName(children, className);
-  }
-  return null;
-}
 
 test("UpdateBanner renders the available version", () => {
   const html = renderToStaticMarkup(
@@ -68,9 +43,9 @@ test("UpdateBanner calls the dismiss handler when Later is clicked", () => {
     viewProps: { version: "0.5.0", canAutoInstall: true },
     handlers: { onDismiss: () => { dismissed = true; } },
   });
-  const laterBtn = findByClassName(element, "update-banner-dismiss-btn");
+  const laterBtn = findElement(element, (el) => (el.props as { className?: string }).className === "update-banner-dismiss-btn");
   assert.ok(laterBtn, "expected a Later button");
-  laterBtn!.props.onClick?.();
+  (laterBtn.props as { onClick?: () => void }).onClick?.();
   assert.equal(dismissed, true);
 });
 
@@ -80,8 +55,8 @@ test("UpdateBanner calls the install handler when Install is clicked", () => {
     viewProps: { version: "0.5.0", canAutoInstall: true },
     handlers: { onInstall: () => { installed = true; } },
   });
-  const installBtn = findByClassName(element, "update-banner-install-btn");
+  const installBtn = findElement(element, (el) => (el.props as { className?: string }).className === "update-banner-install-btn");
   assert.ok(installBtn, "expected an Install button");
-  installBtn!.props.onClick?.();
+  (installBtn.props as { onClick?: () => void }).onClick?.();
   assert.equal(installed, true);
 });

--- a/services/api/scripts/migrate.ts
+++ b/services/api/scripts/migrate.ts
@@ -1,7 +1,47 @@
 import "dotenv/config";
 import fs from "node:fs/promises";
 import path from "node:path";
+import Database from "better-sqlite3";
 import { createClient } from "@libsql/client";
+
+const MIGRATIONS_DIR = path.join(__dirname, "..", "migrations");
+
+/**
+ * Records which migrations have run, so each is applied exactly once.
+ *
+ * Without it, re-running the script re-executes every file. `002` is
+ * `CREATE TABLE IF NOT EXISTS` and shrugs that off, but `003` rebuilds
+ * `saved_bands` by copying every row — unconditionally, on every run, growing
+ * with the data.
+ */
+const LEDGER_DDL = "CREATE TABLE IF NOT EXISTS schema_migrations (filename TEXT PRIMARY KEY, applied_at TEXT NOT NULL);";
+
+async function migrationFiles(): Promise<string[]> {
+  const files = await fs.readdir(MIGRATIONS_DIR);
+  return files.filter((f) => f.endsWith(".sql")).sort();
+}
+
+/** Applies the pending migrations through whichever backend the caller drives. */
+async function applyPending(backend: {
+  label: string;
+  executeMultiple: (sql: string) => Promise<void>;
+  appliedFilenames: () => Promise<Set<string>>;
+  recordApplied: (filename: string) => Promise<void>;
+}): Promise<void> {
+  await backend.executeMultiple(LEDGER_DDL);
+  const applied = await backend.appliedFilenames();
+
+  let ran = 0;
+  for (const file of await migrationFiles()) {
+    if (applied.has(file)) continue;
+    const sql = await fs.readFile(path.join(MIGRATIONS_DIR, file), "utf8");
+    await backend.executeMultiple(sql);
+    await backend.recordApplied(file);
+    console.log(`Migration applied (${backend.label}): ${file}`);
+    ran += 1;
+  }
+  if (ran === 0) console.log(`No pending migrations (${backend.label}).`);
+}
 
 async function migrateTurso(): Promise<void> {
   const databaseUrl = process.env.TURSO_DATABASE_URL;
@@ -9,38 +49,62 @@ async function migrateTurso(): Promise<void> {
     throw new Error("TURSO_DATABASE_URL is required to run Turso migrations");
   }
 
-  const client = createClient({
-    url: databaseUrl,
-    authToken: process.env.TURSO_AUTH_TOKEN ?? "",
-  });
-
-  // Every .sql in the folder, in filename order. Listing them here instead
-  // would mean editing this file for each new migration and forgetting to.
-  const migrationsDir = path.join(__dirname, "..", "migrations");
-  const files = (await fs.readdir(migrationsDir)).filter((f) => f.endsWith(".sql")).sort();
-
+  const client = createClient({ url: databaseUrl, authToken: process.env.TURSO_AUTH_TOKEN ?? "" });
   try {
-    for (const file of files) {
-      const sql = await fs.readFile(path.join(migrationsDir, file), "utf8");
-      await client.executeMultiple(sql);
-      console.log(`Migration applied: ${file}`);
-    }
+    await applyPending({
+      label: "turso",
+      executeMultiple: (sql) => client.executeMultiple(sql),
+      appliedFilenames: async () => {
+        const result = await client.execute("SELECT filename FROM schema_migrations");
+        return new Set(result.rows.map((r) => String(r.filename)));
+      },
+      recordApplied: async (filename) => {
+        await client.execute({
+          sql: "INSERT INTO schema_migrations (filename, applied_at) VALUES (?, ?)",
+          args: [filename, new Date().toISOString()],
+        });
+      },
+    });
   } finally {
     client.close();
   }
 }
 
-// Turso is the only backend that needs a migration run: SQLite creates its own
-// schema in createPreferenceRepository, and the Postgres adapter was removed.
+/**
+ * SQLite needs migrations too, despite creating its tables at boot.
+ *
+ * `createPreferenceRepository` uses `CREATE TABLE IF NOT EXISTS`, which is a
+ * no-op against a database that already exists — so a schema change that alters
+ * an existing column (like making `rating` nullable) never reaches it. That is
+ * how #164 would have shipped working only on fresh databases.
+ */
+async function migrateSqlite(): Promise<void> {
+  const databasePath = process.env.SQLITE_DATABASE_PATH || "bandsearch.db";
+  const db = new Database(databasePath);
+  try {
+    await applyPending({
+      label: `sqlite:${databasePath}`,
+      executeMultiple: async (sql) => { db.exec(sql); },
+      appliedFilenames: async () =>
+        new Set((db.prepare("SELECT filename FROM schema_migrations").all() as { filename: string }[]).map((r) => r.filename)),
+      recordApplied: async (filename) => {
+        db.prepare("INSERT INTO schema_migrations (filename, applied_at) VALUES (?, ?)").run(filename, new Date().toISOString());
+      },
+    });
+  } finally {
+    db.close();
+  }
+}
+
 async function runMigrations(): Promise<void> {
   if (process.env.PREFERENCE_STORE === "postgres" || process.env.DATABASE_URL) {
     throw new Error(
       "Postgres migrations were removed along with the Postgres adapter. "
-      + "Set TURSO_DATABASE_URL and run `npm run migrate:turso`, or use the SQLite "
-      + "default, which needs no migration step.",
+      + "Set TURSO_DATABASE_URL and run `npm run migrate:turso`, or run without it for SQLite.",
     );
   }
-  await migrateTurso();
+  if (process.env.TURSO_DATABASE_URL) await migrateTurso();
+  else await migrateSqlite();
 }
 
 runMigrations().catch((error: Error) => {

--- a/services/api/src/savedBandContext.ts
+++ b/services/api/src/savedBandContext.ts
@@ -6,6 +6,8 @@
 // it belongs next to the recommendation pipeline that consumes it. Adapters are
 // left with plain CRUD, and there is one place to change the prompt format.
 
+import { formatRatingForPrompt } from "../../../shared/schemas/src/contracts.js";
+
 export type SavedBandForContext = {
   id: string;
   name: string;
@@ -21,14 +23,8 @@ export type SavedBandContextSource = {
 
 export function formatSavedBandContextLine(band: SavedBandForContext): string {
   // An unrated band is still a signal — the user chose to keep it — so it stays
-  // in the context. What it must not do is claim a rating: interpolating null
-  // would emit "rating null/5", and a 0 would read as a strong dislike the user
-  // never expressed.
-  const judgement =
-    band.rating === null || band.rating === undefined
-      ? "not yet rated"
-      : `rating ${band.rating}/5`;
-  return `${band.name} (${judgement}) tags: ${band.categories.join(", ")} note: ${band.note}`;
+  // in the context, stating only that no judgement was given.
+  return `${band.name} (${formatRatingForPrompt(band.rating)}) tags: ${band.categories.join(", ")} note: ${band.note}`;
 }
 
 export type SavedBandContextOptions = {

--- a/shared/schemas/src/contracts.ts
+++ b/shared/schemas/src/contracts.ts
@@ -191,3 +191,16 @@ export function validateRecommendationHttpBody(body: unknown): ValidatedRecommen
     obscurityTarget: validateObscurityTarget(b.obscurityTarget),
   };
 }
+
+/**
+ * How a saved band's rating is stated to the model.
+ *
+ * Shared because two call sites format saved bands for a prompt — the API's
+ * preference context and the desktop's priority-style-reference line — and they
+ * drifted: one said "not yet rated" while the other interpolated the absence
+ * straight in as "rating null/5". A missing judgement must never be reported as
+ * a number: 0 reads as a strong dislike the user never expressed.
+ */
+export function formatRatingForPrompt(rating: number | null | undefined): string {
+  return rating == null ? "not yet rated" : `rating ${rating}/5`;
+}


### PR DESCRIPTION
Follow-up to #169, which merged before this landed. **Two of these are defects in code #169 shipped**, not style cleanup — worth looking at before the next release.

## The rating fix reached only one of two prompt formatters

`savedBandContext.ts` was carefully changed to emit `not yet rated`. `buildPriorityContext` in `bootstrapDesktopApp.ts` does the same job on the desktop side and still did:

```ts
`${b.name} (rating ${b.rating}/5)`
```

With `rating` now `number | null`, that writes the literal string **`rating null/5`** into the Gemini prompt — for exactly the unrated bands #164 made possible. I fixed the formatter I went looking for and never checked whether there was a second one.

The rule now lives in one exported `formatRatingForPrompt`, called from both, so there is no third place to miss.

## The migration could not reach SQLite at all

`migrate.ts` only ever ran Turso, on the reasoning that SQLite builds its schema at boot. That is true for `CREATE TABLE IF NOT EXISTS` and false for altering an existing column — so an existing `bandsearch.db` would have kept `rating INTEGER NOT NULL CHECK (…)` **forever**. #164 worked only against a fresh database or Turso, and the script's own error message still told the user SQLite "needs no migration step".

There is now a SQLite migration path, plus a `schema_migrations` ledger so each file runs exactly once — without one, every invocation re-executed `003`, which copies the entire `saved_bands` table.

Verified against a database built with the old constraint:

```
Bestandszeile erhalten:      {"name":"Codeine","rating":4}
unbewertet einfuegbar:       {"name":"Bedhead","rating":null}
Bereichspruefung greift:     CHECK constraint failed: rating IS NULL
```

## Smaller real fixes

- **The retry button had no in-flight guard.** `root.render` commits asynchronously, so a double click started a second polling loop — 30 requests instead of 15, both writing the same state.
- `finishConnecting` mounted from two mutually exclusive branches; the early return existed only to choose which line ran before the same `mount()`.
- `buffered` in the update controller only ever held a copy of `current`.
- An unused `elapsedMs`, a Rust test asserting one claim in two spellings, and `reactApp?.mount()` optional chaining on a `const` that cannot be undefined.

## Duplication I created and then removed

Earlier in the same session I extracted `routedViewOf` into `test/helpers/fakeDom.ts` and counted it as an improvement — then wrote **two more** React tree-walkers inline in test files (`findByClassName`, `findButton`). Merged into one `findElement` in the helper that already existed for this.

## Deliberately not here

Each is a real finding from the same review, and none belongs in this PR — filed separately: the design palette copied across eight view files (the copies have already drifted), `createHashRouter`'s two parallel route tables, `navigate()` not notifying its own subscribers (19 call sites compensate by hand), and the two duplicate row mappers.

## Testing

`npm run ci` green: **343** / **689** / 16 / 28. `cargo test` 23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiphXDP4gVnxirBQw9YnPC