### PR TITLE
fix: stop the specs asserting behaviour the code does not have

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,13 @@ any UI change. Read them before touching a view, and follow the values marked
   implementation should differ from the spec, update the spec — never leave the
   two disagreeing. A code change that silently deviates is a bug even when the
   new behaviour is better.
+- **A spec written ahead of the code must say so.** Designing before building is
+  fine and often right, but the document must then mark the part that is not
+  built yet and link the issue tracking it. Otherwise the spec asserts behaviour
+  the product does not have, and the next reader — human or agent — takes it as
+  description rather than intent. This bit twice on 2026-08-30: the card action
+  row and ADR 0002 both stated future behaviour in the present tense, and
+  `CONTEXT.md` repeated one of them as fact.
 - **Tests assert the spec, not the implementation.** A test written to match
   whatever the code happens to do will lock a spec violation in place and defend
   it against correction. That is worse than having no test.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -28,7 +28,9 @@ AI-powered music recommendations for niche and lesser-known artists. Combines co
 
 - **Artist group** — a named collection of saved bands, with its own identity, used to browse and organise a collection. A group **does not influence recommendations**; it never reaches the preference context. The rule of thumb: a category says something about a band's character, a group says where the user filed it.
 
-- **Note** — free text on a saved band. Only a note the user has actually written or edited counts as their own preference signal and reaches the recommendation prompt. A note left at the value the system pre-filled — the model's own explanation of why it recommended the artist — stays visible to the user but is kept out of the prompt, so the model cannot read its own words back as if the user had said them. See ADR 0002.
+- **Note** — free text on a saved band. It is pre-filled with the model's own explanation of why it recommended the artist, and the user can edit it.
+
+  **Decided but not yet built (ADR 0002, tracked in #166):** only a note the user has actually written or edited *should* count as their own preference signal and reach the recommendation prompt; one left at its pre-filled value *should* stay visible but out of the prompt, so the model cannot read its own words back as if the user had said them. **Today every note reaches the prompt regardless of who wrote it.** Stated here in the conditional deliberately: this entry described the intended rule in the present tense for a while, which made the glossary assert behaviour the code does not have.
 
 - **Obscurity target** — a user-selectable signal (`Cult Following` / `Underground` / `Truly Obscure`) passed to the planner to tune search queries toward less or more obscure artists. Stored per recommendation event.
 

--- a/apps/desktop/src/ui/ConnectingView.ts
+++ b/apps/desktop/src/ui/ConnectingView.ts
@@ -52,14 +52,14 @@ export function ConnectingView({
     React.createElement(
       "h1",
       { style: { fontSize: "15px", fontWeight: 700, letterSpacing: "-0.01em" } },
-      waiting ? "Starting the server" : "Could not reach the server",
+      waiting ? (longWait ? "Still starting…" : "Starting the server") : "Could not reach the server",
     ),
     React.createElement(
       "p",
       { style: { fontSize: "13px", color: palette.textSecondary, maxWidth: "36ch", lineHeight: 1.5 } },
       waiting
         ? longWait
-          ? "Still starting. A server that has been idle can take up to a minute to wake up."
+          ? "A server that has been idle can take up to a minute to wake up."
           : "This can take a moment if the server has been idle."
         : "The server did not respond. Check your connection, or the API endpoint in Settings.",
     ),

--- a/apps/desktop/test/connecting-view.test.ts
+++ b/apps/desktop/test/connecting-view.test.ts
@@ -22,12 +22,16 @@ test("while waiting, no retry button is offered", () => {
   assert.equal(render({ state: "waiting", attempt: 3 }).includes("<button"), false);
 });
 
-test("a long wait is acknowledged rather than looking hung", () => {
+test("a long wait changes the heading, per the locked spec", () => {
+  // UI_GUIDELINES.md locks the Heading column: "Starting the server" while
+  // waiting, "Still starting…" from the fourth attempt. The first version of
+  // this test only checked for /still/i anywhere in the markup, which the body
+  // paragraph satisfied — so it passed while the heading never changed.
   const early = render({ state: "waiting", attempt: 1 });
   const late = render({ state: "waiting", attempt: 6 });
 
-  assert.notEqual(early, late, "the screen must change as attempts pile up");
-  assert.match(late, /still/i);
+  assert.match(early, /<h1[^>]*>Starting the server<\/h1>/);
+  assert.match(late, /<h1[^>]*>Still starting/);
 });
 
 test("giving up offers a way to try again", () => {

--- a/docs/adr/0002-machine-written-notes-stay-out-of-the-prompt.md
+++ b/docs/adr/0002-machine-written-notes-stay-out-of-the-prompt.md
@@ -1,7 +1,11 @@
 # ADR 0002 — Machine-written notes stay out of the recommendation prompt
 
-**Status:** Accepted
+**Status:** Accepted — **not yet implemented**, tracked in #166
 **Date:** 2026-08-30
+
+> The decision below stands; the code does not do it yet. Every note still
+> reaches the prompt regardless of who wrote it. Read "does" in the Decision
+> section as "will".
 
 ## Context
 

--- a/docs/design/UI_EXAMPLES.md
+++ b/docs/design/UI_EXAMPLES.md
@@ -11,6 +11,7 @@ This file provides practical examples that translate `UI_GUIDELINES.md` into imp
 - "Why selected" is concise and specific.
 - Country/genres are short metadata lines.
 - Connection text references prior bands in plain language.
+- *(Not yet built — see the note in UI_GUIDELINES.md. The shipped card still shows Save / Rate / ···.)*
 - Rating stars and Save are always visible, on every screen size; Category/Note are compact actions.
 - Tapping a star saves the band with that rating — rating implies saving.
 - Saving does not imply rating: Save alone keeps a band unrated, which is a real state.

--- a/docs/design/UI_GUIDELINES.md
+++ b/docs/design/UI_GUIDELINES.md
@@ -143,6 +143,11 @@ Card visual spec:
 
 Action row policy (locked, all viewports):
 
+> **Not yet built.** The card still renders the old `Save` / `Rate` / `···` text
+> buttons. This section is the target, not a description of the shipped UI —
+> tracked in #151, #152, #154 and #165. `rating` being optional (#164) is done;
+> the controls below are not.
+
 | Control | Visibility | Behaviour |
 |---|---|---|
 | Rating stars (1–5) | Always | Tapping star *n* saves the band **with rating *n***. Tapping the currently active star clears the rating — the band stays saved, now unrated. |


### PR DESCRIPTION
Follow-up to the spec-conformance review of `origin/main...staging`.

## The problem

Three documents written today describe **unbuilt** work in the present tense, so a reader — human or agent — takes intent for description:

| Document | Says | Reality |
|---|---|---|
| `CONTEXT.md` | notes left pre-filled "**are kept out of the prompt**" | every note still reaches it |
| `docs/adr/0002-*.md` | Status: **Accepted**, no implementation note | nothing implements it (#166) |
| `UI_GUIDELINES.md` | card row = stars + Save toggle | card still renders Save / Rate / ··· |

The glossary case is the worst of the three: `CONTEXT.md` is the shared vocabulary, and it asserted a privacy-relevant rule as shipped behaviour.

All three are now marked as decided-but-not-built, with their tracking issues linked.

## The rule had a gap

`AGENTS.md` already required that a design change updates the spec **in the same PR** — which is exactly what happened. The gap is that a spec written *ahead* of the code says nothing about not being built yet, and the rule never covered that direction.

Added: designing before building is fine and often right, but the document must then mark the unbuilt part and link the issue tracking it.

## One real deviation from a locked value

`UI_GUIDELINES.md` locks the connecting screen's heading to `"Still starting…"` from the fourth attempt. `ConnectingView` only changed its paragraph; the heading stayed `"Starting the server"` forever.

The test did not catch it because it asserted `/still/i` **anywhere in the markup** — which the paragraph satisfied. That is a test written against the implementation rather than the spec, which `AGENTS.md` forbids for precisely this reason, and I wrote it earlier today while adding that very rule.

It now asserts the heading element itself, and the paragraph no longer repeats the word.

## Testing

`npm run ci` green: 343 / 689 / 16 / 28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiphXDP4gVnxirBQw9YnPC