### PR TITLE
fix(desktop): platform links did nothing in browser dev mode

### DIFF
--- a/apps/desktop/src/openExternalLink.ts
+++ b/apps/desktop/src/openExternalLink.ts
@@ -11,20 +11,26 @@ function fallbackOpenUrl(url: string): void {
 /**
  * A plain `<a target="_blank">` click does nothing in the Tauri webview — there
  * is no browser tab for it to open. `@tauri-apps/plugin-opener` is the intended
- * replacement; outside a Tauri host (browser dev) it is absent, so window.open
- * is the fallback. Same require-and-catch shape as createDefaultTauriInvoke in
- * startDesktopBrowserApp.ts.
+ * replacement; outside a Tauri host (browser dev) window.open is the fallback.
+ *
+ * The require() alone succeeds even in browser dev — esbuild bundles the
+ * package regardless of whether a Tauri host answers it — so it cannot be the
+ * only thing guarded. openUrl() itself calls invoke() under the hood, which
+ * only fails once there is no IPC bridge to answer it, asynchronously. Both
+ * stages have to be caught, or browser dev silently does nothing.
  */
 export function resolveOpenUrl(
   loadOpener: () => { openUrl: OpenUrlFn } = () =>
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     require("@tauri-apps/plugin-opener") as { openUrl: OpenUrlFn },
 ): OpenUrlFn {
-  try {
-    return loadOpener().openUrl;
-  } catch {
-    return fallbackOpenUrl;
-  }
+  return async (url: string) => {
+    try {
+      await loadOpener().openUrl(url);
+    } catch {
+      fallbackOpenUrl(url);
+    }
+  };
 }
 
 export const openExternalLink: OpenUrlFn = (url) => resolveOpenUrl()(url);

--- a/apps/desktop/test/open-external-link.test.ts
+++ b/apps/desktop/test/open-external-link.test.ts
@@ -37,3 +37,28 @@ test("resolveOpenUrl falls back to window.open outside a Tauri host", () => {
     delete (globalThis as unknown as { window?: unknown }).window;
   }
 });
+
+test("resolveOpenUrl falls back to window.open when openUrl itself rejects (require succeeded, invoke had no host to answer it)", async () => {
+  const calls: Array<{ url: string; target?: string }> = [];
+  (globalThis as unknown as { window: unknown }).window = {
+    open: (url: string, target?: string) => {
+      calls.push({ url, target });
+    },
+  };
+
+  try {
+    const openUrl = resolveOpenUrl(() => ({
+      openUrl: async () => {
+        throw new Error("invoke() had no Tauri host to answer it");
+      },
+    }));
+
+    await openUrl("https://soundcloud.com/search?q=Fen");
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, "https://soundcloud.com/search?q=Fen");
+    assert.equal(calls[0].target, "_blank");
+  } finally {
+    delete (globalThis as unknown as { window?: unknown }).window;
+  }
+});


### PR DESCRIPTION
## Summary
Found while running an automated Playwright pass against the live Render deployment to verify the fixes from #189, in browser-dev mode (no Tauri host).

`resolveOpenUrl()`'s try/catch only guarded the synchronous `require("@tauri-apps/plugin-opener")` call. esbuild bundles the package regardless of whether a Tauri host actually answers it, so the require always succeeds — meaning the fallback to `window.open()` only ever triggered for a genuinely missing package, never for the real failure mode: `openUrl()` calling `invoke()` with no IPC bridge to answer it, which fails *asynchronously*, after the require already returned successfully. That rejection was never awaited or caught anywhere, so it surfaced as an unhandled promise rejection and did nothing visible.

This only affects browser-dev mode — the actual packaged desktop app runs in a real Tauri webview with a live IPC bridge, where the original fix should already work. But it's a real gap in the fallback path, and worth closing since browser dev is a documented, supported mode in this codebase.

## Verification context
Same Playwright pass confirmed the rest of the Phase 9.5 fixes end-to-end against the real Turso-backed Render deployment: query → 3 recommendation cards rendered → save → create group → full page reload (equivalent to an app restart) → chat history, saved artist, and group all still there. This link bug was the one gap.

## Changes
- `openExternalLink.ts`: `resolveOpenUrl` now wraps the entire attempt — loading the opener *and* calling `openUrl()` — in one try/catch, falling back to `window.open` on failure at either stage
- New test: falls back correctly when `openUrl()` itself rejects (require succeeds, invoke has no host to answer it) — the case the old code missed

## Test plan
- [x] `npm run ci` green (377 desktop tests, full monorepo)
- [x] `npm run build --workspace @bandsearch/desktop` succeeds
- [x] New test reproduces the gap red, passes green after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019fH7pgEAnoPqHZDexU9p7y