### PR TITLE
chore(deps): re-pin allowScripts to versions already in the lockfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "typescript-eslint": "^8.62.1"
   },
   "allowScripts": {
-    "better-sqlite3@12.11.1": true,
-    "esbuild@0.28.1": true
+    "better-sqlite3@13.0.3": true,
+    "esbuild@0.28.2": true
   }
 }


### PR DESCRIPTION
## Summary
`better-sqlite3`/`esbuild` had moved past their pinned `allowScripts` entries — the lockfile already resolves `better-sqlite3` to `^13.0.3`, so a fresh `npm install` blocks their install scripts until the pins catch up. Re-approved via `npm install-scripts approve`.

## Test plan
- [x] `npm run ci` green
- [x] `npm install-scripts ls` reports nothing pending after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019fH7pgEAnoPqHZDexU9p7y