### PR TITLE
fix(api): saving an unrated band 500s on Turso (regression from #164)

### DIFF
--- a/services/api/src/preferences/tursoPreferenceRepository.ts
+++ b/services/api/src/preferences/tursoPreferenceRepository.ts
@@ -49,7 +49,9 @@ export function createTursoPreferenceRepository({ client }: { client: TursoClien
                 (id, user_id, musicbrainz_artist_id, name, rating, categories, note, created_at, updated_at)
               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
               RETURNING *`,
-        args: [id, userId, musicbrainzArtistId, name, bandInput.rating, categories, note, now, now],
+        // ?? null, not raw: libSQL rejects undefined outright, where SQLite
+        // would have coerced it. An omitted rating is legal (CONTEXT.md).
+        args: [id, userId, musicbrainzArtistId, name, bandInput.rating ?? null, categories, note, now, now],
       });
 
       return { ok: true, savedBand: mapRowToSavedBand(result.rows[0]) };

--- a/services/api/test/helpers/sqliteBackedTursoClient.ts
+++ b/services/api/test/helpers/sqliteBackedTursoClient.ts
@@ -51,6 +51,13 @@ export function createPreferenceTestDb(): Database.Database {
 
 /** better-sqlite3 binds numbers and strings; libSQL also accepts booleans and Dates. */
 function toBindable(value: TursoValue): string | number | bigint | null | Uint8Array {
+  // libSQL rejects undefined with "Unsupported type of value"; better-sqlite3
+  // quietly turns it into NULL. Left permissive, this double would accept an
+  // adapter bug that 500s against a real Turso database — which is exactly what
+  // it did for an omitted rating.
+  if (value === undefined) {
+    throw new TypeError("Unsupported type of value: undefined (libSQL rejects it; bind null instead)");
+  }
   if (typeof value === "boolean") return value ? 1 : 0;
   if (value instanceof Date) return value.toISOString();
   return value;


### PR DESCRIPTION
**A regression #164 shipped, on the production backend only.**

## The bug

#164 made an omitted rating legal and added `?? null` when binding it — to the SQLite and in-memory adapters. The Turso adapter was missed:

```ts
// tursoPreferenceRepository.ts, before
args: [id, userId, musicbrainzArtistId, name, bandInput.rating, categories, note, now, now],
```

libSQL rejects `undefined` outright (`TypeError: Unsupported type of value`) where better-sqlite3 coerces it to NULL. So `POST /preferences` without a rating — exactly the case #164 legalised — returns a 500 on Turso, and `render.yaml` sets `PREFERENCE_STORE=turso`.

Nobody has hit it because the desktop Save button only started omitting the rating in the same PR, and Phase 9.5 has never been run.

## Why the contract suite missed it

This is the more useful half. The shared contract exists so all three adapters prove the same behaviour, and it had a passing test called *"a band can be saved with no rating at all"* — for Turso too.

It passed because **the test double was more permissive than the real client**. `toBindable` in `sqliteBackedTursoClient.ts` returned `undefined` unchanged, and better-sqlite3 quietly stored NULL. The adapter looked like it handled a case it would have thrown on.

The double now rejects `undefined` the way libSQL does. That change alone turned the existing test red for Turso — which is how this should have surfaced originally — and the `?? null` makes it green again. It now guards every Turso binding in the suite, not just this one.

## Testing

`npm run ci` green: 343 / **689** / 16 / 28. No new test was needed; the existing contract test does the work once the double stops lying.

## Note

Found by a spec-conformance review over `origin/main...staging`. The same review found that **ADR 0002 was written but never implemented** — `CONTEXT.md` states the rule in the present tense as though it were shipped behaviour. That is a separate issue (#166 tracks the implementation) and is not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiphXDP4gVnxirBQw9YnPC