### PR TITLE
fix(deploy): prepare script broke the Render build

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test:e2e": "playwright test --grep-invert @live",
     "test:e2e:live": "playwright test",
     "ci": "npm run lint && npm run typecheck && npm run test",
-    "prepare": "husky"
+    "prepare": "husky || true"
   },
   "dependencies": {
     "tsx": "^4.23.12"

--- a/shared/schemas/test/render-config.test.ts
+++ b/shared/schemas/test/render-config.test.ts
@@ -58,3 +58,17 @@ test("render.yaml declares required secrets without hardcoding values", () => {
     assert.ok(re.test(renderYaml), `Expected ${key} declared with sync: false`);
   }
 });
+
+test("root prepare script tolerates a missing husky binary", () => {
+  // render.yaml sets NODE_ENV=production, which makes `npm install` skip
+  // devDependencies (husky included) — a bare `husky` prepare script then
+  // fails the whole build on Render. See github.com/typicode/husky/blob/main/docs/how-to.md
+  const pkg = JSON.parse(
+    readFileSync(resolve(__dirname, "../../../package.json"), "utf8"),
+  );
+  assert.equal(
+    pkg.scripts?.prepare,
+    "husky || true",
+    'Expected root package.json scripts.prepare = "husky || true"',
+  );
+});


### PR DESCRIPTION
## Summary
PR #184 fixed `render.yaml`'s health check path and branch, but got merged into `staging` before this second commit was pushed — so this fix never actually landed, even though `staging`→`main` (#185) already went out. This closes that gap.

Confirmed against a real Render build log: `NODE_ENV=production` (set in `render.yaml`) makes `npm install` skip devDependencies, so the root `prepare` script's bare `husky` invocation fails with `husky: not found`, and the whole build dies before it ever reaches app code. Husky's own docs recommend exactly this fix for this case.

## Changes
- `package.json`: `"prepare": "husky"` → `"prepare": "husky || true"`
- `shared/schemas/test/render-config.test.ts`: asserts the root `prepare` script tolerates a missing husky binary

## Test plan
- [x] `npm run ci` green
- [x] `sh -c "husky || true"` confirmed to exit 0 with the binary absent, matching Render's build environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019fH7pgEAnoPqHZDexU9p7y