### PR TITLE
feat(desktop): card-action redesign — rating stars, Save/Saved toggle, Category/Note sheet

### DIFF
--- a/apps/desktop/src/bootstrapDesktopApp.ts
+++ b/apps/desktop/src/bootstrapDesktopApp.ts
@@ -71,6 +71,24 @@ export function bootstrapDesktopApp({
     return recommendations.find((item) => item.artist === artistName);
   }
 
+  // The same id saveBand sends the server, so a lookup against state.savedBands
+  // agrees with what actually got stored — matching by name instead let two
+  // different artists sharing a name collide, and missed a stale client cache
+  // entirely (#163).
+  function resolveMusicbrainzId(artistName: string): string {
+    const recommendation = findLatestRecommendationByName(artistName);
+    const mbFromCard =
+      recommendation?.musicbrainzArtistId && String(recommendation.musicbrainzArtistId).trim()
+        ? String(recommendation.musicbrainzArtistId).trim()
+        : null;
+    return mbFromCard || normalizeArtistId(artistName);
+  }
+
+  function findSavedBandByArtist(artistName: string): SavedBand | undefined {
+    const musicbrainzArtistId = resolveMusicbrainzId(artistName);
+    return state.savedBands.find((item) => item.musicbrainzArtistId === musicbrainzArtistId);
+  }
+
   function upsertSavedBand(savedBand: SavedBand) {
     const existingIndex = state.savedBands.findIndex((item) => item.id === savedBand.id);
     if (existingIndex >= 0) {
@@ -190,12 +208,8 @@ export function bootstrapDesktopApp({
     },
     async saveBand(artistName: string, options: { rating?: number; categories?: string[]; note?: string } = {}) {
       const recommendation = findLatestRecommendationByName(artistName);
-      const mbFromCard =
-        recommendation?.musicbrainzArtistId && String(recommendation.musicbrainzArtistId).trim()
-          ? String(recommendation.musicbrainzArtistId).trim()
-          : null;
       const payload = {
-        musicbrainzArtistId: mbFromCard || normalizeArtistId(artistName),
+        musicbrainzArtistId: resolveMusicbrainzId(artistName),
         name: artistName,
         // No rating unless the user gave one. This used to default to 3,
         // so every "just remember this" became a three-star judgement
@@ -204,16 +218,37 @@ export function bootstrapDesktopApp({
         categories: options.categories || [],
         note: options.note || recommendation?.why || "Saved from recommendation card.",
       };
+      // The server itself dedupes on (user, musicbrainzArtistId) (#163), so a
+      // repeat call updates the existing row rather than creating a second
+      // one — this just needs to hand back that same row, not skip the call.
       const result = await chatClient.createPreference(payload);
       upsertSavedBand(result.savedBand);
       return result.savedBand;
     },
-    async rateBand(artistName: string, rating = 5) {
-      let savedBand = state.savedBands.find((item) => item.name === artistName);
-      if (!savedBand) savedBand = await this.saveBand(artistName, { rating });
+    // Tapping a star implies saving (UI_GUIDELINES.md — "rating implies
+    // saving"); tapping the currently active star clears it via rating: null,
+    // which stays saved and only drops the judgement.
+    async rateBand(artistName: string, rating: number | null = 5) {
+      let savedBand = findSavedBandByArtist(artistName);
+      if (!savedBand) savedBand = await this.saveBand(artistName, rating != null ? { rating } : {});
       const result = await chatClient.updatePreference(savedBand.id, { rating });
       upsertSavedBand(result.savedBand);
       return result.savedBand;
+    },
+    // The ··· sheet's Category/Note edit. Editing implies saving, same as
+    // rating — an artist not yet saved gets created with these fields instead
+    // of failing for lack of a savedBandId.
+    async saveCategoryNote(
+      artistName: string,
+      savedBandId: string | null,
+      updates: { categories: string[]; note: string },
+    ) {
+      if (savedBandId) {
+        const result = await chatClient.updatePreference(savedBandId, updates);
+        upsertSavedBand(result.savedBand);
+        return result.savedBand;
+      }
+      return this.saveBand(artistName, updates);
     },
     async listSavedBands() {
       const bands = await chatClient.listPreferences();

--- a/apps/desktop/src/cardActionLogic.ts
+++ b/apps/desktop/src/cardActionLogic.ts
@@ -1,0 +1,20 @@
+// Pure decision logic behind the recommendation card's action row
+// (UI_GUIDELINES.md, "Action row policy"). Kept out of the JSX so it can be
+// tested directly instead of through a click simulation renderToStaticMarkup
+// cannot do anyway.
+
+/**
+ * Tapping star n sets the rating to n; tapping the currently active star
+ * clears it instead — "every write is reversible from the card."
+ */
+export function nextRatingForStarTap(currentRating: number | null, tappedStar: number): number | null {
+  return currentRating === tappedStar ? null : tappedStar;
+}
+
+/** Comma-separated category input, trimmed and with blanks dropped. */
+export function parseCategoriesInput(text: string): string[] {
+  return text
+    .split(",")
+    .map((c) => c.trim())
+    .filter(Boolean);
+}

--- a/apps/desktop/src/chatAppModel.ts
+++ b/apps/desktop/src/chatAppModel.ts
@@ -18,6 +18,9 @@ export type RenderableRecommendation = {
   saved: boolean;
   rating: number | null;
   savedBandId: string | null;
+  categories: string[];
+  note: string;
+  noteEdited: boolean;
 };
 
 export type ConversationMessage =
@@ -38,11 +41,24 @@ export type ChatAppCollaborator = {
   cancelSearch?(): void;
 };
 
+function findSavedBandForItem(item: RecommendationItem, savedBands: SavedBand[]): SavedBand | null {
+  // musicbrainzArtistId is the same id saveBand/rateBand key their own lookups
+  // on (#163) — matching by name here too let two different artists sharing a
+  // name show one's saved/rated state on the other's card. Not every card
+  // carries an mbid (e.g. a deterministic fallback), so name stays the
+  // fallback rather than the rule.
+  if (item.musicbrainzArtistId) {
+    const byId = savedBands.find((s) => s.musicbrainzArtistId === item.musicbrainzArtistId);
+    if (byId) return byId;
+  }
+  return savedBands.find((s) => s.name === item.artist) ?? null;
+}
+
 function toRenderableRecommendation(
   item: RecommendationItem,
   savedBands: SavedBand[],
 ): RenderableRecommendation {
-  const savedBand = savedBands.find((s) => s.name === item.artist) ?? null;
+  const savedBand = findSavedBandForItem(item, savedBands);
   return {
     title: item.artist,
     why: item.why || "",
@@ -54,6 +70,9 @@ function toRenderableRecommendation(
     saved: savedBand !== null,
     rating: savedBand?.rating ?? null,
     savedBandId: savedBand?.id ?? null,
+    categories: savedBand?.categories ?? [],
+    note: savedBand?.note ?? "",
+    noteEdited: savedBand?.noteEdited ?? false,
   };
 }
 

--- a/apps/desktop/src/chatRenderAdapter.ts
+++ b/apps/desktop/src/chatRenderAdapter.ts
@@ -7,7 +7,7 @@ const MODE_OPTIONS = [
   { value: "preference-aware", label: "Preference-aware" },
 ];
 
-function buildCardViewProps(card: RenderableRecommendation, isMobile: boolean) {
+function buildCardViewProps(card: RenderableRecommendation) {
   return {
     title: card.title,
     why: card.why,
@@ -18,16 +18,23 @@ function buildCardViewProps(card: RenderableRecommendation, isMobile: boolean) {
     imageUrl: card.imageUrl,
     saved: card.saved,
     rating: card.rating,
+    savedBandId: card.savedBandId,
+    categories: card.categories,
+    note: card.note,
+    noteEdited: card.noteEdited,
+    // Rating stars, Save/Saved, and the ··· overflow are primary controls
+    // that never collapse on any viewport (UI_GUIDELINES.md, "Action row
+    // policy" — #152 was this gated behind `!isMobile`).
     actions: {
-      save: { visible: !isMobile },
-      rate: { visible: !isMobile },
+      save: { visible: true },
+      rate: { visible: true },
       more: { visible: true },
     },
     platformLinks: buildPlatformLinks(card.title),
   };
 }
 
-function buildMessageViewProps(messages: ConversationMessage[], isMobile: boolean) {
+function buildMessageViewProps(messages: ConversationMessage[]) {
   return messages.map((msg) => {
     if (msg.role === "user") {
       return { id: msg.id, role: "user" as const, content: msg.content };
@@ -36,17 +43,17 @@ function buildMessageViewProps(messages: ConversationMessage[], isMobile: boolea
       id: msg.id,
       role: "assistant" as const,
       content: msg.content,
-      cards: msg.cards.map((card) => buildCardViewProps(card, isMobile)),
+      cards: msg.cards.map((card) => buildCardViewProps(card)),
     };
   });
 }
 
-function getLatestCards(conversation: ConversationMessage[] | null, isMobile: boolean) {
+function getLatestCards(conversation: ConversationMessage[] | null) {
   if (!conversation) return [];
   for (let i = conversation.length - 1; i >= 0; i--) {
     const msg = conversation[i];
     if (msg.role === "assistant" && msg.cards.length > 0) {
-      return msg.cards.map((card) => buildCardViewProps(card, isMobile));
+      return msg.cards.map((card) => buildCardViewProps(card));
     }
   }
   return [];
@@ -61,12 +68,11 @@ export type ChatViewProps = ReturnType<typeof buildViewProps> & {
 
 function buildViewProps(desktopUi: DesktopChatUiStack) {
   const viewport = desktopUi.getViewport();
-  const isMobile = viewport === "mobile";
   const conversation = desktopUi.getConversation();
   const loading = desktopUi.isLoading();
 
-  const messageViewProps = conversation ? buildMessageViewProps(conversation, isMobile) : null;
-  const cards = getLatestCards(conversation, isMobile);
+  const messageViewProps = conversation ? buildMessageViewProps(conversation) : null;
+  const cards = getLatestCards(conversation);
 
   return {
     headerTitle: "Bandsearch",

--- a/apps/desktop/src/domain.ts
+++ b/apps/desktop/src/domain.ts
@@ -36,6 +36,9 @@ export type SavedBand = {
   name: string;
   rating?: number | null;
   note?: string;
+  // False for a note still at its model-written default; only edited notes
+  // are the user's own input (ADR 0002 / #166).
+  noteEdited?: boolean;
   categories?: string[];
   musicbrainzArtistId?: string;
 };

--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -16,7 +16,13 @@ export { bootstrapDesktopApp };
  */
 type DesktopAppCollaborator = ChatAppCollaborator & {
   saveBand?(artistName: string): unknown;
-  rateBand?(artistName: string, rating?: number): unknown;
+  rateBand?(artistName: string, rating: number | null): unknown;
+  deleteSavedBand?(savedBandId: string): unknown;
+  saveCategoryNote?(
+    artistName: string,
+    savedBandId: string | null,
+    updates: { categories: string[]; note: string },
+  ): unknown;
 };
 
 function bootstrapDesktopUi(options: { app: DesktopAppCollaborator; viewport?: string }) {
@@ -41,8 +47,20 @@ function bootstrapDesktopReactShell({
   const renderAdapter = bootstrapDesktopRenderAdapter({ app, viewport });
   const mergedActionHandlers = {
     onSave: actionHandlers.onSave || ((artistName: string) => app.saveBand?.(artistName)),
-    onRate: actionHandlers.onRate || ((artistName: string) => app.rateBand?.(artistName, 5)),
-    onMore: actionHandlers.onMore || (() => {}),
+    // Forwards whatever rating the star row sent — no default here. A
+    // hardcoded fallback is exactly how "Rate" used to always write 5 (#153).
+    onRate:
+      actionHandlers.onRate || ((artistName: string, rating: number | null) => app.rateBand?.(artistName, rating)),
+    onUnsave:
+      actionHandlers.onUnsave
+      || ((savedBandId: string, artistName: string) => {
+        void artistName;
+        return app.deleteSavedBand?.(savedBandId);
+      }),
+    onSaveCategoryNote:
+      actionHandlers.onSaveCategoryNote
+      || ((artistName: string, savedBandId: string | null, updates: { categories: string[]; note: string }) =>
+        app.saveCategoryNote?.(artistName, savedBandId, updates)),
   };
   const shell = createDesktopReactShell({
     renderAdapter,

--- a/apps/desktop/src/startDesktopBrowserApp.ts
+++ b/apps/desktop/src/startDesktopBrowserApp.ts
@@ -96,8 +96,7 @@ function createDefaultUpdateDismissalStorage(): UpdateDismissalStorage {
 
 export type ActionHandlers = {
   onSave?: (artistName: string) => void;
-  onRate?: (artistName: string) => void;
-  onMore?: () => void;
+  onRate?: (artistName: string, rating: number | null) => void;
 };
 
 /**

--- a/apps/desktop/src/ui/ChatAppView.ts
+++ b/apps/desktop/src/ui/ChatAppView.ts
@@ -6,6 +6,7 @@ import { validateObscurityTarget } from "../../../../shared/schemas/src/contract
 import type { ObscurityTarget } from "../../../../shared/schemas/src/contracts.js";
 import { ObscurityTargetPicker } from "./ObscurityTargetPicker.js";
 import { FeedbackReactionBar } from "./FeedbackReactionBar.js";
+import { nextRatingForStarTap, parseCategoriesInput } from "../cardActionLogic.js";
 
 function getTheme(modeValue: string) {
   const isWarm = modeValue === "preference-aware";
@@ -124,7 +125,179 @@ function PlatformLinks({
   );
 }
 
-function renderCardActions(card: CardViewProps, theme: ReturnType<typeof getTheme>, handlers: ChatHandlers) {
+// UI_GUIDELINES.md, "Action row policy (locked, all viewports)": tapping star
+// n saves the band with rating n; tapping the active star clears it. Rating
+// implies saving — an unsaved artist gets created the moment a star is
+// tapped, same as the old Rate button, just with an actual value the user
+// chose instead of a hardcoded 5 (#153).
+function RatingStars({
+  rating,
+  theme,
+  onRate,
+}: {
+  rating: number | null;
+  theme: ReturnType<typeof getTheme>;
+  onRate: (rating: number | null) => void;
+}) {
+  return React.createElement(
+    "div",
+    { className: "rating-stars", style: { display: "flex", alignItems: "center" } },
+    [1, 2, 3, 4, 5].map((n) =>
+      React.createElement(
+        "button",
+        {
+          key: n,
+          type: "button",
+          className: "rating-star",
+          "aria-label": rating === n ? `Clear rating, currently ${n} of 5` : `Rate ${n} of 5`,
+          onClick: () => onRate(nextRatingForStarTap(rating, n)),
+          style: {
+            background: "transparent",
+            border: "none",
+            cursor: "pointer",
+            padding: "2px 1px",
+            fontSize: "14px",
+            lineHeight: 1,
+            color: rating !== null && n <= rating ? theme.accent : theme.textTertiary,
+          },
+        },
+        rating !== null && n <= rating ? "★" : "☆",
+      ),
+    ),
+  );
+}
+
+// The ··· overflow, behind Category/Note. UI_GUIDELINES.md: "Category shapes
+// what gets recommended... the distinction from an artist group — which does
+// not affect recommendations — is otherwise invisible," and a note stays
+// labelled as the model's own words until the user edits it (ADR 0002).
+function CategoryNoteSheet({
+  card,
+  theme,
+  onSave,
+  onClose,
+}: {
+  card: CardViewProps;
+  theme: ReturnType<typeof getTheme>;
+  onSave: (categories: string[], note: string) => void;
+  onClose: () => void;
+}) {
+  const [categoriesText, setCategoriesText] = React.useState(card.categories.join(", "));
+  const [note, setNote] = React.useState(card.note);
+  const isPrefilled = !card.noteEdited && card.note.length > 0;
+
+  const fieldLabelStyle: React.CSSProperties = {
+    display: "grid",
+    gap: "4px",
+    fontSize: "12px",
+    color: theme.textTertiary,
+  };
+  const fieldStyle = {
+    backgroundColor: theme.inputBg,
+    color: theme.textPrimary,
+    border: `1px solid ${theme.inputBorder}`,
+    borderRadius: "6px",
+    padding: "6px 10px",
+    fontSize: "13px",
+    fontFamily: "inherit",
+  };
+
+  return React.createElement(
+    "div",
+    {
+      className: "category-note-sheet",
+      style: {
+        marginTop: "8px",
+        padding: "10px",
+        border: `1px solid ${theme.border}`,
+        borderRadius: "8px",
+        backgroundColor: theme.pageBg,
+        display: "grid",
+        gap: "8px",
+      },
+    },
+    React.createElement(
+      "p",
+      { style: { fontSize: "12px", color: theme.textSecondary, margin: 0, lineHeight: 1.4 } },
+      "Category shapes what gets recommended next. An artist group is only for your own organizing — it does not affect recommendations.",
+    ),
+    React.createElement(
+      "label",
+      fieldLabelStyle,
+      "Category (comma-separated)",
+      React.createElement("input", {
+        type: "text",
+        value: categoriesText,
+        onChange: (event: React.ChangeEvent<HTMLInputElement>) => setCategoriesText(event.target.value),
+        style: fieldStyle,
+      }),
+    ),
+    React.createElement(
+      "label",
+      fieldLabelStyle,
+      "Note",
+      isPrefilled
+        ? React.createElement(
+            "span",
+            { style: { fontSize: "11px", fontStyle: "italic" } },
+            "AI-suggested — stays out of future recommendations until you edit it.",
+          )
+        : null,
+      React.createElement("textarea", {
+        value: note,
+        onChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => setNote(event.target.value),
+        rows: 3,
+        style: { ...fieldStyle, resize: "vertical" as const },
+      }),
+    ),
+    React.createElement(
+      "div",
+      { style: { display: "flex", gap: "8px", justifyContent: "flex-end" } },
+      React.createElement(
+        "button",
+        {
+          type: "button",
+          onClick: onClose,
+          style: {
+            background: "transparent",
+            border: `1px solid ${theme.border}`,
+            borderRadius: "6px",
+            color: theme.textSecondary,
+            fontSize: "12px",
+            padding: "5px 12px",
+            cursor: "pointer",
+          },
+        },
+        "Cancel",
+      ),
+      React.createElement(
+        "button",
+        {
+          type: "button",
+          onClick: () => onSave(parseCategoriesInput(categoriesText), note),
+          style: {
+            backgroundColor: theme.accent,
+            color: "#0a0d14",
+            border: "none",
+            borderRadius: "6px",
+            fontSize: "12px",
+            fontWeight: 600,
+            padding: "5px 12px",
+            cursor: "pointer",
+          },
+        },
+        "Save",
+      ),
+    ),
+  );
+}
+
+function renderCardActions(
+  card: CardViewProps,
+  theme: ReturnType<typeof getTheme>,
+  handlers: ChatHandlers,
+  onToggleSheet: () => void,
+) {
   const btnStyle = {
     backgroundColor: theme.buttonBg,
     color: theme.buttonText,
@@ -146,25 +319,45 @@ function renderCardActions(card: CardViewProps, theme: ReturnType<typeof getThem
     actions.push(
       React.createElement(
         "button",
-        { key: "save", type: "button", className: "action-btn", style: btnStyle, onClick: () => handlers.onSave(card.title) },
-        "Save",
+        {
+          key: "save",
+          type: "button",
+          className: "action-btn",
+          style: btnStyle,
+          // A toggle, not two states of the same write: unsaved -> saves
+          // without a rating; saved -> removes it. "Saved but not yet rated"
+          // stays a real state because this never implies a rating.
+          onClick: () =>
+            card.saved && card.savedBandId
+              ? handlers.onUnsave?.(card.savedBandId, card.title)
+              : handlers.onSave(card.title),
+        },
+        card.saved ? "Saved" : "Save",
       ),
     );
   }
   if (card.actions?.rate?.visible) {
     actions.push(
-      React.createElement(
-        "button",
-        { key: "rate", type: "button", className: "action-btn", style: btnStyle, onClick: () => handlers.onRate(card.title) },
-        "Rate",
-      ),
+      React.createElement(RatingStars, {
+        key: "rating-stars",
+        rating: card.rating,
+        theme,
+        onRate: (rating: number | null) => handlers.onRate(card.title, rating),
+      }),
     );
   }
   if (card.actions?.more?.visible) {
     actions.push(
       React.createElement(
         "button",
-        { key: "more", type: "button", className: "action-btn", style: btnStyle, onClick: () => handlers.onMore(card.title) },
+        {
+          key: "more",
+          type: "button",
+          className: "action-btn",
+          style: btnStyle,
+          "aria-label": "Edit category and note",
+          onClick: onToggleSheet,
+        },
         "···",
       ),
     );
@@ -187,6 +380,7 @@ function renderCardActions(card: CardViewProps, theme: ReturnType<typeof getThem
 }
 
 function RecommendationCard({ card, theme, isMobile, handlers }: { card: CardViewProps; theme: ReturnType<typeof getTheme>; isMobile: boolean; handlers: ChatHandlers }) {
+  const [sheetOpen, setSheetOpen] = React.useState(false);
   const cardStyles = {
     article: {
       backgroundColor: theme.cardBg,
@@ -274,7 +468,22 @@ function RecommendationCard({ card, theme, isMobile, handlers }: { card: CardVie
       ? React.createElement("p", { style: cardStyles.connection }, card.connection)
       : React.createElement("div", { style: { marginBottom: "8px" } }),
     React.createElement(PlatformLinks, { links: card.platformLinks, onOpenLink: handlers.onOpenLink }),
-    React.createElement("div", { style: cardStyles.actions }, renderCardActions(card, theme, handlers)),
+    React.createElement(
+      "div",
+      { style: cardStyles.actions },
+      renderCardActions(card, theme, handlers, () => setSheetOpen((open) => !open)),
+    ),
+    sheetOpen
+      ? React.createElement(CategoryNoteSheet, {
+          card,
+          theme,
+          onSave: (categories: string[], note: string) => {
+            handlers.onSaveCategoryNote?.(card.title, card.savedBandId, { categories, note });
+            setSheetOpen(false);
+          },
+          onClose: () => setSheetOpen(false),
+        })
+      : null,
   );
 }
 

--- a/apps/desktop/src/ui/createDesktopReactShell.ts
+++ b/apps/desktop/src/ui/createDesktopReactShell.ts
@@ -56,7 +56,8 @@ export function createDesktopReactShell({
     onObscurityTargetChange: (target: string | undefined) => renderAdapter.onObscurityTargetChange?.(target),
     onSave: actionHandlers.onSave || (() => {}),
     onRate: actionHandlers.onRate || (() => {}),
-    onMore: actionHandlers.onMore || (() => {}),
+    onUnsave: actionHandlers.onUnsave || (() => {}),
+    onSaveCategoryNote: actionHandlers.onSaveCategoryNote || (() => {}),
   };
 
   const shell = {
@@ -89,14 +90,45 @@ export function createDesktopReactShell({
         throw error;
       }
     },
-    async rateBand(artistName: string, rating = 5) {
+    async rateBand(artistName: string, rating: number | null) {
       try {
         const result = await handlers.onRate(artistName, rating);
-        actionStatus = { type: "success", message: `Rated ${artistName}: ${rating}/5.` };
+        actionStatus =
+          rating === null
+            ? { type: "success", message: `Cleared the rating for ${artistName}.` }
+            : { type: "success", message: `Rated ${artistName}: ${rating}/5.` };
         scheduleStatusClear();
         return result;
       } catch (error) {
         actionStatus = { type: "error", message: `Rating failed for ${artistName}.` };
+        scheduleStatusClear();
+        throw error;
+      }
+    },
+    async unsaveBand(savedBandId: string, artistName: string) {
+      try {
+        const result = await handlers.onUnsave(savedBandId, artistName);
+        actionStatus = { type: "success", message: `Removed ${artistName} from saved artists.` };
+        scheduleStatusClear();
+        return result;
+      } catch (error) {
+        actionStatus = { type: "error", message: `Could not remove ${artistName}.` };
+        scheduleStatusClear();
+        throw error;
+      }
+    },
+    async saveCategoryNote(
+      artistName: string,
+      savedBandId: string | null,
+      updates: { categories: string[]; note: string },
+    ) {
+      try {
+        const result = await handlers.onSaveCategoryNote(artistName, savedBandId, updates);
+        actionStatus = { type: "success", message: `Updated ${artistName}.` };
+        scheduleStatusClear();
+        return result;
+      } catch (error) {
+        actionStatus = { type: "error", message: `Could not update ${artistName}.` };
         scheduleStatusClear();
         throw error;
       }

--- a/apps/desktop/src/ui/mountDesktopReactApp.ts
+++ b/apps/desktop/src/ui/mountDesktopReactApp.ts
@@ -19,7 +19,13 @@ export type MountShell = {
   updateMode(mode: string): Promise<unknown>;
   submitQuery(query: string): Promise<unknown> | unknown;
   saveBand?(artistName: string): Promise<unknown> | unknown;
-  rateBand?(artistName: string, rating?: number): Promise<unknown> | unknown;
+  rateBand?(artistName: string, rating: number | null): Promise<unknown> | unknown;
+  unsaveBand?(savedBandId: string, artistName: string): Promise<unknown> | unknown;
+  saveCategoryNote?(
+    artistName: string,
+    savedBandId: string | null,
+    updates: { categories: string[]; note: string },
+  ): Promise<unknown> | unknown;
   cancelSearch?(): void;
   retryLastSearch?(): Promise<unknown> | void;
   desktopUi?: { setObscurityTarget?(target: string | undefined): void } | undefined;
@@ -256,16 +262,36 @@ export function createDesktopReactMount({
       }
       return renderCurrent();
     },
-    onRate: async (artistName: string) => {
+    // No default rating here — #153 was this call hardcoding 5 regardless of
+    // what the user actually tapped. The star row always sends an explicit
+    // value (a number, or null to clear).
+    onRate: async (artistName: string, rating: number | null) => {
       try {
-        await shell.rateBand?.(artistName, 5);
+        await shell.rateBand?.(artistName, rating);
       } catch {
         // Error is surfaced via actionStatus in the shell; always re-render.
       }
       return renderCurrent();
     },
-    onMore: (artistName: string) => {
-      void artistName;
+    onUnsave: async (savedBandId: string, artistName: string) => {
+      try {
+        await shell.unsaveBand?.(savedBandId, artistName);
+      } catch {
+        // Error is surfaced via actionStatus in the shell; always re-render.
+      }
+      return renderCurrent();
+    },
+    onSaveCategoryNote: async (
+      artistName: string,
+      savedBandId: string | null,
+      updates: { categories: string[]; note: string },
+    ) => {
+      try {
+        await shell.saveCategoryNote?.(artistName, savedBandId, updates);
+      } catch {
+        // Error is surfaced via actionStatus in the shell; always re-render.
+      }
+      return renderCurrent();
     },
     onOpenLink: (url: string) => {
       openExternalLinkImpl(url);

--- a/apps/desktop/src/ui/viewTypes.ts
+++ b/apps/desktop/src/ui/viewTypes.ts
@@ -10,8 +10,9 @@ export type ChatHandlers = {
   onModeChange(mode: string): unknown;
   onQuerySubmit(query: string): unknown;
   onSave(artistName: string): unknown;
-  onRate(artistName: string, rating?: number): unknown;
-  onMore(artistName: string): unknown;
+  // null clears an existing rating without unsaving the band — see
+  // cardActionLogic.ts's nextRatingForStarTap.
+  onRate(artistName: string, rating: number | null): unknown;
   onObscurityTargetChange?(target: string | undefined): unknown;
   onCopyCard?(title: string, why: string): unknown;
   onCopyAll?(text: string): unknown;
@@ -22,6 +23,10 @@ export type ChatHandlers = {
   onStop?(): unknown;
   onRetry?(): unknown;
   onOpenLink?(url: string): unknown;
+  /** Save toggled off — removes the band entirely (not the same as clearing a rating). */
+  onUnsave?(savedBandId: string, artistName: string): unknown;
+  /** The ··· sheet's persistence call. savedBandId is null when the artist isn't saved yet — editing implies saving. */
+  onSaveCategoryNote?(artistName: string, savedBandId: string | null, updates: { categories: string[]; note: string }): unknown;
 };
 
 /** One saved artist as the saved-artists screen renders it. */

--- a/apps/desktop/test/card-action-logic.test.ts
+++ b/apps/desktop/test/card-action-logic.test.ts
@@ -1,0 +1,23 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { nextRatingForStarTap, parseCategoriesInput } from "../src/cardActionLogic.js";
+
+test("tapping an unrated card at star n rates it n", () => {
+  assert.equal(nextRatingForStarTap(null, 4), 4);
+});
+
+test("tapping a different star than the current rating replaces it", () => {
+  assert.equal(nextRatingForStarTap(3, 5), 5);
+});
+
+test("tapping the currently active star clears the rating", () => {
+  assert.equal(nextRatingForStarTap(4, 4), null);
+});
+
+test("parseCategoriesInput trims and drops blanks", () => {
+  assert.deepEqual(parseCategoriesInput(" blackgaze ,  , shoegaze,"), ["blackgaze", "shoegaze"]);
+});
+
+test("parseCategoriesInput on an empty string is an empty list", () => {
+  assert.deepEqual(parseCategoriesInput(""), []);
+});

--- a/apps/desktop/test/card-actions-app.test.ts
+++ b/apps/desktop/test/card-actions-app.test.ts
@@ -1,0 +1,119 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { bootstrapDesktopApp } from "../src/bootstrapDesktopApp.js";
+import { jsonResponse } from "./helpers/fakeResponse.js";
+
+/**
+ * A small stand-in server: tracks saved bands by id, and resolves POST as
+ * create-or-update on musicbrainzArtistId the same way the real API does
+ * (#163), so rateBand/saveCategoryNote's lookups are exercised against
+ * realistic responses rather than hand-picked fixtures.
+ */
+function appWithFakeServer() {
+  const bands = new Map<string, Record<string, unknown>>();
+  let nextId = 1;
+  let nextRecommendations: Array<{ artist: string; musicbrainzArtistId?: string; why?: string }> = [];
+  const patched: Array<{ id: string; body: Record<string, unknown> }> = [];
+
+  const fetchImpl = (async (url: string, init?: RequestInit) => {
+    const method = init?.method || "GET";
+    const body = typeof init?.body === "string" ? JSON.parse(init.body) : {};
+
+    if (String(url).endsWith("/preferences") && method === "POST") {
+      const existing = [...bands.values()].find((b) => b.musicbrainzArtistId === body.musicbrainzArtistId);
+      if (existing) {
+        Object.assign(existing, { name: body.name, rating: body.rating ?? null, categories: body.categories, note: body.note });
+        return jsonResponse({ savedBand: existing });
+      }
+      const id = `b${nextId++}`;
+      const savedBand = {
+        id,
+        musicbrainzArtistId: body.musicbrainzArtistId,
+        name: body.name,
+        rating: body.rating ?? null,
+        categories: body.categories || [],
+        note: body.note || "",
+      };
+      bands.set(id, savedBand);
+      return jsonResponse({ savedBand });
+    }
+
+    const patchMatch = String(url).match(/\/preferences\/([^/]+)$/);
+    if (patchMatch && method === "PATCH") {
+      const id = patchMatch[1];
+      patched.push({ id, body });
+      const existing = bands.get(id);
+      if (!existing) return jsonResponse({ error: { code: "not_found" } }, { status: 404 });
+      Object.assign(existing, body);
+      return jsonResponse({ savedBand: existing });
+    }
+
+    if (String(url).endsWith("/recommendations")) {
+      return jsonResponse({ recommendations: nextRecommendations, meta: {} });
+    }
+
+    return jsonResponse({});
+  }) as unknown as typeof fetch;
+
+  const app = bootstrapDesktopApp({ apiBaseUrl: "http://api.test", fetchImpl });
+
+  /** Runs a query so the given cards land in state.messages, as a real search would. */
+  async function seedRecommendations(recommendations: typeof nextRecommendations) {
+    nextRecommendations = recommendations;
+    await app.requestRecommendations("some query", "fresh");
+  }
+
+  return { app, bands, patched, seedRecommendations };
+}
+
+test("rateBand finds the saved band by musicbrainzArtistId, not name — two artists sharing a name do not collide", async () => {
+  const { app, patched, seedRecommendations } = appWithFakeServer();
+  await seedRecommendations([{ artist: "Odessa", musicbrainzArtistId: "mb-odessa-1" }]);
+  await app.saveBand("Odessa");
+
+  await seedRecommendations([{ artist: "Odessa", musicbrainzArtistId: "mb-odessa-2" }]);
+  const secondSaved = await app.saveBand("Odessa");
+
+  await app.rateBand("Odessa", 4);
+
+  const lastPatch = patched[patched.length - 1];
+  assert.equal(
+    lastPatch.id,
+    secondSaved.id,
+    "must rate the artist actually referenced by the latest card, not the first same-named one",
+  );
+});
+
+test("rateBand with rating null clears the rating but leaves the band saved", async () => {
+  const { app, bands, seedRecommendations } = appWithFakeServer();
+  await seedRecommendations([{ artist: "Codeine", musicbrainzArtistId: "mb-codeine" }]);
+  const saved = await app.saveBand("Codeine", { rating: 4 });
+
+  await app.rateBand("Codeine", null);
+
+  assert.equal(bands.get(saved.id)?.rating, null);
+  assert.ok(bands.has(saved.id), "the band must still be saved, only unrated");
+});
+
+test("saveCategoryNote updates an existing saved band via its id", async () => {
+  const { app, patched, seedRecommendations } = appWithFakeServer();
+  await seedRecommendations([{ artist: "Fen", musicbrainzArtistId: "mb-fen" }]);
+  const saved = await app.saveBand("Fen");
+
+  await app.saveCategoryNote("Fen", saved.id, { categories: ["atmospheric"], note: "My own words" });
+
+  assert.equal(patched.length, 1);
+  assert.equal(patched[0].id, saved.id);
+  assert.deepEqual(patched[0].body, { categories: ["atmospheric"], note: "My own words" });
+});
+
+test("saveCategoryNote creates a saved band when the artist has no savedBandId yet", async () => {
+  const { app, bands, seedRecommendations } = appWithFakeServer();
+  await seedRecommendations([{ artist: "Alcest", musicbrainzArtistId: "mb-alcest" }]);
+
+  const result = await app.saveCategoryNote("Alcest", null, { categories: ["shoegaze"], note: "First impression" });
+
+  assert.ok(bands.has(result.id));
+  assert.deepEqual(bands.get(result.id)?.categories, ["shoegaze"]);
+  assert.equal(bands.get(result.id)?.note, "First impression");
+});

--- a/apps/desktop/test/chat-app-view.test.ts
+++ b/apps/desktop/test/chat-app-view.test.ts
@@ -45,6 +45,61 @@ test("ChatAppView renders mode, query input, cards, and action buttons", () => {
   assert.equal(html.includes("Saved Fen."), true);
 });
 
+test("RecommendationCard renders 5 rating stars, filled up to the current rating", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(ChatAppView, {
+      viewProps: chatViewProps({
+        cards: [cardViewProps({ title: "Fen", rating: 3 })],
+      }),
+      handlers: chatHandlers(),
+    }),
+  );
+
+  const filled = (html.match(/★/g) || []).length;
+  const empty = (html.match(/☆/g) || []).length;
+  assert.equal(filled, 3, "3 filled stars for a rating of 3");
+  assert.equal(empty, 2, "2 empty stars for the remainder");
+});
+
+test("RecommendationCard renders no filled stars when unrated", () => {
+  const html = renderToStaticMarkup(
+    React.createElement(ChatAppView, {
+      viewProps: chatViewProps({
+        cards: [cardViewProps({ title: "Fen", rating: null })],
+      }),
+      handlers: chatHandlers(),
+    }),
+  );
+
+  assert.equal((html.match(/★/g) || []).length, 0);
+  assert.equal((html.match(/☆/g) || []).length, 5);
+});
+
+test("RecommendationCard's Save action reads Save when unsaved and Saved when saved", () => {
+  const unsavedHtml = renderToStaticMarkup(
+    React.createElement(ChatAppView, {
+      viewProps: chatViewProps({ cards: [cardViewProps({ title: "Fen", saved: false })] }),
+      handlers: chatHandlers(),
+    }),
+  );
+  const savedHtml = renderToStaticMarkup(
+    React.createElement(ChatAppView, {
+      viewProps: chatViewProps({ cards: [cardViewProps({ title: "Fen", saved: true, savedBandId: "band-1" })] }),
+      handlers: chatHandlers(),
+    }),
+  );
+
+  // The header always has its own "Saved" nav button (see chatHandlers()'s
+  // onNavigateSaved), so ">Saved<" alone isn't specific to the card toggle —
+  // counting occurrences is: unsaved has only the header's, saved adds the
+  // card's on top of it.
+  const countOf = (html: string, needle: string) => html.split(needle).length - 1;
+  assert.equal(countOf(unsavedHtml, ">Save<"), 1, "card shows Save when unsaved");
+  assert.equal(countOf(unsavedHtml, ">Saved<"), 1, "only the header's Saved nav button");
+  assert.equal(countOf(savedHtml, ">Saved<"), 2, "header nav button plus the card's toggle");
+  assert.equal(countOf(savedHtml, ">Save<"), 0, "no standalone Save button when the card is saved");
+});
+
 test("RecommendationCard has CSS class for card styling", () => {
   const html = renderToStaticMarkup(
     React.createElement(ChatAppView, {

--- a/apps/desktop/test/chat-render-adapter.test.ts
+++ b/apps/desktop/test/chat-render-adapter.test.ts
@@ -22,6 +22,9 @@ function makeCard(
     saved: false,
     rating: null,
     savedBandId: null,
+    categories: [],
+    note: "",
+    noteEdited: false,
     ...overrides,
   };
 }
@@ -92,32 +95,26 @@ test("render adapter preserves imageUrl from card", () => {
   assert.equal(props.cards[0].imageUrl, "https://example.com/alcest.jpg");
 });
 
-test("render adapter hides save/rate actions on mobile", () => {
-  const ui = makeDesktopUi({ getViewport: () => "mobile" });
-  ui._setConversation([
-    { id: "a-0", role: "assistant", content: "", cards: [makeCard("Fen")] },
-  ]);
+// UI_GUIDELINES.md, "Action row policy (locked, all viewports)": the rating
+// stars and Save are primary and never collapse, on any screen size — saving
+// is what makes preference-aware mode work at all, so it stays one tap away
+// everywhere. This used to be `!isMobile`-gated (#152), which contradicted a
+// spec written 15 minutes before the code that broke it.
+for (const viewport of ["mobile", "desktop"] as const) {
+  test(`render adapter keeps save/rate/more actions visible on ${viewport}`, () => {
+    const ui = makeDesktopUi({ getViewport: () => viewport });
+    ui._setConversation([
+      { id: "a-0", role: "assistant", content: "", cards: [makeCard("Fen")] },
+    ]);
 
-  const adapter = createChatRenderAdapter({ desktopUi: ui });
-  const props = adapter.getViewProps();
+    const adapter = createChatRenderAdapter({ desktopUi: ui });
+    const props = adapter.getViewProps();
 
-  assert.equal(props.cards[0].actions.save.visible, false, "save hidden on mobile");
-  assert.equal(props.cards[0].actions.rate.visible, false, "rate hidden on mobile");
-  assert.equal(props.cards[0].actions.more.visible, true, "more always visible");
-});
-
-test("render adapter shows save/rate actions on desktop", () => {
-  const ui = makeDesktopUi();
-  ui._setConversation([
-    { id: "a-0", role: "assistant", content: "", cards: [makeCard("Fen")] },
-  ]);
-
-  const adapter = createChatRenderAdapter({ desktopUi: ui });
-  const props = adapter.getViewProps();
-
-  assert.equal(props.cards[0].actions.save.visible, true, "save visible on desktop");
-  assert.equal(props.cards[0].actions.rate.visible, true, "rate visible on desktop");
-});
+    assert.equal(props.cards[0].actions.save.visible, true, `save visible on ${viewport}`);
+    assert.equal(props.cards[0].actions.rate.visible, true, `rate visible on ${viewport}`);
+    assert.equal(props.cards[0].actions.more.visible, true, `more visible on ${viewport}`);
+  });
+}
 
 test("onModeChange updates mode and returns refreshed view props", () => {
   const ui = makeDesktopUi();

--- a/apps/desktop/test/desktop-react-shell.test.ts
+++ b/apps/desktop/test/desktop-react-shell.test.ts
@@ -40,7 +40,7 @@ test("desktop react shell renders HTML with recommendation card and actions", as
 });
 
 test("desktop react shell save and rate actions call app handlers", async () => {
-  const calls: Array<{ type: string; artistName: string; rating?: number }> = [];
+  const calls: Array<{ type: string; artistName: string; rating?: number | null }> = [];
   const shell = bootstrapDesktopReactShell({
     app: fakeDesktopApp({
       requestRecommendations: async () => ({ recommendations: [], meta: { modeUsed: "fresh" } }),

--- a/apps/desktop/test/helpers/fakeApp.ts
+++ b/apps/desktop/test/helpers/fakeApp.ts
@@ -6,7 +6,12 @@ type DesktopApp = ChatAppCollaborator & {
   deleteSavedBand(id: string): Promise<unknown>;
   searchArtists(query: string): Promise<ArtistSearchResult[]>;
   saveBand?(artistName: string): unknown;
-  rateBand?(artistName: string, rating?: number): unknown;
+  rateBand?(artistName: string, rating: number | null): unknown;
+  saveCategoryNote?(
+    artistName: string,
+    savedBandId: string | null,
+    updates: { categories: string[]; note: string },
+  ): unknown;
 };
 
 // A complete app double, so each test only states the collaborator calls it

--- a/apps/desktop/test/helpers/fakeViewProps.ts
+++ b/apps/desktop/test/helpers/fakeViewProps.ts
@@ -36,6 +36,10 @@ const BASE_CARD: CardViewProps = {
   imageUrl: null,
   saved: false,
   rating: null,
+  savedBandId: null,
+  categories: [],
+  note: "",
+  noteEdited: false,
   actions: {
     save: { visible: true },
     rate: { visible: true },

--- a/apps/desktop/test/helpers/fakeViewProps.ts
+++ b/apps/desktop/test/helpers/fakeViewProps.ts
@@ -74,7 +74,6 @@ const BASE_HANDLERS: ChatHandlers = {
   onQuerySubmit: () => {},
   onSave: () => {},
   onRate: () => {},
-  onMore: () => {},
 };
 
 export function chatHandlers(overrides: Partial<ChatHandlers> = {}): ChatHandlers {

--- a/apps/desktop/test/mount-desktop-react-app.test.ts
+++ b/apps/desktop/test/mount-desktop-react-app.test.ts
@@ -6,7 +6,7 @@ import type { MountShell } from "../src/ui/mountDesktopReactApp.js";
 import { fakeContainer, fakeReactRoot } from "./helpers/fakeDom.js";
 
 test("desktop react mount renders and wires interaction callbacks", async () => {
-  const calls: Array<{ type: string; element?: ReactNode; mode?: string; query?: string; artistName?: string; rating?: number }> = [];
+  const calls: Array<{ type: string; element?: ReactNode; mode?: string; query?: string; artistName?: string; rating?: number | null }> = [];
   const fakeRoot = fakeReactRoot((element) => {
     calls.push({ type: "render", element });
   });
@@ -42,7 +42,7 @@ test("desktop react mount renders and wires interaction callbacks", async () => 
   await mount.handlers.onModeChange("preference-aware");
   await mount.handlers.onQuerySubmit("I like blackgaze");
   await mount.handlers.onSave("Fen");
-  await mount.handlers.onRate("Fen");
+  await mount.handlers.onRate("Fen", 4);
 
   assert.equal(calls.some((item) => item.type === "mode"), true);
   assert.equal(calls.some((item) => item.type === "query"), true);
@@ -101,9 +101,63 @@ test("onRate re-renders even when shell.rateBand rejects, so a failed rating is 
   mount.mount();
   const rendersBeforeRate = renders.length;
 
-  await mount.handlers.onRate("Fen");
+  await mount.handlers.onRate("Fen", 4);
 
   assert.ok(renders.length > rendersBeforeRate, "a render happened after the rejected rating");
+});
+
+test("onUnsave calls shell.unsaveBand and re-renders even when it rejects", async () => {
+  const renders: ReactNode[] = [];
+  const calls: Array<{ savedBandId: string; artistName: string }> = [];
+  const shell: MountShell = {
+    getViewProps: () => ({}),
+    updateMode: async () => {},
+    submitQuery: async () => {},
+    unsaveBand: async (savedBandId, artistName) => {
+      calls.push({ savedBandId, artistName });
+      throw new Error("network error");
+    },
+  };
+
+  const mount = createDesktopReactMount({
+    shell,
+    createRootImpl: () => fakeReactRoot((element) => renders.push(element)),
+    resolveContainer: () => fakeContainer(),
+  });
+
+  mount.mount();
+  const rendersBeforeUnsave = renders.length;
+  await mount.handlers.onUnsave("band-1", "Fen");
+
+  assert.deepEqual(calls, [{ savedBandId: "band-1", artistName: "Fen" }]);
+  assert.ok(renders.length > rendersBeforeUnsave, "a render happened after the rejected unsave");
+});
+
+test("onSaveCategoryNote calls shell.saveCategoryNote and re-renders even when it rejects", async () => {
+  const renders: ReactNode[] = [];
+  const calls: Array<{ artistName: string; savedBandId: string | null; updates: { categories: string[]; note: string } }> = [];
+  const shell: MountShell = {
+    getViewProps: () => ({}),
+    updateMode: async () => {},
+    submitQuery: async () => {},
+    saveCategoryNote: async (artistName, savedBandId, updates) => {
+      calls.push({ artistName, savedBandId, updates });
+      throw new Error("network error");
+    },
+  };
+
+  const mount = createDesktopReactMount({
+    shell,
+    createRootImpl: () => fakeReactRoot((element) => renders.push(element)),
+    resolveContainer: () => fakeContainer(),
+  });
+
+  mount.mount();
+  const rendersBeforeSave = renders.length;
+  await mount.handlers.onSaveCategoryNote("Fen", "band-1", { categories: ["blackgaze"], note: "My words" });
+
+  assert.deepEqual(calls, [{ artistName: "Fen", savedBandId: "band-1", updates: { categories: ["blackgaze"], note: "My words" } }]);
+  assert.ok(renders.length > rendersBeforeSave, "a render happened after the rejected save");
 });
 
 test("onOpenLink routes through the injected opener instead of a plain <a> navigation", () => {

--- a/services/api/migrations/004_note_edited.sql
+++ b/services/api/migrations/004_note_edited.sql
@@ -1,0 +1,13 @@
+-- Track whether a saved band's note is the user's own words or still the
+-- model's pre-filled explanation of why it recommended the artist.
+--
+-- ADR 0002 / #166: only a user-edited note may reach the recommendation
+-- prompt. The stored text alone cannot tell the two apart, so this column
+-- carries that fact through storage. Existing rows default to 0 (not edited)
+-- — correct, since none of them have been through the edit path this adds.
+--
+-- A plain ADD COLUMN, not a table rebuild: unlike 003 (which changed a CHECK
+-- constraint SQLite cannot alter in place), this only adds a column with a
+-- default, which both SQLite and Turso/libSQL support directly.
+
+ALTER TABLE saved_bands ADD COLUMN note_edited INTEGER NOT NULL DEFAULT 0;

--- a/services/api/src/preferences/preferenceMemory.ts
+++ b/services/api/src/preferences/preferenceMemory.ts
@@ -14,6 +14,7 @@ type SavedBand = {
   rating: number | null;
   categories: string[];
   note: string;
+  noteEdited: boolean;
   createdAt: string;
   updatedAt: string;
 };
@@ -56,15 +57,41 @@ export function createPreferenceMemory() {
       }
 
       const bandInput = input as SavedBandInput;
+      const musicbrainzArtistId = bandInput.musicbrainzArtistId.trim();
       const now = new Date().toISOString();
+
+      // A repeat save of the same artist must not create a second row — it
+      // would double-count the artist in every recommendation prompt (#163).
+      // Checked here rather than enforced by a DB constraint: a unique index
+      // would need a one-time dedup of any rows already duplicated before
+      // this fix shipped, which is a data-loss judgement call this write path
+      // avoids entirely.
+      const existingIndex = savedBands.findIndex(
+        (b) => b.userId === userId && b.musicbrainzArtistId === musicbrainzArtistId,
+      );
+      if (existingIndex >= 0) {
+        const existing = savedBands[existingIndex];
+        const updated: SavedBand = {
+          ...existing,
+          name: bandInput.name.trim(),
+          rating: bandInput.rating ?? null,
+          categories: bandInput.categories.map((c: unknown) => String(c).trim()).filter(Boolean),
+          note: bandInput.note.trim(),
+          updatedAt: now,
+        };
+        savedBands[existingIndex] = updated;
+        return { ok: true, savedBand: withoutUserId(updated) };
+      }
+
       const savedBand: SavedBand = {
         id: randomUUID(),
         userId,
-        musicbrainzArtistId: bandInput.musicbrainzArtistId.trim(),
+        musicbrainzArtistId,
         name: bandInput.name.trim(),
         rating: bandInput.rating ?? null,
         categories: bandInput.categories.map((c: unknown) => String(c).trim()).filter(Boolean),
         note: bandInput.note.trim(),
+        noteEdited: false,
         createdAt: now,
         updatedAt: now,
       };
@@ -108,6 +135,7 @@ export function createPreferenceMemory() {
         rating: next.rating,
         categories: next.categories.map((c: unknown) => String(c).trim()).filter(Boolean),
         note: String(next.note).trim(),
+        noteEdited: updates.note !== undefined ? true : current.noteEdited,
         updatedAt: new Date().toISOString(),
       };
 

--- a/services/api/src/preferences/preferenceRepository.ts
+++ b/services/api/src/preferences/preferenceRepository.ts
@@ -26,6 +26,9 @@ export type SavedBand = {
   rating: number | null;
   categories: string[];
   note: string;
+  // False for a note still at its model-written default; only a note the user
+  // has explicitly edited counts as their own input (ADR 0002 / #166).
+  noteEdited: boolean;
   createdAt: string;
   updatedAt: string;
 };
@@ -159,6 +162,9 @@ export function createPreferenceRepository(runtimeConfig: PreferenceConfig = {})
       rating INTEGER CHECK (rating IS NULL OR (rating >= 1 AND rating <= 5)),
       categories TEXT NOT NULL DEFAULT '[]',
       note TEXT NOT NULL DEFAULT '',
+      -- 0 until the user explicitly edits the note; a pre-filled note stays
+      -- visible but is excluded from the recommendation prompt (#166).
+      note_edited INTEGER NOT NULL DEFAULT 0,
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL
     );
@@ -177,6 +183,7 @@ export function createPreferenceRepository(runtimeConfig: PreferenceConfig = {})
     );
   `);
   addColumnIfMissing(db, "saved_bands", "user_id", "TEXT NOT NULL DEFAULT 'anonymous'");
+  addColumnIfMissing(db, "saved_bands", "note_edited", "INTEGER NOT NULL DEFAULT 0");
   addColumnIfMissing(db, "artist_groups", "user_id", "TEXT NOT NULL DEFAULT 'anonymous'");
   return createSqlitePreferenceRepository({ db });
 }

--- a/services/api/src/preferences/sqlitePreferenceRepository.ts
+++ b/services/api/src/preferences/sqlitePreferenceRepository.ts
@@ -13,6 +13,7 @@ type SavedBandRow = {
   rating: number | null;
   categories: string;
   note: string;
+  note_edited: number;
   created_at: string;
   updated_at: string;
 };
@@ -39,6 +40,7 @@ function mapRowToSavedBand(row: SavedBandRow) {
     rating: row.rating,
     categories: JSON.parse(row.categories || "[]") as string[],
     note: row.note,
+    noteEdited: Boolean(row.note_edited),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -51,17 +53,34 @@ export function createSqlitePreferenceRepository({ db }: { db: Database }): Pref
       if (validation.ok === false) return validation;
 
       const bandInput = input as SavedBandInput;
-      const id = randomUUID();
       const now = new Date().toISOString();
       const categories = JSON.stringify(bandInput.categories.map((c: unknown) => String(c).trim()).filter(Boolean));
       const note = bandInput.note.trim();
       const name = bandInput.name.trim();
       const musicbrainzArtistId = bandInput.musicbrainzArtistId.trim();
 
+      // A repeat save of the same artist must not create a second row — it
+      // would double-count the artist in every recommendation prompt (#163).
+      // Checked here rather than enforced by a DB constraint: a unique index
+      // would need a one-time dedup of any rows already duplicated before
+      // this fix shipped, which is a data-loss judgement call this write path
+      // avoids entirely.
+      const existing = db
+        .prepare("SELECT * FROM saved_bands WHERE user_id = ? AND musicbrainz_artist_id = ?")
+        .get(userId, musicbrainzArtistId) as SavedBandRow | undefined;
+      if (existing) {
+        db.prepare(
+          `UPDATE saved_bands SET name = ?, rating = ?, categories = ?, note = ?, updated_at = ? WHERE id = ?`,
+        ).run(name, bandInput.rating ?? null, categories, note, now, existing.id);
+        const row = db.prepare("SELECT * FROM saved_bands WHERE id = ?").get(existing.id) as SavedBandRow;
+        return { ok: true, savedBand: mapRowToSavedBand(row) };
+      }
+
+      const id = randomUUID();
       db.prepare(
         `INSERT INTO saved_bands
-          (id, user_id, musicbrainz_artist_id, name, rating, categories, note, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          (id, user_id, musicbrainz_artist_id, name, rating, categories, note, note_edited, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?, ?)`,
       ).run(id, userId, musicbrainzArtistId, name, bandInput.rating ?? null, categories, note, now, now);
 
       const row = db.prepare("SELECT * FROM saved_bands WHERE id = ?").get(id) as SavedBandRow;
@@ -92,12 +111,14 @@ export function createSqlitePreferenceRepository({ db }: { db: Database }): Pref
       if (validation.ok === false) return { ok: false, status: 400, error: validation.error };
 
       const updatedAt = new Date().toISOString();
+      const noteEdited = updates.note !== undefined ? 1 : (current.noteEdited ? 1 : 0);
       db.prepare(
-        `UPDATE saved_bands SET rating = ?, categories = ?, note = ?, updated_at = ? WHERE id = ? AND user_id = ?`,
+        `UPDATE saved_bands SET rating = ?, categories = ?, note = ?, note_edited = ?, updated_at = ? WHERE id = ? AND user_id = ?`,
       ).run(
         next.rating,
         JSON.stringify(next.categories.map((c: unknown) => String(c).trim()).filter(Boolean)),
         String(next.note).trim(),
+        noteEdited,
         updatedAt,
         id,
         userId,

--- a/services/api/src/preferences/tursoPreferenceRepository.ts
+++ b/services/api/src/preferences/tursoPreferenceRepository.ts
@@ -25,6 +25,7 @@ function mapRowToSavedBand(row: Row) {
     rating: row.rating === null || row.rating === undefined ? null : Number(row.rating),
     categories: JSON.parse(String(row.categories || "[]")) as string[],
     note: String(row.note),
+    noteEdited: Boolean(Number(row.note_edited ?? 0)),
     createdAt: String(row.created_at),
     updatedAt: String(row.updated_at),
   };
@@ -37,17 +38,39 @@ export function createTursoPreferenceRepository({ client }: { client: TursoClien
       if (validation.ok === false) return validation;
 
       const bandInput = input as SavedBandInput;
-      const id = randomUUID();
       const now = new Date().toISOString();
       const categories = JSON.stringify(bandInput.categories.map((c: unknown) => String(c).trim()).filter(Boolean));
       const note = bandInput.note.trim();
       const name = bandInput.name.trim();
       const musicbrainzArtistId = bandInput.musicbrainzArtistId.trim();
 
+      // A repeat save of the same artist must not create a second row — it
+      // would double-count the artist in every recommendation prompt (#163).
+      // Checked here rather than enforced by a DB constraint: a unique index
+      // would need a one-time dedup of any rows already duplicated before
+      // this fix shipped, which is a data-loss judgement call this write path
+      // avoids entirely.
+      const existingResult = await client.execute({
+        sql: "SELECT * FROM saved_bands WHERE user_id = ? AND musicbrainz_artist_id = ?",
+        args: [userId, musicbrainzArtistId],
+      });
+      if (existingResult.rows.length > 0) {
+        const existingId = String(existingResult.rows[0].id);
+        const updateResult = await client.execute({
+          sql: `UPDATE saved_bands
+                SET name = ?, rating = ?, categories = ?, note = ?, updated_at = ?
+                WHERE id = ?
+                RETURNING *`,
+          args: [name, bandInput.rating ?? null, categories, note, now, existingId],
+        });
+        return { ok: true, savedBand: mapRowToSavedBand(updateResult.rows[0]) };
+      }
+
+      const id = randomUUID();
       const result = await client.execute({
         sql: `INSERT INTO saved_bands
-                (id, user_id, musicbrainz_artist_id, name, rating, categories, note, created_at, updated_at)
-              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                (id, user_id, musicbrainz_artist_id, name, rating, categories, note, note_edited, created_at, updated_at)
+              VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?, ?)
               RETURNING *`,
         // ?? null, not raw: libSQL rejects undefined outright, where SQLite
         // would have coerced it. An omitted rating is legal (CONTEXT.md).
@@ -88,14 +111,15 @@ export function createTursoPreferenceRepository({ client }: { client: TursoClien
 
       const normalizedCategories = JSON.stringify(next.categories.map((c: unknown) => String(c).trim()).filter(Boolean));
       const normalizedNote = String(next.note).trim();
+      const noteEdited = updates.note !== undefined ? 1 : (current.noteEdited ? 1 : 0);
       const updatedAt = new Date().toISOString();
 
       const updateResult = await client.execute({
         sql: `UPDATE saved_bands
-              SET rating = ?, categories = ?, note = ?, updated_at = ?
+              SET rating = ?, categories = ?, note = ?, note_edited = ?, updated_at = ?
               WHERE id = ? AND user_id = ?
               RETURNING *`,
-        args: [next.rating, normalizedCategories, normalizedNote, updatedAt, id, userId],
+        args: [next.rating, normalizedCategories, normalizedNote, noteEdited, updatedAt, id, userId],
       });
 
       return { ok: true, savedBand: mapRowToSavedBand(updateResult.rows[0]) };

--- a/services/api/src/privacy/userDataStore.ts
+++ b/services/api/src/privacy/userDataStore.ts
@@ -119,6 +119,7 @@ export function rowToSavedBand(row: Record<string, unknown>): SavedBand {
     rating: row.rating === null || row.rating === undefined ? null : Number(row.rating),
     categories: parseCategories(row.categories),
     note: String(row.note ?? ""),
+    noteEdited: Boolean(Number(row.note_edited ?? 0)),
     createdAt: String(row.created_at),
     updatedAt: String(row.updated_at),
   };

--- a/services/api/src/savedBandContext.ts
+++ b/services/api/src/savedBandContext.ts
@@ -14,6 +14,11 @@ export type SavedBandForContext = {
   rating: number | null;
   categories: string[];
   note: string;
+  // Only a note the user has written or edited counts as their own input; a
+  // note still at its model-written pre-fill must not read back to the model
+  // as the user's own confirmation of a preference the model introduced
+  // (ADR 0002 / #166).
+  noteEdited: boolean;
 };
 
 /** The only thing context building needs from a repository. */
@@ -24,7 +29,11 @@ export type SavedBandContextSource = {
 export function formatSavedBandContextLine(band: SavedBandForContext): string {
   // An unrated band is still a signal — the user chose to keep it — so it stays
   // in the context, stating only that no judgement was given.
-  return `${band.name} (${formatRatingForPrompt(band.rating)}) tags: ${band.categories.join(", ")} note: ${band.note}`;
+  const base = `${band.name} (${formatRatingForPrompt(band.rating)}) tags: ${band.categories.join(", ")}`;
+  // An unedited note is still the model's own words, not the user's — leaving
+  // it out of the prompt is what stops that text turning into a confirmation
+  // of a preference the model introduced itself (ADR 0002 / #166).
+  return band.noteEdited ? `${base} note: ${band.note}` : base;
 }
 
 export type SavedBandContextOptions = {

--- a/services/api/test/helpers/preferenceRepositoryContract.ts
+++ b/services/api/test/helpers/preferenceRepositoryContract.ts
@@ -115,6 +115,61 @@ export function runPreferenceRepositoryContract(adapterName: string, createRepos
     assert.equal(band.name, "Codeine");
   });
 
+  // -------------------------------------------------------- repeat saves (#163)
+
+  test(label("addSavedBand called twice for the same artist updates the existing row, not a second one"), async () => {
+    const repo = await createRepository();
+    const first = await addBand(repo, { musicbrainzArtistId: "mb-wiccid", name: "Wiccid", rating: undefined });
+
+    const second = await addBand(repo, { musicbrainzArtistId: "mb-wiccid", name: "Wiccid", rating: 4 });
+
+    assert.equal(second.id, first.id, "a repeat save must return the same row, not a new id");
+    const stored = await repo.listSavedBands();
+    assert.equal(stored.length, 1, "the artist must be stored once, not double-counted in the prompt");
+    assert.equal(stored[0].rating, 4);
+  });
+
+  test(label("a repeat save is scoped per user — a second user's save is a separate row"), async () => {
+    const repo = await createRepository();
+    await addBand(repo, { musicbrainzArtistId: "mb-wiccid", name: "Wiccid" });
+
+    await addBand(repo, { musicbrainzArtistId: "mb-wiccid", name: "Wiccid" }, OTHER_USER);
+
+    assert.equal((await repo.listSavedBands()).length, 1);
+    assert.equal((await repo.listSavedBands(OTHER_USER)).length, 1);
+  });
+
+  // ------------------------------------------------- note provenance (#166)
+
+  test(label("a freshly saved band's note is not marked as user-edited"), async () => {
+    const repo = await createRepository();
+    const saved = await addBand(repo, { note: "The model's explanation" });
+
+    assert.equal(saved.noteEdited, false, "a pre-filled note must not read as the user's own words");
+  });
+
+  test(label("updating the note marks it as user-edited"), async () => {
+    const repo = await createRepository();
+    const saved = await addBand(repo, { note: "The model's explanation" });
+
+    const result = await repo.updateSavedBand(saved.id, { note: "My own words about this band" });
+
+    assert.equal(result.ok, true);
+    assert.equal((result.savedBand as SavedBand).noteEdited, true);
+    const [stored] = await repo.listSavedBands();
+    assert.equal(stored.noteEdited, true, "the edited flag must persist, not just the response");
+  });
+
+  test(label("updating rating alone does not mark the note as user-edited"), async () => {
+    const repo = await createRepository();
+    const saved = await addBand(repo, { note: "The model's explanation", rating: undefined });
+
+    await repo.updateSavedBand(saved.id, { rating: 5 });
+
+    const [stored] = await repo.listSavedBands();
+    assert.equal(stored.noteEdited, false, "a rating-only update must not touch note provenance");
+  });
+
   test(label("importSavedBands counts invalid bands as failed and keeps going"), async () => {
     const repo = await createRepository();
     const result = await repo.importSavedBands([

--- a/services/api/test/helpers/sqliteBackedTursoClient.ts
+++ b/services/api/test/helpers/sqliteBackedTursoClient.ts
@@ -24,6 +24,7 @@ export const PREFERENCE_SCHEMA = `
     rating INTEGER CHECK (rating IS NULL OR (rating >= 1 AND rating <= 5)),
     categories TEXT NOT NULL DEFAULT '[]',
     note TEXT NOT NULL DEFAULT '',
+    note_edited INTEGER NOT NULL DEFAULT 0,
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
   );

--- a/services/api/test/recommendation-service.test.ts
+++ b/services/api/test/recommendation-service.test.ts
@@ -8,7 +8,7 @@ import {
 import type { SavedBandForContext } from "../src/savedBandContext.js";
 
 function savedBand(overrides: Partial<SavedBandForContext> = {}): SavedBandForContext {
-  return { id: "b1", name: "Alcest", rating: 5, categories: [], note: "", ...overrides };
+  return { id: "b1", name: "Alcest", rating: 5, categories: [], note: "", noteEdited: false, ...overrides };
 }
 
 test("enrichRecommendationsWithMbIds attaches MusicBrainz id when names match", () => {
@@ -50,7 +50,7 @@ test("resolveRecommendationFacadeInput preference-aware merges priority with the
   );
 
   assert.equal(result.mode, "preference-aware");
-  assert.equal(result.preferenceContext, "note\nAlcest (rating 5/5) tags:  note: ");
+  assert.equal(result.preferenceContext, "note\nAlcest (rating 5/5) tags: ");
 });
 
 test("resolveRecommendationFacadeInput preference-aware narrows the context to the selected ids", async () => {

--- a/services/api/test/recommendations-route.test.ts
+++ b/services/api/test/recommendations-route.test.ts
@@ -38,6 +38,7 @@ function savedBandFixture(overrides: Partial<SavedBand> = {}): SavedBand {
     rating: 5,
     categories: [],
     note: "",
+    noteEdited: false,
     createdAt: "2026-01-01T00:00:00.000Z",
     updatedAt: "2026-01-01T00:00:00.000Z",
     ...overrides,

--- a/services/api/test/saved-band-context.test.ts
+++ b/services/api/test/saved-band-context.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { buildSavedBandContext, formatSavedBandContextLine } from "../src/savedBandContext.js";
 import type { SavedBandContextSource } from "../src/savedBandContext.js";
 import { createInMemoryPreferenceRepository } from "../src/preferences/preferenceMemory.js";
+import { assertRecord } from "./helpers/typeAssertions.js";
 
 type Band = Awaited<ReturnType<SavedBandContextSource["listSavedBands"]>>[number];
 
@@ -13,6 +14,7 @@ function band(overrides: Partial<Band> = {}): Band {
     rating: 5,
     categories: ["slowcore"],
     note: "sparse",
+    noteEdited: true,
     ...overrides,
   } as Band;
 }
@@ -38,6 +40,21 @@ test("an unrated band is described as unrated, not as a zero", () => {
 
 test("a rated band still states its rating", () => {
   assert.match(formatSavedBandContextLine(band({ rating: 4 })), /rating 4\/5/);
+});
+
+test("a pre-filled note the user never edited does not reach the prompt (#166 / ADR 0002)", () => {
+  // The model wrote this text as its own explanation. Reading it back as if it
+  // were the user's confirmation would let the model's vocabulary reinforce
+  // itself across queries — see ADR 0002.
+  const line = formatSavedBandContextLine(band({ note: "The model's own explanation", noteEdited: false }));
+
+  assert.doesNotMatch(line, /model's own explanation/);
+});
+
+test("a note the user has edited does reach the prompt", () => {
+  const line = formatSavedBandContextLine(band({ note: "My own words", noteEdited: true }));
+
+  assert.match(line, /My own words/);
 });
 
 test("an unrated band still carries its tags and note", () => {
@@ -100,14 +117,23 @@ test("buildSavedBandContext scopes an id-filtered read to the given user too", a
 // implementation has to work against a real one.
 test("buildSavedBandContext works against a real repository", async () => {
   const repository = createInMemoryPreferenceRepository();
-  await repository.addSavedBand(
+  const { savedBand } = await repository.addSavedBand(
     { musicbrainzArtistId: "mb-1", name: "Codeine", rating: 5, categories: ["slowcore"], note: "sparse" },
     "user-7",
   );
+  assertRecord(savedBand);
 
+  // Fresh save: the note is still the model's pre-fill, so it stays out of
+  // the prompt (#166).
   const context = await buildSavedBandContext(repository, { userId: "user-7" });
-  assert.match(context, /Codeine \(rating 5\/5\) tags: slowcore note: sparse/);
+  assert.match(context, /Codeine \(rating 5\/5\) tags: slowcore/);
+  assert.doesNotMatch(context, /note: sparse/);
 
   const otherUser = await buildSavedBandContext(repository, { userId: "user-8" });
   assert.equal(otherUser, "", "context must not leak across users");
+
+  // Once the user edits the note, it reaches the prompt.
+  await repository.updateSavedBand(String(savedBand.id), { note: "My actual reason" }, "user-7");
+  const edited = await buildSavedBandContext(repository, { userId: "user-7" });
+  assert.match(edited, /note: My actual reason/);
 });

--- a/services/api/test/sqlite-preference-repository.test.ts
+++ b/services/api/test/sqlite-preference-repository.test.ts
@@ -16,6 +16,7 @@ function createTestDb() {
       rating INTEGER CHECK (rating IS NULL OR (rating >= 1 AND rating <= 5)),
       categories TEXT NOT NULL DEFAULT '[]',
       note TEXT NOT NULL DEFAULT '',
+      note_edited INTEGER NOT NULL DEFAULT 0,
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL
     );

--- a/services/api/test/turso-preference-repository.test.ts
+++ b/services/api/test/turso-preference-repository.test.ts
@@ -31,6 +31,9 @@ test("turso repository adds and maps a saved band", async () => {
     client: {
       execute: async (stmt: ExecutedStatement) => {
         calls.push(stmt);
+        // addSavedBand checks for an existing row (musicbrainzArtistId, #163)
+        // before inserting; an empty result here means "not found yet".
+        if (stmt.sql.includes("SELECT")) return { rows: [], rowsAffected: 0 };
         return { rows: [makeRow()], rowsAffected: 1 };
       },
     },
@@ -52,8 +55,37 @@ test("turso repository adds and maps a saved band", async () => {
   assert.equal(result.savedBand.note, "Beautiful");
   assert.ok(result.savedBand.id, "id must be set");
   assert.ok(result.savedBand.createdAt, "createdAt must be set");
-  assert.equal(calls.length, 1);
-  assert.ok(calls[0].sql.includes("INSERT INTO saved_bands"), "must issue INSERT");
+  assert.equal(calls.length, 2, "a dedup SELECT, then the INSERT");
+  assert.ok(calls[0].sql.includes("SELECT"), "must check for an existing row first");
+  assert.ok(calls[1].sql.includes("INSERT INTO saved_bands"), "must issue INSERT when none exists");
+});
+
+test("turso repository updates rather than duplicates when the artist is already saved", async () => {
+  const calls: ExecutedStatement[] = [];
+  const existingRow = makeRow({ id: "t-1", rating: 3 });
+  const repo = createTursoPreferenceRepository({
+    client: {
+      execute: async (stmt: ExecutedStatement) => {
+        calls.push(stmt);
+        if (stmt.sql.startsWith("SELECT")) return { rows: [existingRow], rowsAffected: 0 };
+        return { rows: [makeRow({ id: "t-1", rating: 5 })], rowsAffected: 1 };
+      },
+    },
+  });
+
+  const result = await repo.addSavedBand({
+    musicbrainzArtistId: "mb-1",
+    name: "Alcest",
+    rating: 5,
+    categories: ["blackgaze", "shoegaze"],
+    note: "Beautiful",
+  });
+
+  assert.equal(result.ok, true);
+  assertRecord(result.savedBand);
+  assert.equal(result.savedBand.id, "t-1", "must update the existing row, not create a new one");
+  assert.equal(calls.length, 2, "a dedup SELECT, then an UPDATE — no INSERT");
+  assert.ok(calls[1].sql.includes("UPDATE saved_bands"), "must issue UPDATE when the artist already exists");
 });
 
 test("turso repository rejects invalid input without calling client", async () => {

--- a/services/api/test/turso-sync-repositories.test.ts
+++ b/services/api/test/turso-sync-repositories.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { createTursoSyncRepositories } from "../src/turso/tursoSyncRepositories.js";
@@ -10,7 +10,7 @@ import { createTursoSyncRepositories } from "../src/turso/tursoSyncRepositories.
 // tests cannot make: that `tursoPreferenceRepository` and friends — written
 // against `@libsql/client`'s result shape — still behave on the sync client.
 
-const migrationPath = path.join(__dirname, "..", "migrations", "002_full_schema.sql");
+const migrationsDir = path.join(__dirname, "..", "migrations");
 
 async function withRepositories<T>(
   fn: (repos: Awaited<ReturnType<typeof createTursoSyncRepositories>>) => Promise<T>,
@@ -18,9 +18,14 @@ async function withRepositories<T>(
   const dir = await mkdtemp(path.join(tmpdir(), "turso-sync-repos-"));
   const repos = await createTursoSyncRepositories({ tursoSyncPath: path.join(dir, "replica.db") });
   try {
-    const schema = await readFile(migrationPath, "utf8");
-    for (const statement of schema.split(";").map((s) => s.trim()).filter(Boolean)) {
-      await repos.client.execute(statement);
+    // Every migration, in order — not just 002 — so this stays the real
+    // schema instead of quietly drifting behind whatever ships in production.
+    const files = (await readdir(migrationsDir)).filter((f) => f.endsWith(".sql")).sort();
+    for (const file of files) {
+      const schema = await readFile(path.join(migrationsDir, file), "utf8");
+      for (const statement of schema.split(";").map((s) => s.trim()).filter(Boolean)) {
+        await repos.client.execute(statement);
+      }
     }
     return await fn(repos);
   } finally {

--- a/services/api/test/user-scoping.test.ts
+++ b/services/api/test/user-scoping.test.ts
@@ -20,6 +20,7 @@ function makeSchema(db: DatabaseType) {
       musicbrainz_artist_id TEXT NOT NULL, name TEXT NOT NULL,
       rating INTEGER CHECK (rating IS NULL OR (rating >= 1 AND rating <= 5)),
       categories TEXT NOT NULL DEFAULT '[]', note TEXT NOT NULL DEFAULT '',
+      note_edited INTEGER NOT NULL DEFAULT 0,
       created_at TEXT NOT NULL, updated_at TEXT NOT NULL
     );
     CREATE TABLE IF NOT EXISTS artist_groups (


### PR DESCRIPTION
## Summary

Implements the card-action redesign per the locked spec in `docs/design/UI_GUIDELINES.md` ("Action row policy") and `docs/adr/0002-machine-written-notes-stay-out-of-the-prompt.md`. Closes #151, #152, #163, #165, #166, and actually builds what #153 (closed as decision-only) described.

**Explicitly out of scope**: #154 (44px touch targets) — filed specifically under Phase 11/Android; mobile isn't shipped yet, so precise touch-target sizing now would be premature.

## What changed, by defect

- **#153 — "Rate" always wrote 5.** Found hardcoded in three separate places while threading the real value through (`bootstrapDesktopApp`'s default param, `createDesktopReactShell`'s default param, `mountDesktopReactApp`'s `onRate` handler). Replaced with an inline 1-5 star row — tap star *n* to rate *n*, tap the active star to clear it (stays saved, now unrated).
- **#151 — the `···` button did nothing.** Now opens a Category/Note sheet (local component state — no handler needed to open it, only to persist).
- **#165 — Category and Note were unreachable and uneditable anywhere.** The sheet makes both editable, and states explicitly that Category shapes recommendations while an artist group does not (the two are otherwise indistinguishable by name).
- **#152 — Save/Rate were hidden on mobile,** contradicting a spec written 15 minutes before the code that broke it. The `!isMobile` gate is gone; the test that encoded the violation as expected behavior is rewritten to assert the opposite, on both viewports.
- **#163 — saving the same artist twice created two rows,** double-counting it in every recommendation prompt. Fixed at the server (`addSavedBand` upserts on `(user, musicbrainzArtistId)` across all three adapters) and the client (`rateBand`/card-saved-state matching by `musicbrainzArtistId`, not name — two different artists sharing a name no longer collide).
- **#166 / ADR 0002 — a pre-filled note read back to the model as the user's own confirmation** of a preference the model introduced. New `note_edited` column; only a note the user has actually edited reaches the prompt. An unedited note stays stored and visible (it answers "why was this recommended"), just excluded from the context sent to the model.

## A scope call worth flagging

#163 asked for "a uniqueness constraint... with the write path treating a repeat as an update." I implemented the upsert-on-conflict write path but **not** a hard DB uniqueness constraint. Adding one now would need a one-time dedup of rows already duplicated by this exact bug (your own "Wiccid" saved twice from earlier testing, for instance) — a data-loss judgement call (which row's rating/note/category wins?) that the write-path fix avoids needing entirely, since it's the only path that creates saved bands.

## Phases (bisectable, one commit each)

1. `b1ac80e` — server: `note_edited` column + dedup-safe `addSavedBand` (all 3 adapters)
2. `fc05bb9` — server: prompt builder excludes unedited notes
3. `1a82936` — client: mbid-based lookups, unrate, `saveCategoryNote`
4. `366838d` — client: drop mobile gating, mbid-based card matching
5. `8725fa4` — UI: rating stars, Save/Saved toggle, Category/Note sheet (phases 5+6 combined — a half-shipped `···` button with no sheet behind it is exactly the defect the spec calls out)

## Test plan
- [x] `npm run ci` green at every commit (full monorepo: API contract tests across memory/sqlite/turso adapters, desktop suite, schemas)
- [x] New migration (`004_note_edited.sql`), a genuine gap it surfaced (`turso-sync-repositories.test.ts` only ever applied `002_full_schema.sql`, never `003` or `004` — now applies every migration file in order)
- [x] `npm run build --workspace @bandsearch/desktop` succeeds
- [x] Red→green TDD throughout — pure decision logic (`cardActionLogic.ts`: star-tap semantics, category parsing) tested directly rather than through click simulation `renderToStaticMarkup` can't do; handler wiring tested at the mount layer (matching this session's established `onSave`/`onRate`/`onOpenLink` pattern)

## Known gaps
- Category/Note sheet's open/close interaction isn't unit-tested at the component level (same limitation as existing hover-state components in this file — `renderToStaticMarkup` can't simulate the click; the persistence call it makes is tested at the mount layer instead)
- `SavedArtistsView` (the `#/saved` screen) wasn't touched — the sheet lives on the recommendation card per the issues; whether the saved-artists screen should also get category/note editing is a separate question

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019fH7pgEAnoPqHZDexU9p7y