### PR TITLE
docs: reconcile ADR 0002, CONTEXT.md, ROADMAP with shipped card-action work

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -28,9 +28,9 @@ AI-powered music recommendations for niche and lesser-known artists. Combines co
 
 - **Artist group** — a named collection of saved bands, with its own identity, used to browse and organise a collection. A group **does not influence recommendations**; it never reaches the preference context. The rule of thumb: a category says something about a band's character, a group says where the user filed it.
 
-- **Note** — free text on a saved band. It is pre-filled with the model's own explanation of why it recommended the artist, and the user can edit it.
+- **Note** — free text on a saved band. It is pre-filled with the model's own explanation of why it recommended the artist, and the user can edit it via the `···` Category/Note sheet on a recommendation card.
 
-  **Decided but not yet built (ADR 0002, tracked in #166):** only a note the user has actually written or edited *should* count as their own preference signal and reach the recommendation prompt; one left at its pre-filled value *should* stay visible but out of the prompt, so the model cannot read its own words back as if the user had said them. **Today every note reaches the prompt regardless of who wrote it.** Stated here in the conditional deliberately: this entry described the intended rule in the present tense for a while, which made the glossary assert behaviour the code does not have.
+  **Built (ADR 0002, #192, merged 2026-08-31):** only a note the user has actually written or edited counts as their own preference signal and reaches the recommendation prompt; one left at its pre-filled value stays visible but out of the prompt, so the model cannot read its own words back as if the user had said them. This is tracked in storage via `noteEdited` (`services/api/src/savedBandContext.ts` and the `note_edited` column added in migration `004_note_edited.sql`) and set `true` only when the user actually edits the sheet's textarea. Tracking issue #166 remains open on GitHub only because this repo's PRs target `staging`, where `Closes #166` never auto-fires — see `AGENTS.md`.
 
 - **Obscurity target** — a user-selectable signal (`Cult Following` / `Underground` / `Truly Obscure`) passed to the planner to tune search queries toward less or more obscure artists. Stored per recommendation event.
 
@@ -42,7 +42,7 @@ AI-powered music recommendations for niche and lesser-known artists. Combines co
 
 - **Progressive auth** — a three-mode auth scheme determined at runtime by the number of registered users: 0 users → pass-through (no token needed), 1 user → auto-attach (all requests associated with the single user), ≥2 users → JWT enforced (`Authorization: Bearer <token>`).
 
-- **Preference repository** — the abstract storage interface for saved bands, artist groups, and user accounts. Concrete adapters: SQLite (`better-sqlite3`), Postgres, Turso/libSQL, and in-memory.
+- **Preference repository** — the abstract storage interface for saved bands, artist groups, and user accounts. Concrete adapters: SQLite (`better-sqlite3`), Turso/libSQL (direct, or a local replica synced via `turso-sync`), and in-memory. A Postgres adapter existed early on and was removed for lacking user scoping (see `docs/ROADMAP.md`, "Architecture — Pending Deepening" entry 8); `PREFERENCE_STORE=postgres` now throws on startup rather than connecting to anything.
 
 - **Session store** — separate from the preference store; holds `chat_sessions` and `chat_messages`. Adapters: SQLite (`better-sqlite3`), in-memory, and Turso/libSQL (`tursoChatSessionRepository`). Selected via `PREFERENCE_STORE` env var alongside the preference and user repositories.
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ See [`docs/architecture/ARCHITECTURE.md`](docs/architecture/ARCHITECTURE.md) for
 | [docs/architecture/ARCHITECTURE.md](docs/architecture/ARCHITECTURE.md) | Full pipeline — nodes, reflection subgraph, state fields, storage, auth, and eval layer |
 | [docs/ROADMAP.md](docs/ROADMAP.md) | Phase-by-phase roadmap with completion status |
 | [docs/adr/0001-prompt-injection-guardrails.md](docs/adr/0001-prompt-injection-guardrails.md) | ADR: prompt injection defence strategy |
+| [docs/adr/0002-machine-written-notes-stay-out-of-the-prompt.md](docs/adr/0002-machine-written-notes-stay-out-of-the-prompt.md) | ADR: only a user-edited note reaches the recommendation prompt |
 | [docs/design/UI_GUIDELINES.md](docs/design/UI_GUIDELINES.md) | UI layout and component guidelines |
 | [docs/maintenance.md](docs/maintenance.md) | Dependency upgrade notes |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Navigation guide for the `docs/` folder.
 | [architecture/ARCHITECTURE.md](architecture/ARCHITECTURE.md) | System architecture — graph pipeline, state fields, integrations, storage, auth — with Mermaid diagrams |
 | [ROADMAP.md](ROADMAP.md) | Phase-by-phase feature roadmap with completion status |
 | [adr/0001-prompt-injection-guardrails.md](adr/0001-prompt-injection-guardrails.md) | ADR: prompt injection defence — bracket-marker envelope and length caps |
+| [adr/0002-machine-written-notes-stay-out-of-the-prompt.md](adr/0002-machine-written-notes-stay-out-of-the-prompt.md) | ADR: only a user-edited note reaches the recommendation prompt, not the model's own pre-filled explanation |
 | [design/UI_GUIDELINES.md](design/UI_GUIDELINES.md) | UI design guidelines — layout, components, responsive behaviour |
 | [design/UI_EXAMPLES.md](design/UI_EXAMPLES.md) | UI copy examples and interaction patterns |
 | [maintenance.md](maintenance.md) | Dependency versions, upgrade notes, and periodic maintenance tasks |
@@ -17,7 +18,7 @@ Navigation guide for the `docs/` folder.
 
 - **New to the codebase?** Read [ARCHITECTURE.md](architecture/ARCHITECTURE.md) first — it covers the full graph pipeline, state, storage, and auth with Mermaid diagrams. Then check [ROADMAP.md](ROADMAP.md) to see where the project stands.
 - **Changing the UI?** Consult [UI_GUIDELINES.md](design/UI_GUIDELINES.md) before writing new components.
-- **Security or prompt design?** See [ADR 0001](adr/0001-prompt-injection-guardrails.md) for the injection defence rationale.
+- **Security or prompt design?** See [ADR 0001](adr/0001-prompt-injection-guardrails.md) for the injection defence rationale and [ADR 0002](adr/0002-machine-written-notes-stay-out-of-the-prompt.md) for why an unedited note is kept out of the prompt.
 - **Planning a new feature?** Check [ROADMAP.md](ROADMAP.md) for phase status and open steps before starting.
 - **Checking dependencies or build health?** See [maintenance.md](maintenance.md) for the latest dependency audit and pending upgrades.
 
@@ -40,6 +41,7 @@ Implementation plans and design specs from earlier development phases. Kept for 
 | [architecture/2026-05-29-eval-architecture.md](architecture/2026-05-29-eval-architecture.md) | Evaluation layer design — three-tier scoring, LLM-as-judge, feedback loop |
 | [architecture/2026-05-30-phase8-implementation-plan.md](architecture/2026-05-30-phase8-implementation-plan.md) | Phase 8 implementation plan (eval & quality observability) |
 | [architecture/2026-06-03-auto-update-plan.md](architecture/2026-06-03-auto-update-plan.md) | Auto-update plan — Tauri updater integration and release pipeline |
+| [architecture/2026-08-30-data-flow-and-eu-residency.md](architecture/2026-08-30-data-flow-and-eu-residency.md) | Where data actually goes (compute/DB/LLM/search providers) and the EU residency vs. sovereignty question for Phase 7 (Android) — factual snapshot, no decision recorded yet |
 | [superpowers/plans/2026-04-30-ui-redesign.md](superpowers/plans/2026-04-30-ui-redesign.md) | UI redesign plan (Phase 3 era) |
 | [superpowers/specs/2026-04-30-tauri-scaffold-design.md](superpowers/specs/2026-04-30-tauri-scaffold-design.md) | Tauri desktop scaffold design spec |
 | [superpowers/specs/2026-05-12-llm-musicbrainz-query-design.md](superpowers/specs/2026-05-12-llm-musicbrainz-query-design.md) | LLM + MusicBrainz query design spec |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -23,16 +23,18 @@ plan, not a second permanent structure.
 2. **Phase 9.5 — verify Render + Turso end-to-end.** The bottleneck. Unblocks
    Android, the deploy gate and the eval data, and it is the one thing claimed
    as infrastructure that has never actually been run.
-3. **The card action work — #151–#154 and #163–#167.** Designed in
-   `docs/adr/0002-*` and the action-row policy; not yet built. Start with
-   #164 (rating becomes nullable), since #151, #152 and #165 all sit on top of
-   it. Independent of the infrastructure work, so it can fill gaps while
-   waiting on a deployment.
-
-   Six of these are live defects, not future work: a dead `···` button on
-   every card, Save and Rate writing hidden ratings, the same artist storable
-   twice and then double-counted in the prompt, and the model reading its own
-   text back as the user's preference.
+3. ~~**The card action work — #151–#154 and #163–#167.**~~ Mostly done. PR #192
+   (`feature/card-action-redesign`, merged 2026-08-31) built rating stars, the
+   Save/Saved toggle, and the Category/Note sheet behind the `···` button —
+   closing #151 (dead `···` button), #152 (Save/Rate hidden on mobile), #163
+   (duplicate saves), #165 (Category/Note uneditable) and #166 (ADR 0002: only
+   an edited note reaches the prompt). #153, #155, #164, #167 and #175 were
+   already closed on GitHub before that PR. **Still open: #154** (card action
+   touch targets are ~32px, below the 44px minimum) — no `minWidth`/`minHeight`
+   sizing was added for the action row in #192. Several of the closed-in-code
+   issues (#151, #152, #163, #165, #166) remain open on GitHub only because
+   this repo's PRs target `staging`, where `Closes #N` never auto-fires — see
+   `AGENTS.md`; close them by hand once this entry is read.
 4. **Phase 10 — signing key, then the first `v0.4.0` release.** In that order.
    This is the first real proof the updater works; the pipeline has only ever
    run against a throwaway `v0.2.1-test` tag.
@@ -55,7 +57,7 @@ Phase 10  signing key + GitHub secrets
 
 Independent, can start any time:
  · Phase 8 F6 / F7 / F8      · Architecture 9 (ESM migration)
- · Phase 10 macOS check      · the card-action work (#151-#154, #163-#167)
+ · Phase 10 macOS check      · #154, the one card-action item left (44px touch targets)
 ```
 
 When an entry moves, say so in place rather than deleting it — an entry that

--- a/docs/adr/0002-machine-written-notes-stay-out-of-the-prompt.md
+++ b/docs/adr/0002-machine-written-notes-stay-out-of-the-prompt.md
@@ -1,11 +1,18 @@
 # ADR 0002 — Machine-written notes stay out of the recommendation prompt
 
-**Status:** Accepted — **not yet implemented**, tracked in #166
+**Status:** Accepted — **implemented** in `feature/card-action-redesign` (#192,
+merged 2026-08-31). Tracking issue #166 is still open on GitHub pending manual
+close (this repo's PRs target `staging`, so `Closes #166` never auto-fires —
+see `AGENTS.md`).
 **Date:** 2026-08-30
 
-> The decision below stands; the code does not do it yet. Every note still
-> reaches the prompt regardless of who wrote it. Read "does" in the Decision
-> section as "will".
+> Written a day before the fix landed. `formatSavedBandContextLine` (in
+> `services/api/src/savedBandContext.ts`) now omits the `note: …` segment
+> whenever `noteEdited` is `false`, and the Category/Note sheet
+> (`apps/desktop/src/ui/ChatAppView.ts`) lets the user actually edit a note,
+> setting `noteEdited: true` on save. The "Context" section below describes
+> the bug as it was before this landed; the "Decision" section is now the
+> live behaviour, not a plan.
 
 ## Context
 
@@ -24,9 +31,11 @@ many queries this narrows recommendations toward the model's own vocabulary,
 and the narrowing is invisible: nothing distinguishes a note the user wrote from
 one the system pre-filled.
 
-Notes are currently not editable anywhere in the UI, so in practice *every*
-note in the system is machine-written. The `···` overflow that the design spec
-assigns to Category/Note was never implemented, which is why this went unnoticed.
+At the time this ADR was written, notes were not editable anywhere in the UI,
+so in practice *every* note in the system was machine-written. The `···`
+overflow that the design spec assigns to Category/Note had not been
+implemented yet, which is why this went unnoticed. Both gaps closed in #192,
+the same change that implemented the decision below.
 
 ## Decision
 

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -242,7 +242,8 @@ Two persistence domains, both backed by an abstract repository pattern to allow 
 |---------|--------|----------|
 | `sqlite` (default) | `DATABASE_PATH` | Local, zero-config |
 | `memory` | — | Ephemeral / testing |
-| `turso` | `TURSO_DATABASE_URL` + `TURSO_AUTH_TOKEN` | Cross-device cloud sync |
+| `turso` | `TURSO_DATABASE_URL` + `TURSO_AUTH_TOKEN` | Cross-device cloud sync — every statement over the network |
+| `turso-sync` | `TURSO_DATABASE_URL` + `TURSO_AUTH_TOKEN` + `TURSO_SYNC_PATH` | Local replica synced with Turso Cloud — reads/writes stay local, so the app keeps working offline |
 
 Tables: `saved_bands` (rating, categories, notes), `artist_groups`
 


### PR DESCRIPTION
## Summary

Scheduled documentation-maintenance pass. Read the codebase end-to-end (`services/api`, `apps/desktop`, `shared/schemas`, `main.py`/`pyproject.toml`, configs) and cross-checked it against `README.md`, `docs/`, `AGENTS.md`, and `CONTEXT.md`. Root `README.md`, the architecture/graph Mermaid diagrams, REST route tables, env var docs, and CI/branching conventions were all verified accurate — no changes needed there. Found and fixed several places that described already-shipped work as pending:

- **ADR 0002** (`docs/adr/0002-machine-written-notes-stay-out-of-the-prompt.md`) was written 2026-08-30 as "not yet implemented, tracked in #166." PR #192 (merged 2026-08-31, the very next day) implemented it: `savedBandContext.ts` now excludes a note from the recommendation prompt unless `noteEdited` is true, and the Category/Note sheet in the desktop UI makes notes actually editable. Updated the status line and context to describe the shipped behaviour instead of the plan.
- **`CONTEXT.md`**'s "Note" glossary entry repeated the same "not yet built" framing. Its "Preference repository" entry still listed a Postgres adapter that was removed (`PREFERENCE_STORE=postgres` now throws on startup) and never mentioned `turso-sync`, a real, `.env.example`-documented storage backend.
- **`docs/ROADMAP.md`**'s work queue still listed the whole card-action batch (`#151-154`, `#163-167`) as "not yet built." Cross-checked each issue number against GitHub state and the `#192` diff: five of six are done in code (some remain open on GitHub only because PRs here target `staging`, so `Closes #N` never auto-fires — per `AGENTS.md`'s own note on this). Only `#154` (44px touch targets) is genuinely still open.
- **`docs/architecture/ARCHITECTURE.md`**'s preferences-store table was missing the `turso-sync` backend entirely.
- **`docs/README.md`** and the root `README.md` documentation tables never linked ADR 0002; `docs/README.md`'s historical-docs table was missing the EU residency/data-flow note (`2026-08-30-data-flow-and-eu-residency.md`).

## Test plan

- [x] Docs-only change; no code touched.
- [x] Every factual claim changed here was checked against the actual source (`savedBandContext.ts`, `ChatAppView.ts`, `migrations/004_note_edited.sql`, `config/env.ts`, `preferenceRepository.ts`) and against GitHub issue/PR history via the GitHub API, not assumed from prior docs.
- [x] Confirmed no other doc drift on the points I checked: LangGraph node/edge names in the Mermaid diagrams match `researchGraph.ts`/`reflectionSubgraph.ts` exactly; the REST route tables match `registerBandsearchRoutes.ts`/`evalRoutes.ts` exactly; CI matrix, env vars, and branching convention all match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeB9wbyCXbj4Sqi5jeZn7F

---
_Generated by [Claude Code](https://claude.ai/code/session_01BeB9wbyCXbj4Sqi5jeZn7F)_