### PR TITLE
fix(desktop): wire up GDPR export and account deletion (#175)

### DIFF
--- a/apps/desktop/src/authApiClient.ts
+++ b/apps/desktop/src/authApiClient.ts
@@ -29,6 +29,10 @@ export type ResetPasswordResult =
   | { ok: true; newRecoveryCode: string }
   | { ok: false; error: string };
 
+export type ExportAccountDataResult =
+  | { ok: true; bundle: Record<string, unknown> }
+  | { ok: false; error: string };
+
 export type DeleteAccountResult =
   | { ok: true; erased: Record<string, number> }
   | { ok: false; error: string };
@@ -38,6 +42,7 @@ export type AuthApiClient = {
   register(input: { email: string; displayName: string; password: string }): Promise<RegisterResult>;
   login(input: { email: string; password: string }): Promise<LoginResult>;
   resetPassword(input: { email: string; recoveryCode: string; newPassword: string }): Promise<ResetPasswordResult>;
+  exportAccountData(): Promise<ExportAccountDataResult>;
   deleteAccount(input: { password: string }): Promise<DeleteAccountResult>;
 };
 
@@ -107,6 +112,22 @@ export function createAuthApiClient({
       const { ok, data } = await post("/auth/reset-password", { email, recoveryCode, newPassword });
       if (!ok) return { ok: false, error: extractError(data, "reset failed") };
       return { ok: true, newRecoveryCode: data.newRecoveryCode as string };
+    },
+
+    async exportAccountData(): Promise<ExportAccountDataResult> {
+      const headers: Record<string, string> = {};
+      const token = typeof getToken === "function" ? getToken() : null;
+      if (token) headers["authorization"] = `Bearer ${token}`;
+      try {
+        const res = await fetchImpl(`${base}/account/export`, { method: "GET", headers });
+        const data = (await res.json()) as Record<string, unknown>;
+        // A failed export must not be handed to the download path: the user
+        // would get a file named like their data containing an error body.
+        if (!res.ok) return { ok: false, error: extractError(data, "export failed") };
+        return { ok: true, bundle: data };
+      } catch {
+        return { ok: false, error: "could not reach the server" };
+      }
     },
 
     async deleteAccount({ password }): Promise<DeleteAccountResult> {

--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -3,7 +3,7 @@ import { createDesktopReactShell } from "./ui/createDesktopReactShell.js";
 import { createDesktopReactMount } from "./ui/mountDesktopReactApp.js";
 import type { DesktopReactMountOptions } from "./ui/mountDesktopReactApp.js";
 import type { ChatAppCollaborator } from "./chatAppModel.js";
-import type { ChatHandlers, UpdateBannerHandlers } from "./ui/viewTypes.js";
+import type { ChatHandlers } from "./ui/viewTypes.js";
 import { createDesktopChatUiStack } from "./desktopChatUiStack.js";
 import { bootstrapDesktopApp } from "./bootstrapDesktopApp.js";
 
@@ -54,67 +54,26 @@ function bootstrapDesktopReactShell({
   return shell;
 }
 
-export type BootstrapDesktopReactAppOptions = {
+/**
+ * Everything the mount takes, minus the shell it builds itself.
+ *
+ * Spelled as an Omit rather than a hand-written list: the list version had to be
+ * edited in three places for every new mount option — declare, destructure,
+ * forward — and a missed one failed silently, since the mount treats absent
+ * handlers as optional. That is how the account export and deletion handlers
+ * came to be declared and never passed (#175).
+ */
+export type BootstrapDesktopReactAppOptions = Omit<DesktopReactMountOptions, "shell"> & {
   app: DesktopAppCollaborator;
   viewport?: string;
   actionHandlers?: Record<string, unknown>;
-  router?: DesktopReactMountOptions["router"];
-  savedArtistsShell?: DesktopReactMountOptions["savedArtistsShell"];
-  getSettingsViewProps?: () => Promise<unknown>;
-  saveGeminiApiKey?: (apiKey: string) => Promise<void>;
-  saveBraveApiKey?: (apiKey: string) => Promise<void>;
-  saveTursoConfig?: (url: string, token: string) => Promise<void>;
-  clearTursoConfig?: () => Promise<void>;
-  saveApiEndpointUrl?: (url: string) => Promise<void>;
-  completeOnboarding?: () => Promise<void>;
-  onLogin?: (email: string, password: string) => Promise<void>;
-  onRegister?: (email: string, displayName: string, password: string) => Promise<{ recoveryCode: string }>;
-  onResetPassword?: (email: string, recoveryCode: string, newPassword: string) => Promise<{ newRecoveryCode: string }>;
-  updateBannerHandlers?: UpdateBannerHandlers;
-  connectingHandlers?: DesktopReactMountOptions["connectingHandlers"];
-  getConnectingViewProps?: DesktopReactMountOptions["getConnectingViewProps"];
 };
 
+
 function bootstrapDesktopReactApp(options: BootstrapDesktopReactAppOptions) {
-  const {
-    app,
-    viewport = "desktop",
-    actionHandlers = {},
-    router = null,
-    savedArtistsShell = null,
-    getSettingsViewProps,
-    saveGeminiApiKey,
-    saveBraveApiKey,
-    saveTursoConfig,
-    clearTursoConfig,
-    saveApiEndpointUrl,
-    completeOnboarding,
-    onLogin,
-    onRegister,
-    onResetPassword,
-    updateBannerHandlers,
-    connectingHandlers,
-    getConnectingViewProps,
-  } = options;
+  const { app, viewport = "desktop", actionHandlers = {}, ...mountOptions } = options;
   const shell = bootstrapDesktopReactShell({ app, viewport, actionHandlers });
-  const mountApi = createDesktopReactMount({
-    shell,
-    router,
-    savedArtistsShell,
-    getSettingsViewProps,
-    saveGeminiApiKey,
-    saveBraveApiKey,
-    saveTursoConfig,
-    clearTursoConfig,
-    saveApiEndpointUrl,
-    completeOnboarding,
-    onLogin,
-    onRegister,
-    onResetPassword,
-    updateBannerHandlers,
-    connectingHandlers,
-    getConnectingViewProps,
-  });
+  const mountApi = createDesktopReactMount({ shell, ...mountOptions });
   return {
     ...mountApi,
     desktopUi: shell.desktopUi,

--- a/apps/desktop/src/startDesktopBrowserApp.ts
+++ b/apps/desktop/src/startDesktopBrowserApp.ts
@@ -198,6 +198,12 @@ export async function startDesktopBrowserApp({
   const w = browserWindow();
   const initialHash = w && typeof w.location?.hash === "string" ? w.location.hash : "";
 
+  // Whether there is an account to export or delete. Read from the auth status
+  // the gate already fetches, so no extra round trip. SettingsView renders the
+  // deletion section as `!accountsEnabled ? null : …`, so leaving this unset
+  // hides it entirely — which is how #175 shipped.
+  let accountsEnabled = false;
+
   // Drives the connecting screen. Read by the mount each time it renders.
   let connectingViewProps: ConnectingViewProps = { state: "waiting" };
 
@@ -208,8 +214,13 @@ export async function startDesktopBrowserApp({
    * which is the part `waitForAuthStatus` alone could not provide: the gate runs
    * before `mount()`, so waiting there would show a blank window.
    */
+  function rememberAccountsEnabled(status: Awaited<ReturnType<typeof authClient.getAuthStatus>>): void {
+    accountsEnabled = status.reachable && status.enabled && status.userCount > 0;
+  }
+
   async function runAuthGate(): Promise<void> {
     const first = await authClient.getAuthStatus();
+    rememberAccountsEnabled(first);
     const route = decideAuthRoute({ status: first, hasToken: Boolean(getAuthToken()) });
     if (route === "unavailable") {
       connectingViewProps = { state: "waiting", attempt: 1 };
@@ -237,6 +248,7 @@ export async function startDesktopBrowserApp({
         void reactApp.mount();
       },
     });
+      rememberAccountsEnabled(status);
       const route = decideAuthRoute({ status, hasToken: Boolean(getAuthToken()) });
       if (route === "unavailable") {
         if (!status.reachable) console.warn("[bandsearch] API unreachable:", status.reason);
@@ -285,7 +297,18 @@ export async function startDesktopBrowserApp({
     actionHandlers,
     router,
     savedArtistsShell,
-    getSettingsViewProps: () => gemini.getSettingsViewProps(),
+    getSettingsViewProps: async () => ({ ...(await gemini.getSettingsViewProps()), accountsEnabled }),
+    onExportAccountData: async () => {
+      const result = await authClient.exportAccountData();
+      if (result.ok === false) throw new Error(result.error);
+      return result.bundle;
+    },
+    onDeleteAccount: async (password: string) => {
+      const result = await authClient.deleteAccount({ password });
+      if (result.ok === false) return { ok: false, error: result.error };
+      clearAuthToken();
+      return { ok: true };
+    },
     saveGeminiApiKey: (key: string) => gemini.saveGeminiApiKey(key),
     saveBraveApiKey: (key: string) => gemini.saveBraveApiKey(key),
     saveTursoConfig: (url: string, token: string) => gemini.saveTursoConfig(url, token),

--- a/apps/desktop/src/ui/SettingsView.ts
+++ b/apps/desktop/src/ui/SettingsView.ts
@@ -599,18 +599,23 @@ function PrivacyCard({
         },
         "Privacy policy",
       ),
-      React.createElement(
+      // Omitted rather than rendered inert when nothing can serve it — the
+      // locked rule in UI_GUIDELINES.md: "No control may render without an
+      // action behind it." A dead "Export my data" is worse than none, because
+      // the privacy policy points users at it.
+      !onExportAccountData ? null : React.createElement(
         "button",
         {
           type: "button",
           className: "export-account-btn",
-          onClick: () => onExportAccountData?.(),
+          onClick: () => onExportAccountData(),
           style: {
             backgroundColor: palette.buttonBg,
             color: palette.buttonText,
             border: `1px solid ${palette.buttonBorder}`,
             borderRadius: "7px",
-            padding: "7px 14px",
+            minHeight: "44px",
+            padding: "0 14px",
             fontSize: "12px",
           },
         },

--- a/apps/desktop/src/ui/mountDesktopReactApp.ts
+++ b/apps/desktop/src/ui/mountDesktopReactApp.ts
@@ -311,8 +311,11 @@ export function createDesktopReactMount({
       if (router) router.navigate("privacy");
       return renderCurrent();
     },
-    onExportAccountData: async () => {
-      if (!onExportAccountData) return;
+    // Left undefined when no collaborator was injected, rather than wrapped in a
+    // function that silently returns. A present-but-inert handler is exactly how
+    // #175 hid: the view could not tell the difference, so the button rendered
+    // and did nothing. Absent, the view omits the control instead.
+    onExportAccountData: !onExportAccountData ? undefined : async () => {
       // Same Blob + a.download path the saved-artists export already uses:
       // the Tauri webview blocks nothing here and it needs no new dependency.
       const bundle = await onExportAccountData();
@@ -324,8 +327,7 @@ export function createDesktopReactMount({
       a.click();
       URL.revokeObjectURL(url);
     },
-    onDeleteAccount: async (password: string) => {
-      if (!onDeleteAccount) return;
+    onDeleteAccount: !onDeleteAccount ? undefined : async (password: string) => {
       const result = await onDeleteAccount(password);
       if (!result.ok) return renderCurrent();
       // Erasing the only account puts the install back to zero users, which is

--- a/apps/desktop/src/ui/mountDesktopReactApp.ts
+++ b/apps/desktop/src/ui/mountDesktopReactApp.ts
@@ -211,7 +211,11 @@ export function createDesktopReactMount({
     }
 
     if (route === "settings") {
-      const viewProps = await Promise.resolve(getSettingsViewProps());
+      // Merged over the injected props so an account action can report itself.
+      // The supplier owns Gemini/Brave status; nothing owned the outcome of an
+      // export or a deletion, so both failed in silence.
+      const supplied = await Promise.resolve(getSettingsViewProps()) as Record<string, unknown>;
+      const viewProps = accountStatus ? { ...supplied, statusMessage: accountStatus } : supplied;
       renderRoot(
         React.createElement(SettingsView as unknown as ViewComponentLike, {
           viewProps,
@@ -318,7 +322,17 @@ export function createDesktopReactMount({
     onExportAccountData: !onExportAccountData ? undefined : async () => {
       // Same Blob + a.download path the saved-artists export already uses:
       // the Tauri webview blocks nothing here and it needs no new dependency.
-      const bundle = await onExportAccountData();
+      let bundle: Record<string, unknown>;
+      try {
+        bundle = await onExportAccountData();
+      } catch (error) {
+        // Previously this rejected into the click handler and surfaced as an
+        // uncaught page error — the user saw nothing at all, on a control the
+        // privacy policy points them at for Art. 15.
+        accountStatus = { type: "error", message: error instanceof Error ? error.message : "export failed" };
+        return renderCurrent();
+      }
+      accountStatus = null;
       const blob = new Blob([JSON.stringify(bundle, null, 2)], { type: "application/json" });
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
@@ -329,13 +343,22 @@ export function createDesktopReactMount({
     },
     onDeleteAccount: !onDeleteAccount ? undefined : async (password: string) => {
       const result = await onDeleteAccount(password);
-      if (!result.ok) return renderCurrent();
+      if (!result.ok) {
+        // A wrong password used to redraw the screen unchanged, which reads as
+        // "nothing happened" rather than "that password was wrong".
+        accountStatus = { type: "error", message: result.error ?? "account deletion failed" };
+        return renderCurrent();
+      }
+      accountStatus = null;
       // Erasing the only account puts the install back to zero users, which is
       // the first-run state — so send them where a fresh install starts.
       if (router) router.navigate("register");
       return renderCurrent();
     },
   };
+
+  // Outcome of the last export or deletion, shown in the privacy card.
+  let accountStatus: { type: "success" | "error"; message: string } | null = null;
 
   const privacyHandlers = {
     onBack: async () => {

--- a/apps/desktop/test/auth-api-client.test.ts
+++ b/apps/desktop/test/auth-api-client.test.ts
@@ -97,6 +97,54 @@ test("auth being genuinely disabled is reported as a reachable answer", async ()
   assert.deepEqual(await client.getAuthStatus(), { reachable: true, enabled: false, userCount: 0 });
 });
 
+// ------------------------------------------------------------ data export
+
+test("exporting account data asks the export endpoint", async () => {
+  const { fetchImpl, calls } = fakeFetch([jsonResponse({ savedBands: [], user: { id: "u1" } })]);
+  const client = createAuthApiClient({ apiBaseUrl: "http://localhost:3001", fetchImpl });
+
+  await client.exportAccountData();
+
+  assert.equal(calls[0].url, "http://localhost:3001/account/export");
+  assert.equal(calls[0].method, "GET");
+});
+
+test("the export is authenticated", async () => {
+  // The route answers for req.userId, so an unauthenticated call exports nothing.
+  const { fetchImpl, calls } = fakeFetch([jsonResponse({ savedBands: [] })]);
+  const client = createAuthApiClient({
+    apiBaseUrl: "http://localhost:3001",
+    fetchImpl,
+    getToken: () => "tok-123",
+  });
+
+  await client.exportAccountData();
+
+  assert.equal(calls[0].headers?.authorization, "Bearer tok-123");
+});
+
+test("the exported bundle is handed back as-is", async () => {
+  const bundle = { user: { id: "u1" }, savedBands: [{ id: "b1", name: "Codeine" }] };
+  const { fetchImpl } = fakeFetch([jsonResponse(bundle)]);
+  const client = createAuthApiClient({ apiBaseUrl: "http://localhost:3001", fetchImpl });
+
+  const result = await client.exportAccountData();
+
+  assert.deepEqual(result.ok === true && result.bundle, bundle);
+});
+
+test("a failed export says so rather than downloading an error body", async () => {
+  // Without this the user gets a JSON file containing the error, named as if it
+  // were their data.
+  const { fetchImpl } = fakeFetch([errorResponse(503, { error: { message: "account export is not available" } })]);
+  const client = createAuthApiClient({ apiBaseUrl: "http://localhost:3001", fetchImpl });
+
+  const result = await client.exportAccountData();
+
+  assert.equal(result.ok, false);
+  assert.equal(result.ok === false && result.error, "account export is not available");
+});
+
 // -------------------------------------------------------------- register
 
 test("register posts the credentials and returns the token and recovery code", async () => {

--- a/apps/desktop/test/settings-privacy-wiring.test.ts
+++ b/apps/desktop/test/settings-privacy-wiring.test.ts
@@ -1,0 +1,93 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { ReactElement } from "react";
+
+import { createDesktopReactMount } from "../src/ui/mountDesktopReactApp.js";
+import { fakeContainer, fakeReactRoot, routedViewOf } from "./helpers/fakeDom.js";
+
+/**
+ * Renders the settings route and hands back the props the view actually
+ * received.
+ *
+ * Every instance of this bug — the saved-artists screen, the ··· button (#151),
+ * account export and deletion (#175) — passed its tests because the view was fed
+ * a hand-written prop object while the mount's real handlers were incomplete.
+ * The views call handlers with `?.`, so a missing one is silent. Pairing the two
+ * is the only arrangement that catches it.
+ */
+async function renderSettings(
+  options: Record<string, unknown> = {},
+  viewProps: Record<string, unknown> = {},
+) {
+  type Rendered = ReactElement<{ viewProps: Record<string, unknown>; handlers: Record<string, unknown> }>;
+  let rendered: Rendered | undefined;
+
+  const mount = createDesktopReactMount({
+    shell: { getViewProps: () => ({}), updateMode: async () => {}, submitQuery: async () => {} },
+    router: { getRoute: () => "settings", navigate: () => {}, onRouteChange: () => {} },
+    getSettingsViewProps: async () => ({ headerTitle: "Settings", hasStoredKey: true, ...viewProps }),
+    createRootImpl: () => fakeReactRoot((element) => {
+      rendered = routedViewOf(element) as Rendered;
+    }),
+    resolveContainer: () => fakeContainer(),
+    ...options,
+  } as unknown as Parameters<typeof createDesktopReactMount>[0]);
+
+  await mount.mount();
+  if (!rendered) throw new Error("expected the settings screen to render");
+  return rendered.props;
+}
+
+test("with no collaborator injected, the screen gets no export handler at all", async () => {
+  // Not merely "the handler does nothing": absent, so the view omits the button.
+  // A present-but-inert handler is what let #175 ship — the view could not tell
+  // the difference, so "Export my data" rendered and silently did nothing while
+  // the privacy policy pointed users at it for Art. 15 and Art. 20.
+  const { handlers } = await renderSettings();
+
+  assert.equal(handlers.onExportAccountData, undefined);
+  assert.equal(handlers.onDeleteAccount, undefined);
+});
+
+test("with collaborators injected, the screen gets both handlers", async () => {
+  const { handlers } = await renderSettings({
+    onExportAccountData: async () => ({}),
+    onDeleteAccount: async () => ({ ok: true }),
+  });
+
+  assert.equal(typeof handlers.onExportAccountData, "function");
+  assert.equal(typeof handlers.onDeleteAccount, "function");
+});
+
+test("the export handler calls through to the injected collaborator", async () => {
+  let asked = 0;
+  const { handlers } = await renderSettings({
+    onExportAccountData: async () => { asked += 1; return { user: { id: "u1" } }; },
+  });
+
+  // The mount wraps the bundle in a Blob download, which needs a DOM the test
+  // has no reason to provide; what matters is that the collaborator is reached
+  // rather than the handler early-returning on an undefined option.
+  await (handlers.onExportAccountData as () => Promise<void>)().catch(() => {});
+
+  assert.equal(asked, 1);
+});
+
+test("the delete handler passes the password through", async () => {
+  const passwords: string[] = [];
+  const { handlers } = await renderSettings({
+    onDeleteAccount: async (password: string) => { passwords.push(password); return { ok: true }; },
+  });
+
+  await (handlers.onDeleteAccount as (p: string) => Promise<void>)("hunter2");
+
+  assert.deepEqual(passwords, ["hunter2"]);
+});
+
+test("the screen is told whether an account exists", async () => {
+  // SettingsView renders `!accountsEnabled ? null : dangerZone`, so an unset
+  // flag hides account deletion entirely — which is how it shipped.
+  const { viewProps } = await renderSettings({}, { accountsEnabled: true });
+
+  assert.equal(viewProps.accountsEnabled, true);
+});

--- a/apps/desktop/test/settings-privacy-wiring.test.ts
+++ b/apps/desktop/test/settings-privacy-wiring.test.ts
@@ -35,7 +35,15 @@ async function renderSettings(
 
   await mount.mount();
   if (!rendered) throw new Error("expected the settings screen to render");
-  return rendered.props;
+  return {
+    ...rendered.props,
+    /** Re-renders and returns the props the view gets the second time round. */
+    async rerender() {
+      await mount.mount();
+      if (!rendered) throw new Error("expected the settings screen to render");
+      return rendered.props;
+    },
+  };
 }
 
 test("with no collaborator injected, the screen gets no export handler at all", async () => {
@@ -90,4 +98,38 @@ test("the screen is told whether an account exists", async () => {
   const { viewProps } = await renderSettings({}, { accountsEnabled: true });
 
   assert.equal(viewProps.accountsEnabled, true);
+});
+
+test("a failed export tells the user instead of throwing into nothing", async () => {
+  // It used to reject into the click handler and surface as an uncaught page
+  // error. Playwright caught exactly that: `pageerror: account export is not
+  // available`, with nothing shown on screen — on a control the privacy policy
+  // points users at for Art. 15.
+  const screen = await renderSettings({
+    onExportAccountData: async () => { throw new Error("account export is not available"); },
+  });
+
+  await (screen.handlers.onExportAccountData as () => Promise<void>)();
+  const after = await screen.rerender();
+
+  assert.deepEqual(after.viewProps.statusMessage, {
+    type: "error",
+    message: "account export is not available",
+  });
+});
+
+test("a wrong password on deletion reports itself", async () => {
+  // Redrawing the screen unchanged reads as "nothing happened" rather than
+  // "that password was wrong".
+  const screen = await renderSettings({
+    onDeleteAccount: async () => ({ ok: false, error: "invalid credentials" }),
+  });
+
+  await (screen.handlers.onDeleteAccount as (p: string) => Promise<void>)("wrong");
+  const after = await screen.rerender();
+
+  assert.deepEqual(after.viewProps.statusMessage, {
+    type: "error",
+    message: "invalid credentials",
+  });
 });

--- a/apps/desktop/test/settings-view.test.ts
+++ b/apps/desktop/test/settings-view.test.ts
@@ -247,11 +247,26 @@ test("settings offers a link to the privacy policy", () => {
   assert.match(html, /Privacy policy/, "a way into the privacy policy is offered");
 });
 
-test("settings offers a way to export all account data", () => {
+test("settings offers a way to export all account data when something can serve it", () => {
+  // The handler is supplied deliberately. This test used to pass `baseHandlers`,
+  // which has none, and still asserted the button rendered — so it certified a
+  // control with nothing behind it, which is precisely how #175 shipped. The
+  // button is now omitted without a handler, per the locked rule in
+  // UI_GUIDELINES.md ("No control may render without an action behind it").
+  const html = renderToStaticMarkup(
+    React.createElement(SettingsView, {
+      viewProps: baseViewProps,
+      handlers: { ...baseHandlers, onExportAccountData: () => {} },
+    }),
+  );
+  assert.match(html, /Export my data/, "an Art. 15/20 export control is offered");
+});
+
+test("settings offers no export control when nothing can serve it", () => {
   const html = renderToStaticMarkup(
     React.createElement(SettingsView, { viewProps: baseViewProps, handlers: baseHandlers }),
   );
-  assert.match(html, /Export my data/, "an Art. 15/20 export control is offered");
+  assert.doesNotMatch(html, /Export my data/, "a dead control is worse than none");
 });
 
 test("choosing the privacy policy navigates to it", () => {

--- a/apps/desktop/test/start-desktop-browser-app.test.ts
+++ b/apps/desktop/test/start-desktop-browser-app.test.ts
@@ -296,3 +296,83 @@ test("a healthy API never shows the connecting screen", async () => {
   assert.equal(statusCalls, 1, "a healthy start must cost exactly one status check");
   assert.equal(routes.includes("connecting"), false, "no detour through connecting");
 });
+
+// --- GDPR export and deletion reach the UI (#175) ----------------------------
+
+/**
+ * Boots with one account present and hands back what the app passed into the
+ * mount. The privacy policy promises Art. 15/17/20 through Settings, so these
+ * handlers existing is a compliance claim, not a convenience.
+ */
+async function startWithAccount(overrides: { userCount?: number; enabled?: boolean } = {}) {
+  const { userCount = 1, enabled = true } = overrides;
+  let mountOptions: Record<string, unknown> = {};
+
+  await startDesktopBrowserApp({
+    invokeTauri: async (cmd) =>
+      cmd === "gemini_config_status" ? { hasStoredKey: true, onboardingComplete: true } : {},
+    updateDismissalStorage: fakeUpdateStorage(),
+    fetchImpl: async (url) => {
+      if (String(url).endsWith("/auth/status")) return jsonResponse({ enabled, userCount });
+      if (String(url).endsWith("/account/export")) return jsonResponse({ user: { id: "u1" }, savedBands: [] });
+      return jsonResponse({});
+    },
+    sleep: async () => {},
+    now: () => 0,
+    deps: {
+      bootstrapDesktopApp: (options) => bootstrapDesktopApp(options),
+      bootstrapDesktopReactApp: (options) => {
+        mountOptions = options as unknown as Record<string, unknown>;
+        return fakeReactApp({ mount: async () => ({}), showUpdateBanner: () => {} });
+      },
+    },
+  });
+
+  return mountOptions;
+}
+
+test("the app supplies an export handler, so 'Export my data' can work", async () => {
+  const options = await startWithAccount();
+
+  assert.equal(
+    typeof options.onExportAccountData,
+    "function",
+    "the privacy policy points users here for Art. 15 and Art. 20",
+  );
+});
+
+test("the app supplies a delete handler, so account deletion can work", async () => {
+  const options = await startWithAccount();
+
+  assert.equal(
+    typeof options.onDeleteAccount,
+    "function",
+    "the privacy policy points users here for Art. 17",
+  );
+});
+
+test("the export handler returns the bundle the API sent", async () => {
+  const options = await startWithAccount();
+
+  const bundle = await (options.onExportAccountData as () => Promise<Record<string, unknown>>)();
+
+  assert.deepEqual(bundle, { user: { id: "u1" }, savedBands: [] });
+});
+
+test("the settings screen is told an account exists, so the delete zone renders", async () => {
+  const options = await startWithAccount({ userCount: 1 });
+
+  const viewProps = await (options.getSettingsViewProps as () => Promise<{ accountsEnabled?: boolean }>)();
+
+  // SettingsView renders `!accountsEnabled ? null : dangerZone`, so leaving this
+  // undefined hides account deletion entirely.
+  assert.equal(viewProps.accountsEnabled, true);
+});
+
+test("with no account yet, the delete zone stays hidden", async () => {
+  const options = await startWithAccount({ userCount: 0 });
+
+  const viewProps = await (options.getSettingsViewProps as () => Promise<{ accountsEnabled?: boolean }>)();
+
+  assert.equal(viewProps.accountsEnabled, false, "nothing to delete before registering");
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -35,7 +35,16 @@ export default defineConfig({
       // Its own database: the suite registers a user, and that must not land in
       // the developer's bandsearch.db (where it would also change the auth-status
       // user count the desktop client routes on).
-      env: { PORT: String(E2E_API_PORT), DATABASE_PATH: E2E_DATABASE_PATH },
+      env: {
+        PORT: String(E2E_API_PORT),
+        DATABASE_PATH: E2E_DATABASE_PATH,
+        // Pinned, not inherited. server.ts loads dotenv, so without this the
+        // suite runs against whatever store the developer happens to have in
+        // .env — and PREFERENCE_STORE=memory disables account export by design,
+        // which made the GDPR specs fail for a reason that had nothing to do
+        // with the code under test.
+        PREFERENCE_STORE: "sqlite",
+      },
     },
     {
       command: "npx tsx tests/e2e/serve-frontend.ts",

--- a/tests/e2e/account-privacy.spec.ts
+++ b/tests/e2e/account-privacy.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test, type APIRequestContext, type Page } from "@playwright/test";
+import { readFile } from "node:fs/promises";
+import { AUTH_TOKEN_STORAGE_KEY, E2E_API_BASE_URL } from "./constants.js";
+
+/**
+ * Browser coverage for the GDPR controls in Settings.
+ *
+ * The unit suite proves every seam in the chain — the client calls the endpoint,
+ * the app passes the handler, the view receives it — and still could not prove
+ * the user gets a file. That gap is exactly how #175 shipped: each part was
+ * fine, nothing joined them, and the privacy policy promised Art. 15/20 anyway.
+ *
+ * These specs run the real API against a real SQLite database with a real
+ * registered user, so they exercise the whole path including the download the
+ * unit tests cannot reach.
+ *
+ * What they still do not cover: Tauri's webview. Playwright drives Chromium,
+ * which matches WebView2 on Windows but not WebKitGTK on Linux.
+ */
+async function seedArtist(page: Page, request: APIRequestContext, name: string) {
+  await page.goto("/");
+  const token = await page.evaluate((key) => localStorage.getItem(key), AUTH_TOKEN_STORAGE_KEY);
+  await request.post(`${E2E_API_BASE_URL}/preferences`, {
+    headers: { authorization: `Bearer ${token}` },
+    data: { musicbrainzArtistId: `mb-${name}`, name, categories: [], note: "" },
+  });
+}
+
+test("the settings screen offers the export control the privacy policy promises", async ({ page }) => {
+  await page.goto("/#/settings");
+
+  // Rendered only when a handler exists (UI_GUIDELINES: no control without an
+  // action behind it), so its presence proves the wiring, not just the markup.
+  await expect(page.locator("button:has-text('Export my data')")).toBeVisible();
+});
+
+test("exporting account data downloads a file", async ({ page }) => {
+  await page.goto("/#/settings");
+
+  const download = page.waitForEvent("download", { timeout: 15000 });
+  await page.click("button:has-text('Export my data')");
+
+  expect((await download).suggestedFilename()).toBe("bandsearch-account-data.json");
+});
+
+test("the exported file contains the user's own saved artists", async ({ page, request }) => {
+  await seedArtist(page, request, "Codeine");
+  await page.goto("/#/settings");
+
+  const download = page.waitForEvent("download", { timeout: 15000 });
+  await page.click("button:has-text('Export my data')");
+  const path = await (await download).path();
+  const bundle = JSON.parse(await readFile(path, "utf8")) as { savedBands?: { name: string }[] };
+
+  // Art. 15 is about the data actually being there, not about a file arriving.
+  expect(bundle.savedBands?.map((b) => b.name)).toContain("Codeine");
+});
+
+test("an unrated saved artist survives the export without gaining a rating", async ({ page, request }) => {
+  // #164 made an unrated band storable; #167 fixed Number(null) becoming 0 in
+  // this very export. A zero here would be a judgement the user never made,
+  // handed back to them as their own data.
+  await seedArtist(page, request, "Bedhead");
+  await page.goto("/#/settings");
+
+  const download = page.waitForEvent("download", { timeout: 15000 });
+  await page.click("button:has-text('Export my data')");
+  const path = await (await download).path();
+  const bundle = JSON.parse(await readFile(path, "utf8")) as { savedBands?: { name: string; rating: number | null }[] };
+
+  const bedhead = bundle.savedBands?.find((b) => b.name === "Bedhead");
+  expect(bedhead?.rating ?? null).toBeNull();
+});


### PR DESCRIPTION
Closes #175.

## The defect

The privacy policy shown inside the app promises both, citing the articles:

> "You can download everything held about you at any time from Settings → Privacy & data (\"Export my data\"). This covers your right of access (Art. 15) and portability (Art. 20)."
> "You can delete your account and all associated data from the same place."

Neither worked:

- `mountDesktopReactApp` declared `onExportAccountData` / `onDeleteAccount` and used them — **no caller ever passed them**, so the wrapper early-returned.
- `accountsEnabled` was never set, so `SettingsView`'s `!accountsEnabled ? null : dangerZone` hid account deletion **entirely**.

The API was fine throughout, with passing tests. Only the desktop wiring was missing.

## The fix

`authApiClient` gains `exportAccountData()` (GET `/account/export`, authenticated). It refuses to hand an error body to the download path — otherwise a 503 becomes a file named like the user's data containing the error. `startDesktopBrowserApp` passes both handlers and derives `accountsEnabled` from the auth status the gate already fetches, so no extra round trip.

## Why it was invisible — and the deeper fix

The mount wrapped each optional collaborator in a function that **silently returned** when it was absent. So the view could not tell "no handler" from "handler that does nothing", and rendered the button either way.

Handlers are now left `undefined` when nothing was injected, and `SettingsView` omits the control. That is what `UI_GUIDELINES.md` has said since this morning:

> No control may render without an action behind it.

This is the fourth instance of one pattern — the saved-artists screen, the `···` button (#151), and this. Architecture entry 7 in the roadmap already documented it.

## Three tests had certified the broken state

`settings-view.test.ts` asserted "Export my data" renders while passing a handler object that **has no export handler**. It proved the button existed, which was never the question. Rewritten to assert the contract both ways: present with a handler, absent without one.

New `settings-privacy-wiring.test.ts` pairs the mount's real handler object with the real view — the arrangement that would have caught all four instances.

**Verified by removing the new wiring again: three tests go red.** The previous suite stayed green through the entire defect.

## Also

`index.ts` collapses from a 19-option hand-written list to `Omit<DesktopReactMountOptions, "shell">` plus a spread. Adding a mount option meant editing three places there and a missed one failed silently — which is how these two handlers came to be declared and never forwarded. 132 lines → 91.

The export button moves to the locked 44px touch target.

## Testing

`npm run ci` green: **358** / 689 / 16 / 28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiphXDP4gVnxirBQw9YnPC